### PR TITLE
feat(users): add xBio, xAvatarUrl, xFollowerCount to User model (#693)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,9 @@ model User {
   xAccessToken      String?
   xRefreshToken     String?
   xTokenExpiresAt   DateTime?
+  xBio              String?
+  xAvatarUrl        String?
+  xFollowerCount    Int?
   tourCompleted     Boolean  @default(false)
   tourStep          Int      @default(0)
   createdAt         DateTime @default(now())

--- a/services/api/src/routes/x-auth.ts
+++ b/services/api/src/routes/x-auth.ts
@@ -112,6 +112,9 @@ xAuthRouter.get("/callback", async (req, res) => {
     const xHandle = profile.username;
     const displayName = profile.name;
     const avatarUrl = profile.profile_image_url || null;
+    const xBio = profile.description ?? null;
+    const xAvatarUrl = profile.profile_image_url ?? null;
+    const xFollowerCount = profile.public_metrics?.followers_count ?? null;
 
     let user = await prisma.user.findFirst({ where: { xHandle } });
 
@@ -124,6 +127,9 @@ xAuthRouter.get("/callback", async (req, res) => {
           xTokenExpiresAt: new Date(Date.now() + expiresIn * 1000),
           displayName: displayName || user.displayName,
           avatarUrl: avatarUrl || user.avatarUrl,
+          xBio: xBio ?? user.xBio,
+          xAvatarUrl: xAvatarUrl ?? user.xAvatarUrl,
+          xFollowerCount: xFollowerCount ?? user.xFollowerCount,
         },
       });
       logger.info({ userId: user.id, xHandle }, "Twitter login — returning user");
@@ -137,6 +143,9 @@ xAuthRouter.get("/callback", async (req, res) => {
           xAccessToken: accessToken,
           xRefreshToken: refreshToken,
           xTokenExpiresAt: new Date(Date.now() + expiresIn * 1000),
+          xBio,
+          xAvatarUrl,
+          xFollowerCount,
           onboardingTrack: "TRACK_B",
           voiceProfile: { create: {} },
         },
@@ -346,7 +355,8 @@ twitterLoginRouter.get("/callback", async (req, res) => {
     const xHandle = profile.username;
     const displayName = profile.name;
     const avatarUrl = profile.profile_image_url || null;
-    const xBio = profile.description || null;
+    const xBio = profile.description ?? null;
+    const xAvatarUrl = profile.profile_image_url ?? null;
     const xFollowerCount = profile.public_metrics?.followers_count ?? null;
 
     // Find existing user by xHandle, or create new one
@@ -362,6 +372,9 @@ twitterLoginRouter.get("/callback", async (req, res) => {
           xTokenExpiresAt: new Date(Date.now() + expiresIn * 1000),
           displayName: displayName || user.displayName,
           avatarUrl: avatarUrl || user.avatarUrl,
+          xBio: xBio ?? user.xBio,
+          xAvatarUrl: xAvatarUrl ?? user.xAvatarUrl,
+          xFollowerCount: xFollowerCount ?? user.xFollowerCount,
         },
       });
       logger.info({ userId: user.id, xHandle }, "Twitter login — returning user");
@@ -376,6 +389,9 @@ twitterLoginRouter.get("/callback", async (req, res) => {
           xAccessToken: accessToken,
           xRefreshToken: refreshToken,
           xTokenExpiresAt: new Date(Date.now() + expiresIn * 1000),
+          xBio,
+          xAvatarUrl,
+          xFollowerCount,
           onboardingTrack: "TRACK_B", // Twitter-first = Track B (Anil's flow)
           voiceProfile: { create: {} },
         },


### PR DESCRIPTION
## Summary
- Adds three optional Twitter/X profile fields to the `User` Prisma model: `xBio`, `xAvatarUrl`, `xFollowerCount`
- Populates them during the X OAuth login/link callback from `fetchTwitterUserProfile` (description, profile_image_url, public_metrics.followers_count)
- Writes apply in both `xAuthRouter` GET `/callback` and `twitterLoginRouter` GET `/callback`, on both create (new user) and update (returning user, new values override only when present)
- `GET /api/users/profile` exposes the new fields automatically via the existing full-user spread response

## Changes
- `prisma/schema.prisma` — add `xBio String?`, `xAvatarUrl String?`, `xFollowerCount Int?` to `User`
- `services/api/src/routes/x-auth.ts` — parse and persist the three fields in both OAuth callback handlers

## Test plan
- [x] `npx prisma generate` succeeds
- [x] `npx tsc --noEmit` → 0 errors
- [ ] Manual: log in via X OAuth, verify `xBio`/`xAvatarUrl`/`xFollowerCount` populated in DB
- [ ] Manual: `GET /api/users/profile` includes the three new fields in the response
- [ ] Run `prisma db push` / migration against staging DB before deploy

Task: #693