### PR TITLE
feat: Oracle chat API for FloatingOracle widget

### DIFF
--- a/services/api/src/routes/oracle.ts
+++ b/services/api/src/routes/oracle.ts
@@ -7,6 +7,7 @@ import {
   buildBlendPreview,
   buildDimensionReaction,
   buildFreeTextResponse,
+  buildOracleSystemPrompt,
 } from "../lib/oracle-prompt";
 import { success } from "../lib/response";
 import { logger } from "../lib/logger";
@@ -202,3 +203,87 @@ function resolvePrompt(
   // No LLM needed — client handles scripted messages
   return null;
 }
+
+// ── General Chat ────────────────────────────────────────────────
+// Used by the FloatingOracle widget on all pages.
+
+const chatSchema = z.object({
+  messages: z
+    .array(
+      z.object({
+        role: z.enum(["user", "oracle"]),
+        content: z.string().max(2000),
+      }),
+    )
+    .min(1)
+    .max(20),
+  page: z.string().optional(),
+});
+
+oracleRouter.post("/chat", async (req: AuthRequest, res) => {
+  try {
+    const body = chatSchema.parse(req.body);
+
+    // Build page context
+    const pageHint = body.page ? `\nThe user is currently on the ${body.page} page.` : "";
+
+    // Fetch user's voice profile for personalization
+    let voiceHint = "";
+    try {
+      const profile = await prisma.voiceProfile.findUnique({
+        where: { userId: req.userId! },
+      });
+      if (profile) {
+        voiceHint = `\nUser's voice profile: Humor ${profile.humor}/100, Formality ${profile.formality}/100, Brevity ${profile.brevity}/100, Contrarian ${profile.contrarianTone}/100.`;
+      }
+    } catch {
+      // Non-fatal — proceed without voice context
+    }
+
+    const systemPrompt =
+      buildOracleSystemPrompt() +
+      `\n\nYou are responding in the floating chat widget inside the Atlas portal.` +
+      `\nThe user's handle is @${req.userId}.` +
+      pageHint +
+      voiceHint +
+      `\n\nKeep responses under 50 words. Be helpful and personalized. If the user asks about Atlas features, guide them. If they ask about crypto/markets, offer to help them draft a take.`;
+
+    const llmMessages = [
+      { role: "system" as const, content: systemPrompt },
+      ...body.messages.map((m) => ({
+        role: (m.role === "oracle" ? "assistant" : "user") as "system" | "user" | "assistant",
+        content: m.content,
+      })),
+    ];
+
+    const response = await withTimeout(
+      routeCompletion({
+        taskType: "oracle_fast",
+        maxTokens: 150,
+        temperature: 0.7,
+        messages: llmMessages,
+      }),
+      8_000,
+      "oracle-chat",
+    );
+
+    logger.info(
+      {
+        provider: response.provider,
+        model: response.model,
+        latencyMs: response.latencyMs,
+        page: body.page,
+      },
+      "Oracle chat response",
+    );
+
+    res.json(success({ text: response.content.trim() }));
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ ok: false, error: "Invalid request", details: err.errors });
+      return;
+    }
+    logger.error({ error: err }, "Oracle chat error");
+    res.status(500).json({ ok: false, error: "Oracle is thinking... try again in a moment." });
+  }
+});


### PR DESCRIPTION
## Summary
- New `POST /api/oracle/chat` endpoint for the floating Oracle widget
- Takes conversation history (up to 20 messages) + current page context
- Fetches user's voice profile for personalized responses
- Routes through existing provider chain (Anthropic → OpenAI → Gemini)
- 8s timeout, graceful error handling

## Test plan
- [x] TypeScript passes
- [x] 390/390 tests pass
- [ ] CI passes
- [ ] E2E: open Oracle widget → type a question → get AI response

🤖 Generated with [Claude Code](https://claude.com/claude-code)