### PR TITLE
fix: strip em dashes from generated tweet content

### DIFF
--- a/services/api/src/lib/draft-generation.ts
+++ b/services/api/src/lib/draft-generation.ts
@@ -58,7 +58,7 @@ export interface PersistedDraftGeneration {
 const ROUTE_TIMEOUT_MS = 90_000;
 
 export function normalizeGeneratedTweet(content: string): string {
-  const trimmed = content.trim();
+  const trimmed = content.trim().replace(/—/g, " - ");
   if (trimmed.length <= 280) return trimmed;
   return `${trimmed.slice(0, 277).trimEnd()}...`;
 }

--- a/services/api/src/lib/oracle-prompt.ts
+++ b/services/api/src/lib/oracle-prompt.ts
@@ -47,7 +47,8 @@ Examples of good Oracle messages:
 - "Interesting combo — Cobie's brevity + Hasu's depth. Here's what a tweet might sound like in this blend..."
 - "Most people start at 50/50. But based on your tweets, you've got a strong enough voice to go 70/30."
 
-Never use bullet points or numbered lists. Speak in natural sentences. Keep it under 50 words.`;
+Never use bullet points or numbered lists. Speak in natural sentences. Keep it under 50 words.
+Never use em dashes (—). Use a regular hyphen (-) instead.`;
 }
 
 // ── Calibration Commentary ───────────────────────────────────────

--- a/services/api/src/lib/prompt.ts
+++ b/services/api/src/lib/prompt.ts
@@ -199,6 +199,7 @@ ${voiceDescription}
 - Stay within 280 characters. This is a hard limit.
 - No hashtags unless the voice style explicitly demands them (very casual + high humor).
 - Sound like a real person, not a bot. No corporate speak.
+- Never use em dashes (—). Use a short hyphen (-) or restructure the sentence instead.
 - ${getSourceTypeInstruction(sourceType)}`;
 
   // Add blend instructions if applicable


### PR DESCRIPTION
## Summary
- Add em dash rule to tweet generation system prompt (prompt.ts)
- Strip em dashes in normalizeGeneratedTweet post-processing (draft-generation.ts)
- Add em dash rule to Oracle system prompt (oracle-prompt.ts)

Em dashes are a common AI writing artifact that makes content look bot-generated. Belt-and-suspenders: instruct the model AND strip in post-processing.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>