### PR TITLE
fix: 5 critical bugs — monitors, campaigns, oracle chat, route registration

### DIFF
--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -20,6 +20,8 @@ import briefingRouter from "./routes/briefing";
 import { docsRouter } from "./routes/docs";
 import { xAuthRouter } from "./routes/x-auth";
 import { oracleRouter } from "./routes/oracle";
+import { campaignsRouter } from "./routes/campaigns";
+import { monitorsRouter } from "./routes/monitors";
 import { buildErrorResponse, requestIdMiddleware } from "./middleware/requestId";
 import { rateLimit } from "./middleware/rateLimit";
 import { requestLogger } from "./middleware/requestLogger";
@@ -114,6 +116,8 @@ app.use("/api/loop", loopRouter);
 app.use("/api/briefing", briefingRouter);
 app.use("/api/auth/x", xAuthRouter);
 app.use("/api/oracle", oracleRouter);
+app.use("/api/campaigns", campaignsRouter);
+app.use("/api/monitors", monitorsRouter);
 
 // 404 handler — catch unknown routes before error handlers
 app.use((req, res) => {

--- a/services/api/src/routes/campaigns.ts
+++ b/services/api/src/routes/campaigns.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { prisma } from "../lib/prisma";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { logger } from "../lib/logger";
+import { success, error } from "../lib/response";
 
 export const campaignsRouter = Router({ mergeParams: true });
 campaignsRouter.use(authenticate);
@@ -35,10 +36,10 @@ campaignsRouter.get("/", async (req: AuthRequest, res) => {
       draftCount: c._count.drafts,
       _count: undefined,
     }));
-    res.json({ campaigns: result });
+    res.json(success({ campaigns: result }));
   } catch (err: any) {
     logger.error({ err: err.message }, "Failed to list campaigns");
-    res.status(500).json({ error: "Failed to list campaigns" });
+    res.status(500).json(error("Failed to list campaigns"));
   }
 });
 
@@ -50,13 +51,13 @@ campaignsRouter.post("/", async (req: AuthRequest, res) => {
       data: { userId: req.userId!, name: body.name, description: body.description },
     });
     logger.info({ campaignId: campaign.id, userId: req.userId }, "Campaign created");
-    res.status(201).json({ campaign: { ...campaign, draftCount: 0 } });
+    res.status(201).json(success({ campaign: { ...campaign, draftCount: 0 } }));
   } catch (err: any) {
     if (err instanceof z.ZodError) {
-      return res.status(400).json({ error: "Invalid request", details: err.errors });
+      return res.status(400).json(error("Invalid request", 400, err.errors));
     }
     logger.error({ err: err.message }, "Failed to create campaign");
-    res.status(500).json({ error: "Failed to create campaign" });
+    res.status(500).json(error("Failed to create campaign"));
   }
 });
 
@@ -68,12 +69,12 @@ campaignsRouter.get("/:id", async (req: AuthRequest, res) => {
       include: { drafts: { orderBy: { sortOrder: "asc" } } },
     });
     if (!campaign) {
-      return res.status(404).json({ error: "Campaign not found" });
+      return res.status(404).json(error("Campaign not found", 404));
     }
-    res.json({ campaign: { ...campaign, draftCount: campaign.drafts.length } });
+    res.json(success({ campaign: { ...campaign, draftCount: campaign.drafts.length } }));
   } catch (err: any) {
     logger.error({ err: err.message }, "Failed to get campaign");
-    res.status(500).json({ error: "Failed to get campaign" });
+    res.status(500).json(error("Failed to get campaign"));
   }
 });
 
@@ -86,19 +87,19 @@ campaignsRouter.patch("/:id", async (req: AuthRequest, res) => {
       data: body,
     });
     if (updated.count === 0) {
-      return res.status(404).json({ error: "Campaign not found" });
+      return res.status(404).json(error("Campaign not found", 404));
     }
     const campaign = await prisma.campaign.findUnique({
       where: { id: paramId(req) },
       include: { drafts: true },
     });
-    res.json({ campaign: { ...campaign, draftCount: campaign?.drafts.length ?? 0, drafts: undefined } });
+    res.json(success({ campaign: { ...campaign, draftCount: campaign?.drafts.length ?? 0, drafts: undefined } }));
   } catch (err: any) {
     if (err instanceof z.ZodError) {
-      return res.status(400).json({ error: "Invalid request", details: err.errors });
+      return res.status(400).json(error("Invalid request", 400, err.errors));
     }
     logger.error({ err: err.message }, "Failed to update campaign");
-    res.status(500).json({ error: "Failed to update campaign" });
+    res.status(500).json(error("Failed to update campaign"));
   }
 });
 
@@ -113,12 +114,12 @@ campaignsRouter.delete("/:id", async (req: AuthRequest, res) => {
       where: { id: paramId(req), userId: req.userId },
     });
     if (deleted.count === 0) {
-      return res.status(404).json({ error: "Campaign not found" });
+      return res.status(404).json(error("Campaign not found", 404));
     }
-    res.json({ success: true });
+    res.json(success({ deleted: true }));
   } catch (err: any) {
     logger.error({ err: err.message }, "Failed to delete campaign");
-    res.status(500).json({ error: "Failed to delete campaign" });
+    res.status(500).json(error("Failed to delete campaign"));
   }
 });
 
@@ -133,21 +134,21 @@ campaignsRouter.post("/:id/drafts", async (req: AuthRequest, res) => {
     const campaign = await prisma.campaign.findFirst({
       where: { id: paramId(req), userId: req.userId },
     });
-    if (!campaign) return res.status(404).json({ error: "Campaign not found" });
+    if (!campaign) return res.status(404).json(error("Campaign not found", 404));
 
     const draft = await prisma.tweetDraft.updateMany({
       where: { id: draftId, userId: req.userId },
       data: { campaignId: paramId(req), sortOrder: sortOrder ?? 0 },
     });
-    if (draft.count === 0) return res.status(404).json({ error: "Draft not found" });
+    if (draft.count === 0) return res.status(404).json(error("Draft not found", 404));
 
-    res.json({ success: true });
+    res.json(success({ deleted: true }));
   } catch (err: any) {
     if (err instanceof z.ZodError) {
-      return res.status(400).json({ error: "Invalid request", details: err.errors });
+      return res.status(400).json(error("Invalid request", 400, err.errors));
     }
     logger.error({ err: err.message }, "Failed to add draft to campaign");
-    res.status(500).json({ error: "Failed to add draft to campaign" });
+    res.status(500).json(error("Failed to add draft to campaign"));
   }
 });
 
@@ -158,10 +159,10 @@ campaignsRouter.delete("/:id/drafts/:draftId", async (req: AuthRequest, res) => 
       where: { id: paramId(req, "draftId"), campaignId: paramId(req), userId: req.userId },
       data: { campaignId: null, sortOrder: null },
     });
-    if (updated.count === 0) return res.status(404).json({ error: "Draft not found in campaign" });
-    res.json({ success: true });
+    if (updated.count === 0) return res.status(404).json(error("Draft not found in campaign", 404));
+    res.json(success({ deleted: true }));
   } catch (err: any) {
     logger.error({ err: err.message }, "Failed to remove draft from campaign");
-    res.status(500).json({ error: "Failed to remove draft from campaign" });
+    res.status(500).json(error("Failed to remove draft from campaign"));
   }
 });

--- a/services/api/src/routes/monitors.ts
+++ b/services/api/src/routes/monitors.ts
@@ -8,7 +8,7 @@ export const monitorsRouter = Router();
 monitorsRouter.use(authenticate);
 
 function paramId(req: AuthRequest): string {
-  return paramId(req) as string;
+  return req.params.id as string;
 }
 
 const createSchema = z.object({

--- a/services/api/src/routes/oracle.ts
+++ b/services/api/src/routes/oracle.ts
@@ -7,6 +7,7 @@ import {
   buildBlendPreview,
   buildDimensionReaction,
   buildFreeTextResponse,
+  buildOracleSystemPrompt,
 } from "../lib/oracle-prompt";
 import { success } from "../lib/response";
 import { logger } from "../lib/logger";
@@ -202,3 +203,59 @@ function resolvePrompt(
   // No LLM needed — client handles scripted messages
   return null;
 }
+
+// ── General Chat ────────────────────────────────────────────────
+
+const chatSchema = z.object({
+  messages: z
+    .array(z.object({ role: z.enum(["user", "oracle"]), content: z.string().max(2000) }))
+    .min(1)
+    .max(20),
+  page: z.string().optional(),
+});
+
+oracleRouter.post("/chat", async (req: AuthRequest, res) => {
+  try {
+    const body = chatSchema.parse(req.body);
+
+    const pageHint = body.page ? `\nThe user is on the ${body.page} page.` : "";
+
+    let voiceHint = "";
+    try {
+      const profile = await prisma.voiceProfile.findUnique({ where: { userId: req.userId! } });
+      if (profile) {
+        voiceHint = `\nVoice: Humor ${profile.humor}/100, Formality ${profile.formality}/100, Brevity ${profile.brevity}/100, Contrarian ${profile.contrarianTone}/100.`;
+      }
+    } catch {}
+
+    const systemPrompt =
+      buildOracleSystemPrompt() +
+      `\n\nYou are in the floating chat widget inside Atlas.` +
+      pageHint + voiceHint +
+      `\n\nKeep responses under 50 words. Be helpful and personalized.`;
+
+    const llmMessages = [
+      { role: "system" as const, content: systemPrompt },
+      ...body.messages.map((m) => ({
+        role: (m.role === "oracle" ? "assistant" : "user") as "system" | "user" | "assistant",
+        content: m.content,
+      })),
+    ];
+
+    const response = await withTimeout(
+      routeCompletion({ taskType: "oracle_fast", maxTokens: 150, temperature: 0.7, messages: llmMessages }),
+      8_000,
+      "oracle-chat",
+    );
+
+    logger.info({ provider: response.provider, latencyMs: response.latencyMs, page: body.page }, "Oracle chat response");
+    res.json(success({ text: response.content.trim() }));
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ ok: false, error: "Invalid request", details: err.errors });
+      return;
+    }
+    logger.error({ error: err }, "Oracle chat error");
+    res.status(500).json({ ok: false, error: "Oracle is thinking... try again in a moment." });
+  }
+});


### PR DESCRIPTION
## Summary
1. **monitors.ts** — `paramId()` infinite recursion → reads `req.params.id`
2. **campaigns.ts** — bare JSON responses → `success()`/`error()` envelope
3. **index.ts** — register `/api/campaigns` and `/api/monitors` (were unreachable)
4. **oracle.ts** — add `/chat` endpoint for FloatingOracle widget (was missing)

## Test plan
- [x] 390/390 tests pass
- [x] TypeScript clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)