### PR TITLE
fix(arena): accurate UTC daily streak calculation

### DIFF
--- a/services/api/src/__tests__/lib/arena.test.ts
+++ b/services/api/src/__tests__/lib/arena.test.ts
@@ -7,7 +7,14 @@ import {
 } from "../../lib/arena";
 
 describe("arena helpers", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("computes a day-based consistency streak from unique posting days", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-04-10T12:00:00Z"));
+
     const streak = calculateConsistencyStreak([
       new Date("2026-04-09T10:00:00Z"),
       new Date("2026-04-09T18:30:00Z"),
@@ -17,6 +24,31 @@ describe("arena helpers", () => {
     ]);
 
     expect(streak).toBe(3);
+  });
+
+  it("starts from today when present and treats UTC midnight boundaries as separate days", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-04-10T12:00:00Z"));
+
+    const streak = calculateConsistencyStreak([
+      new Date("2026-04-10T00:01:00Z"),
+      new Date("2026-04-09T23:59:00Z"),
+      new Date("2026-04-08T13:00:00Z"),
+    ]);
+
+    expect(streak).toBe(3);
+  });
+
+  it("returns 0 when there is no post today or yesterday", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-04-10T12:00:00Z"));
+
+    const streak = calculateConsistencyStreak([
+      new Date("2026-04-08T12:00:00Z"),
+      new Date("2026-04-07T12:00:00Z"),
+    ]);
+
+    expect(streak).toBe(0);
   });
 
   it("prefers stored engagement metrics and falls back to predicted engagement when missing", () => {
@@ -36,6 +68,9 @@ describe("arena helpers", () => {
   });
 
   it("builds ranked leaderboard entries and keeps the requesting user in view", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-04-10T12:00:00Z"));
+
     const users: ArenaUser[] = [
       { id: "user-1", handle: "alice", displayName: "Alice", avatarUrl: null },
       { id: "user-2", handle: "bruno", displayName: "Bruno", avatarUrl: null },

--- a/services/api/src/lib/arena.ts
+++ b/services/api/src/lib/arena.ts
@@ -67,24 +67,32 @@ function normalize(value: number, maxValue: number): number {
 }
 
 export function calculateConsistencyStreak(postDates: Date[]): number {
-  const uniqueDays = [...new Set(postDates.map(toUtcDayStart))].sort((a, b) => b - a);
+  const dayMs = 86400000;
+  const uniqueDays = new Set(
+    postDates
+      .map(toUtcDayStart)
+      .filter((value) => Number.isFinite(value)),
+  );
 
-  if (uniqueDays.length === 0) {
+  if (uniqueDays.size === 0) {
     return 0;
   }
 
-  let streak = 1;
+  const todayUtc = toUtcDayStart(new Date());
+  const startDay = uniqueDays.has(todayUtc)
+    ? todayUtc
+    : uniqueDays.has(todayUtc - dayMs)
+      ? todayUtc - dayMs
+      : null;
 
-  for (let index = 1; index < uniqueDays.length; index += 1) {
-    const previousDay = uniqueDays[index - 1];
-    const currentDay = uniqueDays[index];
+  if (startDay === null) {
+    return 0;
+  }
 
-    if (previousDay - currentDay === 86400000) {
-      streak += 1;
-      continue;
-    }
+  let streak = 0;
 
-    break;
+  for (let day = startDay; uniqueDays.has(day); day -= dayMs) {
+    streak += 1;
   }
 
   return streak;


### PR DESCRIPTION
## What changed
- updated `calculateConsistencyStreak` to count consecutive UTC calendar days with at least one post
- anchored streaks to UTC today, or UTC yesterday when there is no post today
- return `0` when there is no post on either UTC today or UTC yesterday
- added tests for today/yesterday anchoring, UTC midnight boundaries, and deterministic system time handling

## Why
The previous streak logic started from the newest historical posting day, so an old run of consecutive posts could still report a non-zero streak even when the user had not posted recently.

## Impact
Arena leaderboard streaks now reflect current daily activity instead of historical sequences, and posts around midnight UTC are bucketed into the correct day.

## Validation
- `npx jest services/api/src/__tests__/lib/arena.test.ts`
- `npx tsc --noEmit`