### PR TITLE
feat: enable Telegram bot on server start

### DIFF
--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -136,6 +136,7 @@ const server = createServer(app);
 server.timeout = 120_000; // 2 min — AI generation routes need more than Railway's 30s default
 server.keepAliveTimeout = 65_000;
 initSocket(server, allowedOrigins);
+initBot();
 
 server.listen(PORT, () => {
   logger.info({ port: PORT }, `Atlas API running on port ${PORT}`);


### PR DESCRIPTION
## Summary
- Add `initBot()` call in index.ts to start the Telegram bot when `TELEGRAM_BOT_TOKEN` is set
- Bot service was already fully implemented in lib/telegram.ts, just never initialized
- `TELEGRAM_BOT_TOKEN` env var set on Railway

## Test plan
- [ ] Bot responds to /start in Telegram
- [ ] /link command stores chatId on user record
- [ ] Alert delivery routes to Telegram when subscription has TELEGRAM channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)