### PR TITLE
feat: exponential backoff retry for external API calls (P8-009)

### DIFF
--- a/services/api/src/__tests__/lib/retry.test.ts
+++ b/services/api/src/__tests__/lib/retry.test.ts
@@ -1,0 +1,151 @@
+jest.mock("../../lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import { withRetry } from "../../lib/retry";
+
+describe("withRetry", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns result on first success", async () => {
+    const fn = jest.fn().mockResolvedValue("ok");
+    const result = await withRetry(fn, "test");
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 429 and succeeds", async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce({ status: 429, message: "rate limited" })
+      .mockResolvedValue("ok");
+
+    const result = await withRetry(fn, "test", {
+      maxRetries: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 10,
+    });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on 500 and succeeds", async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce({ status: 500, message: "internal error" })
+      .mockResolvedValue("recovered");
+
+    const result = await withRetry(fn, "test", {
+      maxRetries: 2,
+      baseDelayMs: 1,
+      maxDelayMs: 10,
+    });
+    expect(result).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on 503 status", async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce({ status: 503, message: "unavailable" })
+      .mockRejectedValueOnce({ status: 503, message: "still unavailable" })
+      .mockResolvedValue("back");
+
+    const result = await withRetry(fn, "test", {
+      maxRetries: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 10,
+    });
+    expect(result).toBe("back");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws immediately on non-retryable error", async () => {
+    const err = { status: 400, message: "bad request" };
+    const fn = jest.fn().mockRejectedValue(err);
+
+    await expect(
+      withRetry(fn, "test", { maxRetries: 3, baseDelayMs: 1 }),
+    ).rejects.toEqual(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws after exhausting retries", async () => {
+    const err = { status: 429, message: "rate limited" };
+    const fn = jest.fn().mockRejectedValue(err);
+
+    await expect(
+      withRetry(fn, "test", { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 5 }),
+    ).rejects.toEqual(err);
+    expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it("retries on RateLimitError name", async () => {
+    const err = Object.assign(new Error("rate limit"), { name: "RateLimitError" });
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("ok");
+
+    const result = await withRetry(fn, "test", {
+      maxRetries: 1,
+      baseDelayMs: 1,
+    });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on ECONNRESET", async () => {
+    const err = Object.assign(new Error("connection reset"), { code: "ECONNRESET" });
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("reconnected");
+
+    const result = await withRetry(fn, "test", {
+      maxRetries: 1,
+      baseDelayMs: 1,
+    });
+    expect(result).toBe("reconnected");
+  });
+
+  it("retries on nested response.status", async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce({ response: { status: 502 } })
+      .mockResolvedValue("ok");
+
+    const result = await withRetry(fn, "test", {
+      maxRetries: 1,
+      baseDelayMs: 1,
+    });
+    expect(result).toBe("ok");
+  });
+
+  it("does not retry on 401 unauthorized", async () => {
+    const err = { status: 401, message: "unauthorized" };
+    const fn = jest.fn().mockRejectedValue(err);
+
+    await expect(
+      withRetry(fn, "test", { maxRetries: 3, baseDelayMs: 1 }),
+    ).rejects.toEqual(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects maxRetries: 0", async () => {
+    const err = { status: 500, message: "error" };
+    const fn = jest.fn().mockRejectedValue(err);
+
+    await expect(
+      withRetry(fn, "test", { maxRetries: 0, baseDelayMs: 1 }),
+    ).rejects.toEqual(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/api/src/lib/gemini.ts
+++ b/services/api/src/lib/gemini.ts
@@ -1,5 +1,6 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { config } from "./config";
+import { withRetry } from "./retry";
 
 let client: GoogleGenerativeAI | null = null;
 
@@ -46,12 +47,16 @@ export async function generateImage(params: ImageGenParams): Promise<ImageGenRes
   // Use Gemini's image generation model
   const model = client.getGenerativeModel({ model: config.GEMINI_MODEL });
 
-  const result = await model.generateContent({
-    contents: [{ role: "user", parts: [{ text: `Generate an image: ${fullPrompt}. Aspect ratio: ${aspectRatio}.` }] }],
-    generationConfig: {
-      maxOutputTokens: 1000,
-    },
-  });
+  const result = await withRetry(
+    () =>
+      model.generateContent({
+        contents: [{ role: "user", parts: [{ text: `Generate an image: ${fullPrompt}. Aspect ratio: ${aspectRatio}.` }] }],
+        generationConfig: {
+          maxOutputTokens: 1000,
+        },
+      }),
+    "gemini:generateImage",
+  );
 
   const response = result.response;
   const text = response.text();
@@ -81,11 +86,13 @@ export async function generateVisualConcept(tweetContent: string, style: ImageSt
   const client = getGeminiClient();
   const model = client.getGenerativeModel({ model: config.GEMINI_MODEL });
 
-  const result = await model.generateContent({
-    contents: [{
-      role: "user",
-      parts: [{
-        text: `You are a visual design AI for crypto Twitter content. Given this tweet, create a visual concept.
+  const result = await withRetry(
+    () =>
+      model.generateContent({
+        contents: [{
+          role: "user",
+          parts: [{
+            text: `You are a visual design AI for crypto Twitter content. Given this tweet, create a visual concept.
 
 Tweet: "${tweetContent}"
 
@@ -103,7 +110,9 @@ Use the Atlas brand palette: primary #4ecdc4 (teal), bg #1a1a2e, surface #2d3748
     generationConfig: {
       maxOutputTokens: 500,
     },
-  });
+  }),
+    "gemini:generateVisualConcept",
+  );
 
   const text = result.response.text();
   const jsonStr = text.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();

--- a/services/api/src/lib/grok.ts
+++ b/services/api/src/lib/grok.ts
@@ -1,6 +1,7 @@
 import OpenAI from "openai";
 import { config } from "./config";
 import { getCached, setCache } from "./redis";
+import { withRetry } from "./retry";
 
 // Grok uses OpenAI-compatible API with different base URL
 let client: OpenAI | null = null;
@@ -66,18 +67,22 @@ export async function searchTrending(params: TrendingSearchParams): Promise<Tren
 
   const client = getGrokClient();
 
-  const response = await client.chat.completions.create({
-    model: "grok-3",
-    max_tokens: 2000,
-    temperature: 0.5,
-    messages: [
-      { role: "system", content: TRENDING_SYSTEM_PROMPT },
-      {
-        role: "user",
-        content: `Topics I follow: ${topics.join(", ")}\n\nFind me the top ${limit} trending discussions on Twitter/X related to these topics right now.`,
-      },
-    ],
-  });
+  const response = await withRetry(
+    () =>
+      client.chat.completions.create({
+        model: "grok-3",
+        max_tokens: 2000,
+        temperature: 0.5,
+        messages: [
+          { role: "system", content: TRENDING_SYSTEM_PROMPT },
+          {
+            role: "user",
+            content: `Topics I follow: ${topics.join(", ")}\n\nFind me the top ${limit} trending discussions on Twitter/X related to these topics right now.`,
+          },
+        ],
+      }),
+    "grok:searchTrending",
+  );
 
   const content = response.choices[0]?.message?.content;
   if (!content) throw new Error("Empty response from Grok");

--- a/services/api/src/lib/providers/gemini.ts
+++ b/services/api/src/lib/providers/gemini.ts
@@ -1,5 +1,6 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { config as envConfig } from "../config";
+import { withRetry } from "../retry";
 import type { Provider, ProviderConfig, CompletionRequest, CompletionResponse } from "./types";
 
 let client: GoogleGenerativeAI | null = null;
@@ -44,13 +45,17 @@ export const geminiProvider: Provider = {
       });
     }
 
-    const result = await model.generateContent({
-      contents,
-      generationConfig: {
-        maxOutputTokens: request.maxTokens ?? 1024,
-        ...(request.temperature !== undefined && { temperature: request.temperature }),
-      },
-    });
+    const result = await withRetry(
+      () =>
+        model.generateContent({
+          contents,
+          generationConfig: {
+            maxOutputTokens: request.maxTokens ?? 1024,
+            ...(request.temperature !== undefined && { temperature: request.temperature }),
+          },
+        }),
+      "gemini-provider:complete",
+    );
 
     const content = result.response.text();
 

--- a/services/api/src/lib/providers/grok.ts
+++ b/services/api/src/lib/providers/grok.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
 import { config as envConfig } from "../config";
+import { withRetry } from "../retry";
 import type { Provider, ProviderConfig, CompletionRequest, CompletionResponse } from "./types";
 
 let client: OpenAI | null = null;
@@ -29,15 +30,19 @@ export const grokProvider: Provider = {
     const ai = getClient();
     const start = Date.now();
 
-    const response = await ai.chat.completions.create({
-      model: config.defaultModel,
-      max_tokens: request.maxTokens ?? 1024,
-      ...(request.temperature !== undefined && { temperature: request.temperature }),
-      messages: request.messages.map((m) => ({
-        role: m.role,
-        content: m.content,
-      })),
-    });
+    const response = await withRetry(
+      () =>
+        ai.chat.completions.create({
+          model: config.defaultModel,
+          max_tokens: request.maxTokens ?? 1024,
+          ...(request.temperature !== undefined && { temperature: request.temperature }),
+          messages: request.messages.map((m) => ({
+            role: m.role,
+            content: m.content,
+          })),
+        }),
+      "grok-provider:complete",
+    );
 
     const content = response.choices[0]?.message?.content?.trim() ?? "";
 

--- a/services/api/src/lib/retry.ts
+++ b/services/api/src/lib/retry.ts
@@ -1,0 +1,83 @@
+import { logger } from "./logger";
+
+interface RetryOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  /** HTTP status codes that should trigger a retry */
+  retryableStatuses?: number[];
+}
+
+const DEFAULTS: Required<RetryOptions> = {
+  maxRetries: 3,
+  baseDelayMs: 500,
+  maxDelayMs: 10_000,
+  retryableStatuses: [429, 500, 502, 503, 504],
+};
+
+function isRetryable(err: unknown, statuses: number[]): boolean {
+  if (err == null || typeof err !== "object") return false;
+
+  // Google Generative AI errors expose .status
+  const status =
+    (err as { status?: number }).status ??
+    (err as { statusCode?: number }).statusCode ??
+    (err as { response?: { status?: number } }).response?.status;
+
+  if (status && statuses.includes(status)) return true;
+
+  // OpenAI SDK wraps rate-limit errors in APIError with .status
+  const name = (err as { name?: string }).name ?? "";
+  if (name === "RateLimitError" || name === "InternalServerError") return true;
+
+  // Network-level errors
+  const code = (err as { code?: string }).code;
+  if (code === "ECONNRESET" || code === "ETIMEDOUT" || code === "ENOTFOUND") return true;
+
+  return false;
+}
+
+function jitteredDelay(base: number, attempt: number, max: number): number {
+  const exponential = base * 2 ** attempt;
+  const capped = Math.min(exponential, max);
+  // Add ±25% jitter
+  return capped * (0.75 + Math.random() * 0.5);
+}
+
+/**
+ * Retry an async function with exponential backoff + jitter.
+ * Only retries on transient HTTP errors (429, 5xx) and network failures.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  label: string,
+  opts?: RetryOptions,
+): Promise<T> {
+  const { maxRetries, baseDelayMs, maxDelayMs, retryableStatuses } = {
+    ...DEFAULTS,
+    ...opts,
+  };
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+
+      if (attempt === maxRetries || !isRetryable(err, retryableStatuses)) {
+        break;
+      }
+
+      const delay = jitteredDelay(baseDelayMs, attempt, maxDelayMs);
+      logger.warn(
+        { attempt: attempt + 1, maxRetries, delayMs: Math.round(delay), label },
+        `[retry] ${label} — attempt ${attempt + 1} failed, retrying in ${Math.round(delay)}ms`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}


### PR DESCRIPTION
## Summary
- New `lib/retry.ts` — generic `withRetry()` utility with exponential backoff + jitter
- Wraps all Gemini and Grok API calls (6 call sites across 4 files)
- Handles HTTP 429, 500, 502, 503, 504, plus `RateLimitError`, `InternalServerError`, and network errors (`ECONNRESET`, `ETIMEDOUT`)
- Max 3 retries, base 500ms delay, capped at 10s, ±25% jitter

## Test plan
- [x] 11 new tests in `retry.test.ts` covering: success, retry on 429/500/503, nested `response.status`, `RateLimitError` name, `ECONNRESET`, non-retryable 400/401, `maxRetries: 0`, retry exhaustion
- [x] Full suite: 30 suites, 260 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)