### PR TITLE
feat: add deliveredAt to Alert model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -248,6 +248,7 @@ model Alert {
   category    AlertCategory @default(SIGNAL)
   userId      String?
   expiresAt   DateTime?
+  deliveredAt DateTime?
   createdAt   DateTime    @default(now())
 
   user User? @relation(fields: [userId], references: [id], onDelete: SetNull)

--- a/services/api/src/lib/alertDelivery.ts
+++ b/services/api/src/lib/alertDelivery.ts
@@ -38,10 +38,16 @@ export async function dispatchAlert(alert: AlertPayload): Promise<void> {
 
     if (telegramSubs.length === 0) return;
 
-    // Deliver via Telegram (non-blocking)
-    deliverAlertToUser(alert, alert.userId).catch((err) =>
-      logger.error({ err }, `[alertDelivery] Telegram delivery failed for alert ${alert.id}`)
-    );
+    // Deliver via Telegram and stamp deliveredAt on success
+    deliverAlertToUser(alert, alert.userId)
+      .then((ok) => {
+        if (ok) {
+          prisma.alert.update({ where: { id: alert.id }, data: { deliveredAt: new Date() } }).catch(() => {});
+        }
+      })
+      .catch((err) =>
+        logger.error({ err }, `[alertDelivery] Telegram delivery failed for alert ${alert.id}`)
+      );
   } catch (err) {
     logger.error({ err }, `[alertDelivery] Dispatch failed for alert ${alert.id}`);
   }


### PR DESCRIPTION
## Summary
- Adds `deliveredAt DateTime?` field to Alert model in Prisma schema
- Updates `dispatchAlert()` to stamp `deliveredAt` on successful Telegram delivery
- Enables tracking of which alerts were actually delivered vs just created

## Test plan
- [ ] Railway deploy runs `prisma db push` — verify schema syncs
- [ ] Send `/alerts` in Telegram bot — verify alerts display
- [ ] Create alert for user with Telegram linked — verify `deliveredAt` gets set

🤖 Generated with [Claude Code](https://claude.com/claude-code)