### PR TITLE
fix: restore public reference-accounts route

### DIFF
--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -7,7 +7,7 @@ import cors from "cors";
 import dotenv from "dotenv";
 import { config } from "./lib/config";
 import { authRouter } from "./routes/auth";
-import { voiceRouter } from "./routes/voice";
+import { voiceRouter, referenceAccountsRouter } from "./routes/voice";
 import { draftsRouter } from "./routes/drafts";
 import { analyticsRouter } from "./routes/analytics";
 import { alertsRouter } from "./routes/alerts";
@@ -103,6 +103,7 @@ app.get("/health", async (_req, res) => {
 app.use("/api/docs", docsRouter);
 app.use("/api/auth", authRouter);
 app.use("/api/users", usersRouter);
+app.use("/api/voice", referenceAccountsRouter);
 app.use("/api/voice", voiceRouter);
 app.use("/api/drafts", draftsRouter);
 app.use("/api/analytics", analyticsRouter);


### PR DESCRIPTION
Lost in merge. Oracle onboarding needs this without auth.