### PR TITLE
feat(users): persist X profile fields from OAuth callback

### DIFF
--- a/services/api/src/__tests__/auth.test.ts
+++ b/services/api/src/__tests__/auth.test.ts
@@ -57,6 +57,9 @@ const mockUser = {
   handle: "testuser",
   email: "test@example.com",
   role: "ANALYST",
+  xBio: "Crypto analyst",
+  xAvatarUrl: "https://example.com/avatar.jpg",
+  xFollowerCount: 12345,
   voiceProfile: null,
 };
 
@@ -145,5 +148,20 @@ describe("GET /api/auth/me", () => {
     const data = expectSuccessResponse<any>(res.body);
     expect(data.user.id).toBe("user-123");
     expect(data.user.voiceProfile).toBeDefined();
+    expect(data.user.xBio).toBe("Crypto analyst");
+    expect(data.user.xAvatarUrl).toBe("https://example.com/avatar.jpg");
+    expect(data.user.xFollowerCount).toBe(12345);
+    expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: "user-123" },
+      select: {
+        id: true,
+        handle: true,
+        role: true,
+        xBio: true,
+        xAvatarUrl: true,
+        xFollowerCount: true,
+        voiceProfile: true,
+      },
+    });
   });
 });

--- a/services/api/src/__tests__/routes/x-auth.test.ts
+++ b/services/api/src/__tests__/routes/x-auth.test.ts
@@ -33,6 +33,7 @@ jest.mock("../../lib/prisma", () => ({
 jest.mock("../../lib/twitter", () => ({
   generateOAuthUrl: jest.fn(),
   exchangeCodeForTokens: jest.fn(),
+  fetchTwitterUserProfile: jest.fn(),
   lookupUser: jest.fn(),
 }));
 
@@ -42,13 +43,13 @@ const setIntervalSpy = jest.spyOn(global, "setInterval").mockImplementation(
 );
 
 import { prisma } from "../../lib/prisma";
-import { generateOAuthUrl, exchangeCodeForTokens } from "../../lib/twitter";
+import { generateOAuthUrl, exchangeCodeForTokens, fetchTwitterUserProfile } from "../../lib/twitter";
 import { xAuthRouter } from "../../routes/x-auth";
 
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockGenerateOAuthUrl = generateOAuthUrl as jest.MockedFunction<typeof generateOAuthUrl>;
 const mockExchangeCodeForTokens = exchangeCodeForTokens as jest.MockedFunction<typeof exchangeCodeForTokens>;
-const mockFetch = jest.fn();
+const mockFetchTwitterUserProfile = fetchTwitterUserProfile as jest.MockedFunction<typeof fetchTwitterUserProfile>;
 
 const app = express();
 app.use(express.json());
@@ -56,27 +57,18 @@ app.use(requestIdMiddleware);
 app.use("/api/auth/x", xAuthRouter);
 
 const AUTH = { Authorization: "Bearer mock_token" };
-const originalFetch = global.fetch;
 
 beforeAll(() => {
   process.env.JWT_SECRET = "test-secret";
-  global.fetch = mockFetch as typeof fetch;
 });
 
 afterAll(() => {
   delete process.env.JWT_SECRET;
   setIntervalSpy.mockRestore();
-
-  if (originalFetch) {
-    global.fetch = originalFetch;
-  } else {
-    (global as any).fetch = undefined;
-  }
 });
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockFetch.mockReset();
 
   mockGenerateOAuthUrl.mockImplementation((state: string) => ({
     url: `https://twitter.example.com/i/oauth2/authorize?state=${state}`,
@@ -87,6 +79,18 @@ beforeEach(() => {
     accessToken: "access-token",
     refreshToken: "refresh-token",
     expiresIn: 3600,
+  });
+  mockFetchTwitterUserProfile.mockResolvedValue({
+    id: "x-user-1",
+    username: "atlas_handle",
+    name: "Atlas Handle",
+    description: "Crypto analyst",
+    profile_image_url: "https://example.com/avatar_400x400.jpg",
+    public_metrics: {
+      followers_count: 12345,
+      following_count: 50,
+      tweet_count: 100,
+    },
   });
 
   (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(null);
@@ -165,25 +169,18 @@ describe("POST /api/auth/x/callback", () => {
     expect(callbackRes.body.error).toBe("OAuth session expired. Please try again.");
     expect(callbackRes.body.message).toBe("OAuth session expired. Please try again.");
     expect(mockExchangeCodeForTokens).not.toHaveBeenCalled();
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockFetchTwitterUserProfile).not.toHaveBeenCalled();
 
     nowSpy.mockRestore();
   });
 
-  it("exchanges code for tokens and stores them", async () => {
+  it("exchanges code for tokens and stores the X profile", async () => {
     const authorizeRes = await request(app)
       .post("/api/auth/x/authorize")
       .set(AUTH);
 
     expect(authorizeRes.status).toBe(200);
     const { state } = expectSuccessResponse<{ url: string; state: string }>(authorizeRes.body);
-
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: jest.fn().mockResolvedValue({
-        data: { username: "atlas_handle" },
-      }),
-    });
 
     const callbackRes = await request(app)
       .post("/api/auth/x/callback")
@@ -196,9 +193,7 @@ describe("POST /api/auth/x/callback", () => {
     expect(data.linked).toBe(true);
     expect(data.xHandle).toBe("atlas_handle");
     expect(mockExchangeCodeForTokens).toHaveBeenCalledWith("oauth-code", "verifier-123");
-    expect(mockFetch).toHaveBeenCalledWith("https://api.twitter.com/2/users/me", {
-      headers: { Authorization: "Bearer access-token" },
-    });
+    expect(mockFetchTwitterUserProfile).toHaveBeenCalledWith("access-token");
     expect(mockPrisma.user.update).toHaveBeenCalledWith({
       where: { id: "user-123" },
       data: {
@@ -206,6 +201,9 @@ describe("POST /api/auth/x/callback", () => {
         xRefreshToken: "refresh-token",
         xTokenExpiresAt: expect.any(Date),
         xHandle: "atlas_handle",
+        xBio: "Crypto analyst",
+        xAvatarUrl: "https://example.com/avatar_400x400.jpg",
+        xFollowerCount: 12345,
       },
     });
   });

--- a/services/api/src/routes/auth.ts
+++ b/services/api/src/routes/auth.ts
@@ -313,13 +313,19 @@ authRouter.get("/me", authenticate, async (req: AuthRequest, res) => {
   try {
     const user = await prisma.user.findUnique({
       where: { id: req.userId },
-      include: { voiceProfile: true },
+      select: {
+        id: true,
+        handle: true,
+        role: true,
+        xBio: true,
+        xAvatarUrl: true,
+        xFollowerCount: true,
+        voiceProfile: true,
+      },
     });
     if (!user) return res.status(404).json(error("User not found"));
 
-    res.json(success({
-      user: { id: user.id, handle: user.handle, role: user.role, voiceProfile: user.voiceProfile },
-    }));
+    res.json(success({ user }));
   } catch (err: any) {
     logger.error({ err: err.message }, "Me error:", err.message);
     res.status(500).json(error("Failed to get user"));

--- a/services/api/src/routes/x-auth.ts
+++ b/services/api/src/routes/x-auth.ts
@@ -191,19 +191,11 @@ xAuthRouter.post("/callback", authenticate, async (req: AuthRequest, res) => {
     // Exchange code for tokens
     const { accessToken, refreshToken, expiresIn } = await exchangeCodeForTokens(code, pending.codeVerifier);
 
-    // Look up the user's X handle
-    let xHandle: string | undefined;
-    try {
-      const meRes = await fetch("https://api.twitter.com/2/users/me", {
-        headers: { Authorization: `Bearer ${accessToken}` },
-      });
-      if (meRes.ok) {
-        const meData = await meRes.json() as { data: { username: string } };
-        xHandle = meData.data.username;
-      }
-    } catch {
-      // Non-critical — we can proceed without the handle
-    }
+    const profile = await fetchTwitterUserProfile(accessToken);
+    const xHandle = profile.username;
+    const xBio = profile.description ?? null;
+    const xAvatarUrl = profile.profile_image_url ?? null;
+    const xFollowerCount = profile.public_metrics?.followers_count ?? null;
 
     // Store tokens on the user
     await prisma.user.update({
@@ -212,7 +204,10 @@ xAuthRouter.post("/callback", authenticate, async (req: AuthRequest, res) => {
         xAccessToken: accessToken,
         xRefreshToken: refreshToken,
         xTokenExpiresAt: new Date(Date.now() + expiresIn * 1000),
-        ...(xHandle && { xHandle }),
+        xHandle,
+        xBio,
+        xAvatarUrl,
+        xFollowerCount,
       },
     });
 


### PR DESCRIPTION
## What changed
- updated the X account link callback to persist `xBio`, `xAvatarUrl`, and `xFollowerCount` from the authenticated Twitter/X profile response
- updated `GET /api/auth/me` to return `xBio`, `xAvatarUrl`, and `xFollowerCount` alongside the existing profile payload
- extended the auth and X auth route tests to cover the new persisted fields and `/me` response shape

## Validation
- `npx tsc --noEmit`
- `npx jest services/api/src/__tests__/auth.test.ts services/api/src/__tests__/routes/x-auth.test.ts --runInBand`
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/postgres' npx prisma validate`

## Notes
- `npx prisma validate` and `npx prisma db push` were blocked in the original checkout because `DATABASE_URL` was not set
- no Notion task ID was provided