### PR TITLE
fix: auth cookie attrs + rate limit config constants

### DIFF
--- a/services/api/src/lib/cookies.ts
+++ b/services/api/src/lib/cookies.ts
@@ -29,8 +29,8 @@ export function setAuthCookies(res: Response, accessToken: string, refreshToken:
 }
 
 export function clearAuthCookies(res: Response): void {
-  res.clearCookie("atlas_access_token", { path: "/" });
-  res.clearCookie("atlas_refresh_token", { path: "/" });
+  res.clearCookie("atlas_access_token", COOKIE_OPTIONS);
+  res.clearCookie("atlas_refresh_token", COOKIE_OPTIONS);
 }
 
 export function getAccessToken(req: Request): string | null {

--- a/services/api/src/routes/x-auth.ts
+++ b/services/api/src/routes/x-auth.ts
@@ -11,11 +11,7 @@ import { config } from "../lib/config";
 import { rateLimit } from "../middleware/rateLimit";
 
 export const xAuthRouter = Router();
-const authRateLimiter = rateLimit(
-  config.RATE_LIMIT_AUTH_MAX_REQUESTS,
-  config.RATE_LIMIT_AUTH_WINDOW_MS,
-);
-xAuthRouter.use(authRateLimiter);
+xAuthRouter.use(rateLimit(20, 60 * 1000)); // 20 req/min for auth routes
 
 // In-memory store for PKCE code verifiers (keyed by state)
 // In production, use Redis. This works for single-instance deploys.


### PR DESCRIPTION
Two auth bug fixes from codex/arena-backend:\n- clearAuthCookies now matches SameSite/Secure attrs set by setAuthCookies (fixes logout cookie clearing)\n- Rate limit uses inline constants instead of missing RATE_LIMIT_AUTH_* env vars