### PR TITLE
fix: round 2 — monitors, campaigns, transcribe, x-auth

### DIFF
--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -22,6 +22,7 @@ import { xAuthRouter } from "./routes/x-auth";
 import { oracleRouter } from "./routes/oracle";
 import { campaignsRouter } from "./routes/campaigns";
 import { monitorsRouter } from "./routes/monitors";
+import { transcribeRouter } from "./routes/transcribe";
 import { buildErrorResponse, requestIdMiddleware } from "./middleware/requestId";
 import { rateLimit } from "./middleware/rateLimit";
 import { requestLogger } from "./middleware/requestLogger";
@@ -119,6 +120,7 @@ app.use("/api/auth/x", xAuthRouter);
 app.use("/api/oracle", oracleRouter);
 app.use("/api/campaigns", campaignsRouter);
 app.use("/api/monitors", monitorsRouter);
+app.use("/api/transcribe", transcribeRouter);
 
 // 404 handler — catch unknown routes before error handlers
 app.use((req, res) => {

--- a/services/api/src/routes/campaigns.ts
+++ b/services/api/src/routes/campaigns.ts
@@ -142,7 +142,7 @@ campaignsRouter.post("/:id/drafts", async (req: AuthRequest, res) => {
     });
     if (draft.count === 0) return res.status(404).json(error("Draft not found", 404));
 
-    res.json(success({ deleted: true }));
+    res.json(success({ added: true }));
   } catch (err: any) {
     if (err instanceof z.ZodError) {
       return res.status(400).json(error("Invalid request", 400, err.errors));
@@ -160,7 +160,7 @@ campaignsRouter.delete("/:id/drafts/:draftId", async (req: AuthRequest, res) => 
       data: { campaignId: null, sortOrder: null },
     });
     if (updated.count === 0) return res.status(404).json(error("Draft not found in campaign", 404));
-    res.json(success({ deleted: true }));
+    res.json(success({ removed: true }));
   } catch (err: any) {
     logger.error({ err: err.message }, "Failed to remove draft from campaign");
     res.status(500).json(error("Failed to remove draft from campaign"));

--- a/services/api/src/routes/monitors.ts
+++ b/services/api/src/routes/monitors.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { prisma } from "../lib/prisma";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { logger } from "../lib/logger";
+import { success, error } from "../lib/response";
 
 export const monitorsRouter = Router();
 monitorsRouter.use(authenticate);
@@ -33,10 +34,10 @@ monitorsRouter.get("/", async (req: AuthRequest, res) => {
       where: { userId: req.userId },
       orderBy: { createdAt: "desc" },
     });
-    res.json({ monitors });
+    res.json(success({ monitors }));
   } catch (err: any) {
     logger.error({ err: err.message }, "Failed to list monitors");
-    res.status(500).json({ error: "Failed to list monitors" });
+    res.status(500).json(error("Failed to list monitors"));
   }
 });
 

--- a/services/api/src/routes/x-auth.ts
+++ b/services/api/src/routes/x-auth.ts
@@ -3,6 +3,7 @@ import { prisma } from "../lib/prisma";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { generateOAuthUrl, exchangeCodeForTokens, lookupUser } from "../lib/twitter";
 import { logger } from "../lib/logger";
+import { error } from "../lib/response";
 import { buildErrorResponse } from "../middleware/requestId";
 import { success } from "../lib/response";
 
@@ -98,16 +99,21 @@ xAuthRouter.post("/callback", authenticate, async (req: AuthRequest, res) => {
  * Check if the user has linked their X account.
  */
 xAuthRouter.get("/status", authenticate, async (req: AuthRequest, res) => {
-  const user = await prisma.user.findUnique({
-    where: { id: req.userId! },
-    select: { xHandle: true, xAccessToken: true, xTokenExpiresAt: true },
-  });
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.userId! },
+      select: { xHandle: true, xAccessToken: true, xTokenExpiresAt: true },
+    });
 
-  res.json(success({
-    linked: !!user?.xAccessToken,
-    xHandle: user?.xHandle || null,
-    tokenExpired: user?.xTokenExpiresAt ? user.xTokenExpiresAt < new Date() : true,
-  }));
+    res.json(success({
+      linked: !!user?.xAccessToken,
+      xHandle: user?.xHandle || null,
+      tokenExpired: user?.xTokenExpiresAt ? user.xTokenExpiresAt < new Date() : true,
+    }));
+  } catch (err: any) {
+    logger.error({ err: err.message }, "X auth status check failed");
+    res.status(500).json(error("Failed to check X auth status"));
+  }
 });
 
 /**
@@ -115,12 +121,18 @@ xAuthRouter.get("/status", authenticate, async (req: AuthRequest, res) => {
  * Remove X account link.
  */
 xAuthRouter.post("/disconnect", authenticate, async (req: AuthRequest, res) => {
-  await prisma.user.update({
-    where: { id: req.userId! },
-    data: { xAccessToken: null, xRefreshToken: null, xTokenExpiresAt: null, xHandle: null },
-  });
-  res.json(success({ linked: false }));
+  try {
+    await prisma.user.update({
+      where: { id: req.userId! },
+      data: { xAccessToken: null, xRefreshToken: null, xTokenExpiresAt: null, xHandle: null },
+    });
+    res.json(success({ linked: false }));
+  } catch (err: any) {
+    logger.error({ err: err.message }, "X auth disconnect failed");
+    res.status(500).json(error("Failed to disconnect X account"));
+  }
 });
+
 
 // Cleanup expired pending OAuth entries periodically
 setInterval(() => {


### PR DESCRIPTION
## Summary
- monitors.ts: wrap GET response in success() envelope
- campaigns.ts: fix add-draft returning wrong property name
- index.ts: register /api/transcribe (voice capture was unreachable)
- x-auth.ts: add try/catch + error import for /status and /disconnect

## Test plan
- [x] 390/390 tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)