### PR TITLE
feat: QA Test Run API endpoints

### DIFF
--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -19,6 +19,7 @@ import { loopRouter } from "./routes/loop";
 import briefingRouter from "./routes/briefing";
 import { docsRouter } from "./routes/docs";
 import { xAuthRouter } from "./routes/x-auth";
+import { qaRouter } from "./routes/qa";
 import { buildErrorResponse, requestIdMiddleware } from "./middleware/requestId";
 import { rateLimit } from "./middleware/rateLimit";
 import { requestLogger } from "./middleware/requestLogger";
@@ -113,6 +114,7 @@ app.use("/api/images", imagesRouter);
 app.use("/api/loop", loopRouter);
 app.use("/api/briefing", briefingRouter);
 app.use("/api/auth/x", xAuthRouter);
+app.use("/api/qa", qaRouter);
 
 // 404 handler — catch unknown routes before error handlers
 app.use((req, res) => {

--- a/services/api/src/routes/qa.ts
+++ b/services/api/src/routes/qa.ts
@@ -1,0 +1,136 @@
+import { Router } from "express";
+import { authenticate, AuthRequest } from "../middleware/auth";
+import { supabaseAdmin } from "../lib/supabase";
+import { prisma } from "../lib/prisma";
+import { success, error } from "../lib/response";
+import { logger } from "../lib/logger";
+
+export const qaRouter = Router();
+qaRouter.use(authenticate);
+
+const TABLE = "qa_test_runs";
+
+// List all test runs for project 'atlas'
+qaRouter.get("/runs", async (req: AuthRequest, res) => {
+  try {
+    const { data, error: dbErr } = await supabaseAdmin!
+      .from(TABLE)
+      .select("*")
+      .eq("project", "atlas")
+      .order("created_at", { ascending: false });
+
+    if (dbErr) throw dbErr;
+    res.json(success({ runs: data }));
+  } catch (err: any) {
+    logger.error({ err: err.message }, "Failed to list QA runs");
+    res.status(500).json(error("Failed to list QA runs"));
+  }
+});
+
+// Get single test run
+qaRouter.get("/runs/:id", async (req: AuthRequest, res) => {
+  try {
+    const { data, error: dbErr } = await supabaseAdmin!
+      .from(TABLE)
+      .select("*")
+      .eq("id", req.params.id)
+      .single();
+
+    if (dbErr || !data) return res.status(404).json(error("Test run not found"));
+    res.json(success({ run: data }));
+  } catch (err: any) {
+    logger.error({ err: err.message }, "Failed to get QA run");
+    res.status(500).json(error("Failed to get QA run"));
+  }
+});
+
+// Create test run
+qaRouter.post("/runs", async (req: AuthRequest, res) => {
+  try {
+    const { tester_name, tester_initials } = req.body;
+    if (!tester_name || !tester_initials) {
+      return res.status(400).json(error("tester_name and tester_initials required"));
+    }
+
+    const { data, error: dbErr } = await supabaseAdmin!
+      .from(TABLE)
+      .insert({
+        project: "atlas",
+        tester_id: req.userId,
+        tester_name,
+        tester_initials,
+        status: "in_progress",
+        results: {},
+        summary: {},
+      })
+      .select()
+      .single();
+
+    if (dbErr) throw dbErr;
+    res.status(201).json(success({ run: data }));
+  } catch (err: any) {
+    logger.error({ err: err.message }, "Failed to create QA run");
+    res.status(500).json(error("Failed to create QA run"));
+  }
+});
+
+// Update test run (owner or MANAGER)
+qaRouter.patch("/runs/:id", async (req: AuthRequest, res) => {
+  try {
+    const { data: run, error: fetchErr } = await supabaseAdmin!
+      .from(TABLE)
+      .select("tester_id")
+      .eq("id", req.params.id)
+      .single();
+
+    if (fetchErr || !run) return res.status(404).json(error("Test run not found"));
+
+    // Check ownership or manager role
+    if (run.tester_id !== req.userId) {
+      const user = await prisma.user.findUnique({ where: { id: req.userId } });
+      if (!user || user.role === "ANALYST") {
+        return res.status(403).json(error("Only the tester or a manager can update this run"));
+      }
+    }
+
+    const { results, summary, status } = req.body;
+    const { data, error: dbErr } = await supabaseAdmin!
+      .from(TABLE)
+      .update({
+        ...(results !== undefined && { results }),
+        ...(summary !== undefined && { summary }),
+        ...(status !== undefined && { status }),
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", req.params.id)
+      .select()
+      .single();
+
+    if (dbErr) throw dbErr;
+    res.json(success({ run: data }));
+  } catch (err: any) {
+    logger.error({ err: err.message }, "Failed to update QA run");
+    res.status(500).json(error("Failed to update QA run"));
+  }
+});
+
+// Delete test run (MANAGER only)
+qaRouter.delete("/runs/:id", async (req: AuthRequest, res) => {
+  try {
+    const user = await prisma.user.findUnique({ where: { id: req.userId } });
+    if (!user || user.role === "ANALYST") {
+      return res.status(403).json(error("Manager access required"));
+    }
+
+    const { error: dbErr } = await supabaseAdmin!
+      .from(TABLE)
+      .delete()
+      .eq("id", req.params.id);
+
+    if (dbErr) throw dbErr;
+    res.json(success({ deleted: true }));
+  } catch (err: any) {
+    logger.error({ err: err.message }, "Failed to delete QA run");
+    res.status(500).json(error("Failed to delete QA run"));
+  }
+});


### PR DESCRIPTION
## Summary
- Adds `/api/qa/runs` CRUD endpoints backed by Supabase `qa_test_runs` table
- GET (list/single), POST (create), PATCH (update results/status), DELETE
- Auth required on all endpoints
- Owner or MANAGER can update runs, MANAGER can delete
- Used by the new `/admin/qa` page in atlas-portal

## Test plan
- [x] TypeScript compiles cleanly
- [ ] Manual test: create run, update results, verify in Supabase
- [ ] Verify role-based access (ANALYST blocked from delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)