### PR TITLE
feat: complete pino structured logging (P8-005)

### DIFF
--- a/services/api/src/__tests__/lib/alertDelivery.test.ts
+++ b/services/api/src/__tests__/lib/alertDelivery.test.ts
@@ -16,6 +16,19 @@ jest.mock("../../lib/telegram", () => ({
   deliverAlertToUser: jest.fn(),
 }));
 
+import { logger } from "../../lib/logger";
+
+jest.mock("../../lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+
+
 import { prisma } from "../../lib/prisma";
 import { deliverAlertToUser } from "../../lib/telegram";
 import { dispatchAlert } from "../../lib/alertDelivery";
@@ -77,7 +90,7 @@ describe("dispatchAlert", () => {
 
   it("logs Telegram delivery failures without throwing", async () => {
     const error = new Error("telegram offline");
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = logger.error as jest.Mock;
     (mockPrisma.alertSubscription.findMany as jest.Mock).mockResolvedValueOnce([
       { id: "sub-1", delivery: ["TELEGRAM"] },
     ]);
@@ -86,24 +99,18 @@ describe("dispatchAlert", () => {
     await dispatchAlert(baseAlert);
     await flushPromises();
 
-    expect(errorSpy).toHaveBeenCalledWith(
-      "[alertDelivery] Telegram delivery failed for alert alert-1:",
-      error
-    );
+    expect(errorSpy).toHaveBeenCalledWith({ err: error }, "[alertDelivery] Telegram delivery failed for alert alert-1");
 
     errorSpy.mockRestore();
   });
 
   it("logs subscription lookup failures without throwing", async () => {
     const error = new Error("db unavailable");
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = logger.error as jest.Mock;
     (mockPrisma.alertSubscription.findMany as jest.Mock).mockRejectedValueOnce(error);
 
     await expect(dispatchAlert(baseAlert)).resolves.toBeUndefined();
-    expect(errorSpy).toHaveBeenCalledWith(
-      "[alertDelivery] Dispatch failed for alert alert-1:",
-      error
-    );
+    expect(errorSpy).toHaveBeenCalledWith({ err: error }, "[alertDelivery] Dispatch failed for alert alert-1");
 
     errorSpy.mockRestore();
   });

--- a/services/api/src/__tests__/lib/telegram.test.ts
+++ b/services/api/src/__tests__/lib/telegram.test.ts
@@ -1,3 +1,5 @@
+// Logger mock is set up per-test via jest.doMock inside loadTelegramModule
+
 type PrismaMock = {
   user: {
     findUnique: jest.Mock;
@@ -70,6 +72,15 @@ describe("telegram", () => {
     telegrafInstances = [];
     launchImplementation = jest.fn().mockResolvedValue(undefined);
 
+    jest.doMock("../../lib/logger", () => ({
+      logger: {
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn(),
+      },
+    }));
+
     jest.doMock("../../lib/config", () => ({
       config: {
         TELEGRAM_BOT_TOKEN: token,
@@ -131,8 +142,9 @@ describe("telegram", () => {
   });
 
   it("returns null and warns when TELEGRAM_BOT_TOKEN is not set", () => {
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     const { initBot, getBot } = loadTelegramModule("");
+    const { logger: freshLogger } = require("../../lib/logger");
+    const warnSpy = freshLogger.warn as jest.Mock;
 
     expect(initBot()).toBeNull();
     expect(getBot()).toBeNull();
@@ -143,9 +155,10 @@ describe("telegram", () => {
   });
 
   it("initializes the bot, registers handlers, and starts polling", async () => {
-    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     const onceSpy = jest.spyOn(process, "once");
     const { initBot, getBot } = loadTelegramModule();
+    const { logger: freshLogger } = require("../../lib/logger");
+    const logSpy = freshLogger.info as jest.Mock;
 
     const bot = initBot();
     await flushPromises();
@@ -170,7 +183,6 @@ describe("telegram", () => {
 
   it("stops the bot on shutdown signals", async () => {
     const signalHandlers: Record<string, () => void> = {};
-    jest.spyOn(console, "log").mockImplementation(() => {});
     jest.spyOn(process, "once").mockImplementation(((signal: string, handler: () => void) => {
       signalHandlers[signal] = handler;
       return process;
@@ -188,18 +200,18 @@ describe("telegram", () => {
   });
 
   it("logs bot launch failures", async () => {
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     const { initBot } = loadTelegramModule();
+    const { logger: freshLogger } = require("../../lib/logger");
+    const errorSpy = freshLogger.error as jest.Mock;
     launchImplementation.mockRejectedValueOnce(new Error("launch failed"));
 
     initBot();
     await flushPromises();
 
-    expect(errorSpy).toHaveBeenCalledWith("[telegram] Bot launch failed:", "launch failed");
+    expect(errorSpy).toHaveBeenCalledWith({ err: "launch failed" }, "[telegram] Bot launch failed");
   });
 
   it("replies to /start and /help commands", async () => {
-    jest.spyOn(console, "log").mockImplementation(() => {});
     const { initBot } = loadTelegramModule();
     initBot();
     await flushPromises();
@@ -227,9 +239,9 @@ describe("telegram", () => {
   });
 
   it("handles /link usage errors, missing users, conflicts, success, and recovery", async () => {
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    jest.spyOn(console, "log").mockImplementation(() => {});
     const { initBot } = loadTelegramModule();
+    const { logger: freshLogger } = require("../../lib/logger");
+    const errorSpy = freshLogger.error as jest.Mock;
     initBot();
     await flushPromises();
 
@@ -272,14 +284,14 @@ describe("telegram", () => {
     prismaMock.user.findUnique.mockRejectedValueOnce(new Error("db down"));
     const failureCtx = createContext("/link atlas");
     await getBotInstance().commandHandlers.link(failureCtx);
-    expect(errorSpy).toHaveBeenCalledWith("[telegram] Link error:", expect.any(Error));
+    expect(errorSpy).toHaveBeenCalledWith({ err: expect.any(Error) }, "[telegram] Link error");
     expect(failureCtx.reply).toHaveBeenCalledWith("Something went wrong. Please try again.");
   });
 
   it("handles /unlink cases", async () => {
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    jest.spyOn(console, "log").mockImplementation(() => {});
     const { initBot } = loadTelegramModule();
+    const { logger: freshLogger } = require("../../lib/logger");
+    const errorSpy = freshLogger.error as jest.Mock;
     initBot();
     await flushPromises();
 
@@ -305,14 +317,14 @@ describe("telegram", () => {
     prismaMock.user.findFirst.mockRejectedValueOnce(new Error("db down"));
     const failureCtx = createContext("/unlink", 555);
     await getBotInstance().commandHandlers.unlink(failureCtx);
-    expect(errorSpy).toHaveBeenCalledWith("[telegram] Unlink error:", expect.any(Error));
+    expect(errorSpy).toHaveBeenCalledWith({ err: expect.any(Error) }, "[telegram] Unlink error");
     expect(failureCtx.reply).toHaveBeenCalledWith("Something went wrong. Please try again.");
   });
 
   it("handles /alerts cases and formats recent alerts", async () => {
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    jest.spyOn(console, "log").mockImplementation(() => {});
     const { initBot } = loadTelegramModule();
+    const { logger: freshLogger } = require("../../lib/logger");
+    const errorSpy = freshLogger.error as jest.Mock;
     initBot();
     await flushPromises();
 
@@ -363,14 +375,14 @@ describe("telegram", () => {
     prismaMock.user.findFirst.mockRejectedValueOnce(new Error("db down"));
     const failureCtx = createContext("/alerts", 999);
     await getBotInstance().commandHandlers.alerts(failureCtx);
-    expect(errorSpy).toHaveBeenCalledWith("[telegram] Alerts error:", expect.any(Error));
+    expect(errorSpy).toHaveBeenCalledWith({ err: expect.any(Error) }, "[telegram] Alerts error");
     expect(failureCtx.reply).toHaveBeenCalledWith("Failed to fetch alerts.");
   });
 
   it("handles /subscriptions cases and formats active subscriptions", async () => {
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    jest.spyOn(console, "log").mockImplementation(() => {});
     const { initBot } = loadTelegramModule();
+    const { logger: freshLogger } = require("../../lib/logger");
+    const errorSpy = freshLogger.error as jest.Mock;
     initBot();
     await flushPromises();
 
@@ -403,12 +415,11 @@ describe("telegram", () => {
     prismaMock.user.findFirst.mockRejectedValueOnce(new Error("db down"));
     const failureCtx = createContext("/subscriptions", 222);
     await getBotInstance().commandHandlers.subscriptions(failureCtx);
-    expect(errorSpy).toHaveBeenCalledWith("[telegram] Subscriptions error:", expect.any(Error));
+    expect(errorSpy).toHaveBeenCalledWith({ err: expect.any(Error) }, "[telegram] Subscriptions error");
     expect(failureCtx.reply).toHaveBeenCalledWith("Failed to fetch subscriptions.");
   });
 
   it("sends alert messages with formatting and truncation", async () => {
-    jest.spyOn(console, "log").mockImplementation(() => {});
     const { initBot, deliverAlert } = loadTelegramModule();
     initBot();
     await flushPromises();
@@ -434,9 +445,9 @@ describe("telegram", () => {
   });
 
   it("returns false when delivery cannot be sent", async () => {
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    jest.spyOn(console, "log").mockImplementation(() => {});
     const { deliverAlert, initBot } = loadTelegramModule();
+    const { logger: freshLogger } = require("../../lib/logger");
+    const errorSpy = freshLogger.error as jest.Mock;
 
     expect(
       await deliverAlert(
@@ -461,15 +472,15 @@ describe("telegram", () => {
       )
     ).resolves.toBe(false);
     expect(errorSpy).toHaveBeenCalledWith(
-      "[telegram] Failed to deliver alert to chat chat-123:",
-      expect.any(Error)
+      { err: expect.any(Error), chatId: "chat-123" },
+      "[telegram] Failed to deliver alert"
     );
   });
 
   it("looks up linked users before delivering alerts", async () => {
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    jest.spyOn(console, "log").mockImplementation(() => {});
     const { initBot, deliverAlertToUser } = loadTelegramModule();
+    const { logger: freshLogger } = require("../../lib/logger");
+    const errorSpy = freshLogger.error as jest.Mock;
     initBot();
     await flushPromises();
 
@@ -514,8 +525,8 @@ describe("telegram", () => {
       )
     ).resolves.toBe(false);
     expect(errorSpy).toHaveBeenCalledWith(
-      "[telegram] Failed to look up user user-3:",
-      expect.any(Error)
+      { err: expect.any(Error), userId: "user-3" },
+      "[telegram] Failed to look up user"
     );
   });
 });

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -15,6 +15,8 @@ import { trendingRouter } from "./routes/trending";
 import { imagesRouter } from "./routes/images";
 import { buildErrorResponse, requestIdMiddleware } from "./middleware/requestId";
 import { rateLimit } from "./middleware/rateLimit";
+import { requestLogger } from "./middleware/requestLogger";
+import { logger } from "./lib/logger";
 import { formatErrorResponse } from "./lib/errors";
 import { prisma } from "./lib/prisma";
 import { getRedis } from "./lib/redis";
@@ -45,6 +47,7 @@ app.use(
 );
 app.use(express.json({ limit: "10mb" }));
 app.use(requestIdMiddleware);
+app.use(requestLogger);
 app.use(rateLimit(100, 60 * 1000)); // Global: 100 req/min per IP
 
 // Health check
@@ -106,13 +109,13 @@ app.use((err: Error, req: express.Request, res: express.Response, _next: express
   const requestId = (req as any).requestId;
   const { statusCode, body } = formatErrorResponse(err, requestId);
   if (statusCode >= 500) {
-    console.error(`[${requestId}] ${err.message}`);
+    logger.error({ requestId, err: err.message }, `Unhandled error: ${err.message}`);
   }
   res.status(statusCode).json(body);
 });
 
 app.listen(PORT, () => {
-  console.log(`Atlas API running on port ${PORT}`);
+  logger.info({ port: PORT }, `Atlas API running on port ${PORT}`);
 });
 
 export default app;

--- a/services/api/src/lib/alertDelivery.ts
+++ b/services/api/src/lib/alertDelivery.ts
@@ -1,3 +1,4 @@
+import { logger } from "./logger";
 /**
  * Alert Delivery Dispatcher
  *
@@ -39,9 +40,9 @@ export async function dispatchAlert(alert: AlertPayload): Promise<void> {
 
     // Deliver via Telegram (non-blocking)
     deliverAlertToUser(alert, alert.userId).catch((err) =>
-      console.error(`[alertDelivery] Telegram delivery failed for alert ${alert.id}:`, err)
+      logger.error({ err }, `[alertDelivery] Telegram delivery failed for alert ${alert.id}`)
     );
   } catch (err) {
-    console.error(`[alertDelivery] Dispatch failed for alert ${alert.id}:`, err);
+    logger.error({ err }, `[alertDelivery] Dispatch failed for alert ${alert.id}`);
   }
 }

--- a/services/api/src/lib/telegram.ts
+++ b/services/api/src/lib/telegram.ts
@@ -1,3 +1,4 @@
+import { logger } from "./logger";
 /**
  * Telegram Bot — Atlas alert delivery channel.
  *
@@ -20,7 +21,7 @@ let bot: Telegraf | null = null;
 export function initBot(): Telegraf | null {
   const token = config.TELEGRAM_BOT_TOKEN;
   if (!token) {
-    console.warn("[telegram] TELEGRAM_BOT_TOKEN not set — Telegram bot disabled");
+    logger.warn("[telegram] TELEGRAM_BOT_TOKEN not set — Telegram bot disabled");
     return null;
   }
 
@@ -78,7 +79,7 @@ export function initBot(): Telegraf | null {
 
       ctx.reply(`Linked to Atlas account @${handle}. You'll now receive alerts here.`);
     } catch (err) {
-      console.error("[telegram] Link error:", err);
+      logger.error({ err }, "[telegram] Link error");
       ctx.reply("Something went wrong. Please try again.");
     }
   });
@@ -100,7 +101,7 @@ export function initBot(): Telegraf | null {
 
       ctx.reply("Unlinked. You will no longer receive alerts here.");
     } catch (err) {
-      console.error("[telegram] Unlink error:", err);
+      logger.error({ err }, "[telegram] Unlink error");
       ctx.reply("Something went wrong. Please try again.");
     }
   });
@@ -139,7 +140,7 @@ export function initBot(): Telegraf | null {
 
       ctx.reply(`Recent alerts:\n\n${formatted}`);
     } catch (err) {
-      console.error("[telegram] Alerts error:", err);
+      logger.error({ err }, "[telegram] Alerts error");
       ctx.reply("Failed to fetch alerts.");
     }
   });
@@ -171,7 +172,7 @@ export function initBot(): Telegraf | null {
 
       ctx.reply(`Active subscriptions:\n\n${formatted}`);
     } catch (err) {
-      console.error("[telegram] Subscriptions error:", err);
+      logger.error({ err }, "[telegram] Subscriptions error");
       ctx.reply("Failed to fetch subscriptions.");
     }
   });
@@ -179,8 +180,8 @@ export function initBot(): Telegraf | null {
   // Start polling (non-blocking)
   bot
     .launch()
-    .then(() => console.log("[telegram] Bot started (long polling)"))
-    .catch((err) => console.error("[telegram] Bot launch failed:", err.message));
+    .then(() => logger.info("[telegram] Bot started (long polling)"))
+    .catch((err) => logger.error({ err: err.message }, "[telegram] Bot launch failed"));
 
   // Graceful shutdown
   process.once("SIGINT", () => bot?.stop("SIGINT"));
@@ -212,7 +213,7 @@ export async function deliverAlert(
     await bot.telegram.sendMessage(chatId, message);
     return true;
   } catch (err) {
-    console.error(`[telegram] Failed to deliver alert to chat ${chatId}:`, err);
+    logger.error({ err, chatId }, "[telegram] Failed to deliver alert");
     return false;
   }
 }
@@ -234,7 +235,7 @@ export async function deliverAlertToUser(
     if (!user?.telegramChatId) return false;
     return deliverAlert(alert, user.telegramChatId);
   } catch (err) {
-    console.error(`[telegram] Failed to look up user ${userId}:`, err);
+    logger.error({ err, userId }, "[telegram] Failed to look up user");
     return false;
   }
 }

--- a/services/api/src/routes/images.ts
+++ b/services/api/src/routes/images.ts
@@ -4,6 +4,7 @@ import { prisma } from "../lib/prisma";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { generateVisualConcept, ImageStyle } from "../lib/gemini";
 import { buildErrorResponse } from "../middleware/requestId";
+import { logger } from "../lib/logger";
 
 export const imagesRouter = Router();
 imagesRouter.use(authenticate);
@@ -48,7 +49,7 @@ imagesRouter.post("/generate", async (req: AuthRequest, res) => {
         .status(400)
         .json(buildErrorResponse(req, "Invalid request", { details: err.errors }));
     }
-    console.error("Image generation failed:", err.message);
+    logger.error({ err: err.message }, "Image generation failed");
     res
       .status(502)
       .json(buildErrorResponse(req, "Image generation failed"));
@@ -92,7 +93,7 @@ imagesRouter.post("/generate-for-draft", async (req: AuthRequest, res) => {
         .status(400)
         .json(buildErrorResponse(req, "Invalid request", { details: err.errors }));
     }
-    console.error("Image generation failed:", err.message);
+    logger.error({ err: err.message }, "Image generation failed");
     res
       .status(502)
       .json(buildErrorResponse(req, "Image generation failed"));

--- a/services/api/src/routes/research.ts
+++ b/services/api/src/routes/research.ts
@@ -4,6 +4,7 @@ import { prisma } from "../lib/prisma";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { conductResearch } from "../lib/research";
 import { buildErrorResponse } from "../middleware/requestId";
+import { logger } from "../lib/logger";
 
 export const researchRouter = Router();
 researchRouter.use(authenticate);
@@ -45,7 +46,7 @@ researchRouter.post("/", async (req: AuthRequest, res) => {
         .status(400)
         .json(buildErrorResponse(req, "Invalid request", { details: err.errors }));
     }
-    console.error("Research failed:", err.message);
+    logger.error({ err: err.message }, "Research failed");
     res.status(502).json(buildErrorResponse(req, "Research failed"));
   }
 });

--- a/services/api/src/routes/trending.ts
+++ b/services/api/src/routes/trending.ts
@@ -4,6 +4,7 @@ import { prisma } from "../lib/prisma";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { searchTrending } from "../lib/grok";
 import { buildErrorResponse } from "../middleware/requestId";
+import { logger } from "../lib/logger";
 
 export const trendingRouter = Router();
 trendingRouter.use(authenticate);
@@ -59,7 +60,7 @@ trendingRouter.post("/scan", async (req: AuthRequest, res) => {
         .status(400)
         .json(buildErrorResponse(req, "Invalid request", { details: err.errors }));
     }
-    console.error("Trending scan failed:", err.message);
+    logger.error({ err: err.message }, "Trending scan failed");
     res.status(502).json(buildErrorResponse(req, "Twitter scan failed"));
   }
 });
@@ -96,7 +97,7 @@ trendingRouter.get("/topics", async (req: AuthRequest, res) => {
         .status(400)
         .json(buildErrorResponse(req, "Invalid request", { details: err.errors }));
     }
-    console.error("Failed to get topics:", err.message);
+    logger.error({ err: err.message }, "Failed to get topics");
     res
       .status(500)
       .json(buildErrorResponse(req, "Failed to load trending topics"));


### PR DESCRIPTION
## Summary
- Migrate all `console.log/warn/error` to pino structured logger across telegram, alertDelivery, routes, and index
- Fix telegram test mock ordering bug (7 tests were failing because `require("../../lib/logger")` was called before `loadTelegramModule()`, getting a stale mock instance)

## Test plan
- [x] `npm test` — **29/29 suites, 249/249 tests, 0 failures** (was 28/29 before this fix)
- [x] `npm run build` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)