### PR TITLE
feat: avoid repeating tweet angles using recent draft history

### DIFF
--- a/services/api/src/lib/generate.ts
+++ b/services/api/src/lib/generate.ts
@@ -31,6 +31,7 @@ interface GenerateParams {
   researchContext?: string;
   replyAngle?: string;
   angleInstruction?: string;
+  recentDrafts?: string[];
 }
 
 interface GenerateResult {

--- a/services/api/src/lib/pipeline/index.ts
+++ b/services/api/src/lib/pipeline/index.ts
@@ -18,6 +18,7 @@
 import { runPipeline } from "./runner";
 import { fetchVoiceStep } from "./steps/fetchVoice";
 import { fetchBlendStep } from "./steps/fetchBlend";
+import { fetchRecentDraftsStep } from "./steps/fetchRecentDrafts";
 import { fetchArticleStep } from "./steps/fetchArticle";
 import { summarizeContentStep } from "./steps/summarizeContent";
 import { researchStep } from "./steps/research";
@@ -43,7 +44,7 @@ export async function runGenerationPipeline(input: GenerationInput): Promise<Pip
   };
 
   return runPipeline(
-    [fetchVoiceStep, fetchBlendStep, fetchArticleStep, summarizeContentStep, researchStep, generateStep],
+    [fetchVoiceStep, fetchBlendStep, fetchRecentDraftsStep, fetchArticleStep, summarizeContentStep, researchStep, generateStep],
     ctx,
   );
 }

--- a/services/api/src/lib/pipeline/steps/fetchRecentDrafts.ts
+++ b/services/api/src/lib/pipeline/steps/fetchRecentDrafts.ts
@@ -1,0 +1,21 @@
+import { prisma } from "../../prisma";
+import type { PipelineStep } from "../types";
+
+export const fetchRecentDraftsStep: PipelineStep = {
+  name: "fetchRecentDrafts",
+  group: "prepare",   // runs in parallel with fetchVoice and fetchBlend
+  optional: true,     // never block generation if this fails
+
+  async execute(ctx) {
+    const recent = await prisma.tweetDraft.findMany({
+      where: { userId: ctx.userId },
+      orderBy: { createdAt: "desc" },
+      take: 3,
+      select: { content: true },
+    });
+
+    if (recent.length > 0) {
+      ctx.recentDraftTexts = recent.map((d) => d.content);
+    }
+  },
+};

--- a/services/api/src/lib/pipeline/steps/generate.ts
+++ b/services/api/src/lib/pipeline/steps/generate.ts
@@ -27,6 +27,7 @@ export const generateStep: PipelineStep = {
       researchContext: ctx.researchContext,
       replyAngle: ctx.replyAngle,
       angleInstruction: ctx.angleInstruction,
+      recentDrafts: ctx.recentDraftTexts,
     });
 
     ctx.generatedContent = result.content;

--- a/services/api/src/lib/pipeline/types.ts
+++ b/services/api/src/lib/pipeline/types.ts
@@ -45,6 +45,8 @@ export interface PipelineContext {
   articleUrl?: string;
   /** Set by fetchArticleStep when URL fetch fails */
   fetchArticleError?: string;
+  /** Last 3 generated drafts for this user — used to avoid repeating angles */
+  recentDraftTexts?: string[];
 
   // --- Observability ---
   stepResults: StepResult[];

--- a/services/api/src/lib/prompt.ts
+++ b/services/api/src/lib/prompt.ts
@@ -32,6 +32,7 @@ interface PromptParams {
   researchContext?: string;
   replyAngle?: string;
   angleInstruction?: string;
+  recentDrafts?: string[];
 }
 
 /** Prefix extreme dimension values with IMPORTANT for LLM emphasis */
@@ -232,6 +233,14 @@ ${voiceDescription}
   // Add feedback if this is a refinement
   if (feedback) {
     system += `\n\n## Refinement Request\nThe user gave this feedback on a previous version: "${feedback}"\nAdjust your output based on this feedback while maintaining the voice profile.`;
+  }
+
+  // Inject recent drafts to prevent angle repetition
+  if (params.recentDrafts && params.recentDrafts.length > 0) {
+    const draftList = params.recentDrafts
+      .map((d, i) => `${i + 1}. "${d.slice(0, 120)}${d.length > 120 ? "..." : ""}"`)
+      .join("\n");
+    system += `\n\n## Avoid These Angles\nThe user's recent drafts (do NOT repeat the same framing, hook, or angle):\n${draftList}\n\nWrite something fresh — different opening, different perspective, different structural approach.`;
   }
 
   const sourceLabel = sourceType.replace("_", " ").toLowerCase();


### PR DESCRIPTION
## Summary
- New pipeline step fetchRecentDrafts (prepare group, optional, parallel) fetches the user's last 3 drafts
- Injects them into the generation system prompt as "Avoid These Angles"
- Model is instructed to write a fresh framing, hook, and perspective
- Step is optional so it never blocks generation if DB query fails

## Why
Atlas was generating content that felt stale — same angles, same hooks. The model had no memory of what it already wrote. Now it does.

Generated with [Claude Code](https://claude.com/claude-code)