### PR TITLE
feat: real streak tracking, Gemini images, Oracle improvements, arena periods, auth hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,8 @@ ANTHROPIC_API_KEY=your-anthropic-key-here
 GOOGLE_AI_API_KEY=your-google-ai-api-key-here
 # Gemini model override used by the Google AI client (default: gemini-2.5-flash)
 GEMINI_MODEL=gemini-2.5-flash
+# Optional dedicated Gemini image model override for /api/images (default fallback: gemini-2.5-flash-image)
+GEMINI_IMAGE_MODEL=gemini-2.5-flash-image
 # xAI / Grok API key for trending and research features
 XAI_API_KEY=your-xai-api-key-here
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
   analyticsEvents   AnalyticsEvent[]
   alertSubscriptions AlertSubscription[]
   sessions          Session[]
+  oracleSessions    OracleSession[]
   researchResults   ResearchResult[]
   generatedImages   GeneratedImage[]
   alerts            Alert[]
@@ -71,6 +72,18 @@ model Session {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("sessions")
+}
+
+model OracleSession {
+  id        String   @id @default(cuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  messages  Json     @default("[]")
+  context   Json?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("oracle_sessions")
 }
 
 model VoiceProfile {

--- a/services/api/src/__tests__/lib/gemini.test.ts
+++ b/services/api/src/__tests__/lib/gemini.test.ts
@@ -1,0 +1,155 @@
+const mockConfig: {
+  GOOGLE_AI_API_KEY?: string;
+  GEMINI_MODEL: string;
+  GEMINI_IMAGE_MODEL?: string;
+} = {
+  GOOGLE_AI_API_KEY: "test-key",
+  GEMINI_MODEL: "gemini-2.5-flash",
+  GEMINI_IMAGE_MODEL: undefined,
+};
+
+const mockGenerateContent = jest.fn();
+const mockGetGenerativeModel = jest.fn(() => ({
+  generateContent: mockGenerateContent,
+}));
+const mockGoogleGenerativeAI = jest.fn(() => ({
+  getGenerativeModel: mockGetGenerativeModel,
+}));
+
+jest.mock("../../lib/config", () => ({
+  get config() {
+    return mockConfig;
+  },
+}));
+
+jest.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: mockGoogleGenerativeAI,
+}));
+
+import { generateImage, generateVisualConcept } from "../../lib/gemini";
+
+describe("gemini image helpers", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfig.GOOGLE_AI_API_KEY = "test-key";
+    mockConfig.GEMINI_MODEL = "gemini-2.5-flash";
+    mockConfig.GEMINI_IMAGE_MODEL = undefined;
+    global.fetch = jest.fn() as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("parses inline image data from Gemini responses", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [{
+          content: {
+            parts: [{ inlineData: { data: "ZmFrZS1pbWFnZQ==", mimeType: "image/png" } }],
+          },
+        }],
+      }),
+    });
+
+    const result = await generateImage({
+      content: "BTC is mooning",
+      style: "quote_card",
+      aspectRatio: "4:5",
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      imageData: "ZmFrZS1pbWFnZQ==",
+      mimeType: "image/png",
+    }));
+
+    const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toContain("/models/gemini-2.5-flash-image:generateContent");
+
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body.generationConfig.responseModalities).toEqual(["Image"]);
+    expect(body.generationConfig.imageConfig.aspectRatio).toBe("4:5");
+  });
+
+  it("falls back to the current image model when GEMINI_MODEL points at a deprecated 2.0 image model", async () => {
+    mockConfig.GEMINI_MODEL = "gemini-2.0-flash-exp-image-generation";
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [{
+          content: {
+            parts: [{ inlineData: { data: "ZmFrZS1pbWFnZQ==", mimeType: "image/png" } }],
+          },
+        }],
+      }),
+    });
+
+    await generateImage({
+      content: "BTC is mooning",
+      style: "thumbnail",
+    });
+
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain("/models/gemini-2.5-flash-image:generateContent");
+  });
+
+  it("uses GEMINI_IMAGE_MODEL when explicitly configured", async () => {
+    mockConfig.GEMINI_IMAGE_MODEL = "gemini-3.1-flash-image-preview";
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [{
+          content: {
+            parts: [{ inlineData: { data: "ZmFrZS1pbWFnZQ==", mimeType: "image/png" } }],
+          },
+        }],
+      }),
+    });
+
+    await generateImage({
+      content: "BTC is mooning",
+      style: "thumbnail",
+    });
+
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain("/models/gemini-3.1-flash-image-preview:generateContent");
+  });
+
+  it("throws a useful error when Gemini returns text instead of an image", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [{
+          content: {
+            parts: [{ text: "I can only describe the image." }],
+          },
+        }],
+      }),
+    });
+
+    await expect(generateImage({
+      content: "BTC is mooning",
+      style: "quote_card",
+    })).rejects.toThrow("Gemini image model returned text instead of an image");
+  });
+
+  it("uses a text model fallback for structured concept generation", async () => {
+    mockConfig.GEMINI_MODEL = "gemini-2.0-flash-exp-image-generation";
+    mockGenerateContent.mockResolvedValueOnce({
+      response: {
+        text: () => JSON.stringify({
+          concept: "A bold crypto visual",
+          colorScheme: ["#4ecdc4", "#1a1a2e", "#2d3748"],
+          layout: "centered-quote",
+          elements: ["headline frame"],
+        }),
+      },
+    });
+
+    const result = await generateVisualConcept("BTC is mooning", "quote_card");
+
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith({ model: "gemini-2.5-flash" });
+    expect(result.concept).toBe("A bold crypto visual");
+  });
+});

--- a/services/api/src/__tests__/lib/streak.test.ts
+++ b/services/api/src/__tests__/lib/streak.test.ts
@@ -1,0 +1,107 @@
+import { calculateStreakFromDates, toUtcDayStart } from "../../lib/streak";
+
+describe("calculateStreakFromDates", () => {
+  const NOW = new Date("2026-04-10T15:30:00Z"); // Friday, April 10, 2026
+
+  it("returns zeroed broken state when there are no activity dates", () => {
+    const result = calculateStreakFromDates([], NOW);
+    expect(result).toEqual({
+      currentStreak: 0,
+      longestStreak: 0,
+      status: "broken",
+      lastActivityAt: null,
+    });
+  });
+
+  it("reports an active streak when the user has activity today", () => {
+    const result = calculateStreakFromDates(
+      [
+        new Date("2026-04-10T09:15:00Z"),
+        new Date("2026-04-10T22:00:00Z"), // multiple events same day still = 1 day
+        new Date("2026-04-09T18:00:00Z"),
+        new Date("2026-04-08T07:00:00Z"),
+        new Date("2026-04-05T12:00:00Z"), // older activity — doesn't extend the current run
+      ],
+      NOW,
+    );
+
+    expect(result.currentStreak).toBe(3);
+    expect(result.longestStreak).toBe(3);
+    expect(result.status).toBe("active");
+    expect(result.lastActivityAt?.toISOString()).toBe("2026-04-10T22:00:00.000Z");
+  });
+
+  it("reports at_risk when the last activity was yesterday but not today", () => {
+    const result = calculateStreakFromDates(
+      [
+        new Date("2026-04-09T21:45:00Z"),
+        new Date("2026-04-08T08:00:00Z"),
+        new Date("2026-04-07T10:00:00Z"),
+      ],
+      NOW,
+    );
+
+    expect(result.currentStreak).toBe(3);
+    expect(result.status).toBe("at_risk");
+  });
+
+  it("reports broken when the last activity was more than one day ago", () => {
+    const result = calculateStreakFromDates(
+      [
+        new Date("2026-04-07T10:00:00Z"),
+        new Date("2026-04-06T10:00:00Z"),
+        new Date("2026-04-05T10:00:00Z"),
+      ],
+      NOW,
+    );
+
+    expect(result.currentStreak).toBe(0);
+    expect(result.longestStreak).toBe(3);
+    expect(result.status).toBe("broken");
+  });
+
+  it("tracks the longest historical streak even when the current streak is shorter", () => {
+    const result = calculateStreakFromDates(
+      [
+        // Longest historical run: 5 consecutive days (Mar 20-24)
+        new Date("2026-03-20T10:00:00Z"),
+        new Date("2026-03-21T10:00:00Z"),
+        new Date("2026-03-22T10:00:00Z"),
+        new Date("2026-03-23T10:00:00Z"),
+        new Date("2026-03-24T10:00:00Z"),
+        // Current run ending today: 2 days
+        new Date("2026-04-09T10:00:00Z"),
+        new Date("2026-04-10T10:00:00Z"),
+      ],
+      NOW,
+    );
+
+    expect(result.currentStreak).toBe(2);
+    expect(result.longestStreak).toBe(5);
+    expect(result.status).toBe("active");
+  });
+
+  it("handles duplicate-day events without double counting", () => {
+    const result = calculateStreakFromDates(
+      [
+        new Date("2026-04-10T00:05:00Z"),
+        new Date("2026-04-10T09:00:00Z"),
+        new Date("2026-04-10T23:55:00Z"),
+      ],
+      NOW,
+    );
+
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(1);
+    expect(result.status).toBe("active");
+  });
+
+  it("treats days in UTC regardless of local event time-of-day", () => {
+    const day1 = new Date("2026-04-09T23:59:59Z");
+    const day2 = new Date("2026-04-10T00:00:01Z");
+    expect(toUtcDayStart(day1)).not.toBe(toUtcDayStart(day2));
+
+    const result = calculateStreakFromDates([day1, day2], NOW);
+    expect(result.currentStreak).toBe(2);
+  });
+});

--- a/services/api/src/__tests__/routes/images.test.ts
+++ b/services/api/src/__tests__/routes/images.test.ts
@@ -38,6 +38,7 @@ jest.mock("../../lib/prisma", () => ({
 }));
 
 jest.mock("../../lib/gemini", () => ({
+  generateImage: jest.fn(),
   generateVisualConcept: jest.fn(),
 }));
 
@@ -50,8 +51,9 @@ jest.mock("../../lib/config", () => ({
 }));
 
 import { prisma } from "../../lib/prisma";
-import { generateVisualConcept } from "../../lib/gemini";
+import { generateImage, generateVisualConcept } from "../../lib/gemini";
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockGenerateImage = generateImage as jest.Mock;
 const mockGenerateVisualConcept = generateVisualConcept as jest.Mock;
 
 const app = express();
@@ -62,9 +64,10 @@ app.use("/api/images", imagesRouter);
 const AUTH = { Authorization: "Bearer mock_token" };
 
 const mockConcept = {
-  description: "A bold crypto-themed graphic",
+  concept: "A bold crypto-themed graphic",
   colorScheme: ["#F7931A", "#FFFFFF"],
-  layout: "centered",
+  layout: "centered-quote",
+  elements: ["candlestick chart", "headline frame"],
 };
 
 const mockImage = {
@@ -72,8 +75,14 @@ const mockImage = {
   userId: "user-123",
   prompt: "BTC is mooning",
   style: "quote_card",
-  imageUrl: JSON.stringify(mockConcept),
-  mimeType: "application/json",
+  imageUrl: "data:image/png;base64,ZmFrZS1pbWFnZQ==",
+  mimeType: "image/png",
+};
+
+const mockGeneratedAsset = {
+  imageData: "ZmFrZS1pbWFnZQ==",
+  mimeType: "image/png",
+  promptUsed: "prompt used",
 };
 
 beforeAll(() => {
@@ -82,6 +91,11 @@ beforeAll(() => {
 
 afterAll(() => {
   delete process.env.JWT_SECRET;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConfig.GOOGLE_AI_API_KEY = "test-key";
 });
 
 describe("POST /api/images/generate", () => {
@@ -97,6 +111,7 @@ describe("POST /api/images/generate", () => {
   });
 
   it("generates image concept and returns it", async () => {
+    mockGenerateImage.mockResolvedValueOnce(mockGeneratedAsset);
     mockGenerateVisualConcept.mockResolvedValueOnce(mockConcept);
     (mockPrisma.generatedImage.create as jest.Mock).mockResolvedValueOnce(mockImage);
     (mockPrisma.analyticsEvent.create as jest.Mock).mockResolvedValueOnce({});
@@ -110,10 +125,16 @@ describe("POST /api/images/generate", () => {
     const data = expectSuccessResponse<any>(res.body);
     expect(data.image.id).toBe("img-1");
     expect(data.image.concept).toEqual(mockConcept);
+    expect(mockPrisma.generatedImage.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        imageUrl: "data:image/png;base64,ZmFrZS1pbWFnZQ==",
+        mimeType: "image/png",
+      }),
+    });
   });
 
   it("returns 502 when AI generation fails", async () => {
-    mockGenerateVisualConcept.mockRejectedValueOnce(new Error("Gemini error"));
+    mockGenerateImage.mockRejectedValueOnce(new Error("Gemini error"));
 
     const res = await request(app)
       .post("/api/images/generate")
@@ -135,6 +156,23 @@ describe("POST /api/images/generate", () => {
 
     expect(res.status).toBe(503);
     mockConfig.GOOGLE_AI_API_KEY = original;
+  });
+
+  it("falls back to a deterministic concept when concept generation fails", async () => {
+    mockGenerateImage.mockResolvedValueOnce(mockGeneratedAsset);
+    mockGenerateVisualConcept.mockRejectedValueOnce(new Error("structured output failed"));
+    (mockPrisma.generatedImage.create as jest.Mock).mockResolvedValueOnce(mockImage);
+    (mockPrisma.analyticsEvent.create as jest.Mock).mockResolvedValueOnce({});
+
+    const res = await request(app)
+      .post("/api/images/generate")
+      .set(AUTH)
+      .send({ prompt: "BTC is mooning", style: "quote_card" });
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.image.concept.colorScheme).toEqual(["#4ecdc4", "#1a1a2e", "#2d3748"]);
+    expect(data.image.concept.layout).toBe("centered-quote");
   });
 });
 
@@ -162,6 +200,7 @@ describe("POST /api/images/generate-for-draft", () => {
   it("generates image for a draft", async () => {
     const draft = { id: "draft-1", content: "BTC is mooning", userId: "user-123" };
     (mockPrisma.tweetDraft.findFirst as jest.Mock).mockResolvedValueOnce(draft);
+    mockGenerateImage.mockResolvedValueOnce(mockGeneratedAsset);
     mockGenerateVisualConcept.mockResolvedValueOnce(mockConcept);
     const img = { ...mockImage, draftId: "draft-1" };
     (mockPrisma.generatedImage.create as jest.Mock).mockResolvedValueOnce(img);
@@ -189,6 +228,20 @@ describe("GET /api/images/for-draft/:draftId", () => {
     const res = await request(app).get("/api/images/for-draft/draft-1").set(AUTH);
     expect(res.status).toBe(200);
     expect(expectSuccessResponse<any>(res.body).images).toHaveLength(1);
+  });
+
+  it("hydrates concept payloads from legacy JSON image records", async () => {
+    const legacyImage = {
+      ...mockImage,
+      imageUrl: JSON.stringify(mockConcept),
+      mimeType: "application/json",
+    };
+    (mockPrisma.generatedImage.findMany as jest.Mock).mockResolvedValueOnce([legacyImage]);
+
+    const res = await request(app).get("/api/images/for-draft/draft-1").set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(expectSuccessResponse<any>(res.body).images[0].concept).toEqual(mockConcept);
   });
 
   it("returns 500 when loading images fails", async () => {

--- a/services/api/src/__tests__/routes/oracle.test.ts
+++ b/services/api/src/__tests__/routes/oracle.test.ts
@@ -23,6 +23,12 @@ jest.mock("../../lib/prisma", () => ({
       create: jest.fn(),
       update: jest.fn(),
     },
+    voiceProfile: {
+      findUnique: jest.fn().mockResolvedValue(null),
+    },
+    tweetDraft: {
+      count: jest.fn().mockResolvedValue(0),
+    },
   },
 }));
 
@@ -32,6 +38,17 @@ jest.mock("../../lib/anthropic", () => ({
 
 jest.mock("../../lib/providers/router", () => ({
   routeCompletion: jest.fn(),
+}));
+
+jest.mock("../../lib/openclaw-router", () => ({
+  runOracleCompletion: jest.fn(),
+  resolveProfileForPhase: jest.fn((phase?: string) => {
+    if (!phase) return "fast";
+    const p = phase.toLowerCase();
+    return p.includes("calibrat") || p.includes("analy") || p.includes("smart")
+      ? "smart"
+      : "fast";
+  }),
 }));
 
 jest.mock("../../lib/oracle-prompt", () => ({
@@ -62,11 +79,15 @@ jest.mock("../../lib/logger", () => ({
 
 import { prisma } from "../../lib/prisma";
 import { getAnthropicClient } from "../../lib/anthropic";
+import { runOracleCompletion } from "../../lib/openclaw-router";
 import { oracleRouter } from "../../routes/oracle";
 
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockGetAnthropicClient = getAnthropicClient as jest.Mock;
 const mockAnthropicCreate = jest.fn();
+const mockRunOracleCompletion = runOracleCompletion as jest.MockedFunction<
+  typeof runOracleCompletion
+>;
 
 const app = express();
 app.use(express.json());
@@ -244,6 +265,91 @@ describe("POST /api/oracle/message", () => {
         where: { id: "oracle-session-1" },
       }),
     );
+  });
+});
+
+describe("POST /api/oracle/chat (OpenClaw shape)", () => {
+  it("returns 401 without auth", async () => {
+    const res = await request(app)
+      .post("/api/oracle/chat")
+      .send({ message: "Hey Oracle" });
+    expect(res.status).toBe(401);
+  });
+
+  it("routes `message` payloads through the OpenClaw router", async () => {
+    mockRunOracleCompletion.mockResolvedValueOnce({
+      reply: "Your voice leans contrarian — lean in.",
+      model: "claude-haiku-4-5-20251001",
+      provider: "anthropic",
+      tokens: 248,
+      latencyMs: 512,
+    });
+
+    const res = await request(app)
+      .post("/api/oracle/chat")
+      .set(AUTH)
+      .send({
+        message: "Help me calibrate my voice",
+        phase: "calibration",
+        context: { track: "a" },
+      });
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.reply).toContain("contrarian");
+    expect(data.model).toBe("claude-haiku-4-5-20251001");
+    expect(data.tokens).toBe(248);
+
+    expect(mockRunOracleCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: "smart",
+        userMessage: "Help me calibrate my voice",
+        systemPrompt: expect.stringContaining("Current phase: calibration"),
+      }),
+    );
+  });
+
+  it("defaults to the fast profile for quick chat", async () => {
+    mockRunOracleCompletion.mockResolvedValueOnce({
+      reply: "Try opening with a contrarian hook.",
+      model: "claude-haiku-4-5-20251001",
+      provider: "anthropic",
+      tokens: 90,
+      latencyMs: 320,
+    });
+
+    const res = await request(app)
+      .post("/api/oracle/chat")
+      .set(AUTH)
+      .send({ message: "What should I tweet about ETH?" });
+
+    expect(res.status).toBe(200);
+    expect(mockRunOracleCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ profile: "fast" }),
+    );
+  });
+
+  it("still supports the legacy { messages, page } shape", async () => {
+    const { routeCompletion } = jest.requireMock("../../lib/providers/router");
+    (routeCompletion as jest.Mock).mockResolvedValueOnce({
+      content: "Legacy reply",
+      provider: "anthropic",
+      model: "claude-haiku-4-5-20251001",
+      latencyMs: 100,
+    });
+
+    const res = await request(app)
+      .post("/api/oracle/chat")
+      .set(AUTH)
+      .send({
+        messages: [{ role: "user", content: "hi" }],
+        page: "dashboard",
+      });
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.text).toBe("Legacy reply");
+    expect(mockRunOracleCompletion).not.toHaveBeenCalled();
   });
 });
 

--- a/services/api/src/__tests__/routes/oracle.test.ts
+++ b/services/api/src/__tests__/routes/oracle.test.ts
@@ -1,0 +1,280 @@
+import express from "express";
+import request from "supertest";
+import { requestIdMiddleware } from "../../middleware/requestId";
+import { expectErrorResponse, expectSuccessResponse } from "../helpers/response";
+
+jest.mock("../../middleware/auth", () => ({
+  authenticate: jest.fn((req: any, res: any, next: any) => {
+    const header = req.headers.authorization;
+    if (!header?.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Missing authorization token" });
+    }
+
+    req.userId = "user-123";
+    next();
+  }),
+  AuthRequest: {},
+}));
+
+jest.mock("../../lib/prisma", () => ({
+  prisma: {
+    oracleSession: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../lib/anthropic", () => ({
+  getAnthropicClient: jest.fn(),
+}));
+
+jest.mock("../../lib/providers/router", () => ({
+  routeCompletion: jest.fn(),
+}));
+
+jest.mock("../../lib/oracle-prompt", () => ({
+  buildOracleSystemPrompt: jest.fn(() => "Oracle system prompt"),
+  buildCalibrationCommentary: jest.fn(),
+  buildBlendPreview: jest.fn(),
+  buildDimensionReaction: jest.fn(),
+  buildFreeTextResponse: jest.fn(),
+}));
+
+jest.mock("../../lib/oracle-tools", () => ({
+  ORACLE_TOOLS: [],
+  CONFIRMATION_REQUIRED: new Set(),
+  SERVER_EXECUTABLE: new Set(),
+}));
+
+jest.mock("../../lib/timeout", () => ({
+  withTimeout: jest.fn((promise: Promise<unknown>) => promise),
+}));
+
+jest.mock("../../lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import { prisma } from "../../lib/prisma";
+import { getAnthropicClient } from "../../lib/anthropic";
+import { oracleRouter } from "../../routes/oracle";
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockGetAnthropicClient = getAnthropicClient as jest.Mock;
+const mockAnthropicCreate = jest.fn();
+
+const app = express();
+app.use(express.json());
+app.use(requestIdMiddleware);
+app.use("/api/oracle", oracleRouter);
+
+const AUTH = { Authorization: "Bearer mock-token" };
+
+const baseSession = {
+  id: "oracle-session-1",
+  userId: "user-123",
+  messages: [],
+  context: null,
+  createdAt: new Date("2026-04-10T08:00:00.000Z"),
+  updatedAt: new Date("2026-04-10T08:00:00.000Z"),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetAnthropicClient.mockReturnValue({
+    messages: {
+      create: mockAnthropicCreate,
+    },
+  });
+});
+
+describe("GET /api/oracle/session", () => {
+  it("returns 401 without auth", async () => {
+    const res = await request(app).get("/api/oracle/session");
+    expect(res.status).toBe(401);
+  });
+
+  it("creates a session when one does not exist", async () => {
+    (mockPrisma.oracleSession.findFirst as jest.Mock).mockResolvedValueOnce(null);
+    (mockPrisma.oracleSession.create as jest.Mock).mockResolvedValueOnce(baseSession);
+
+    const res = await request(app).get("/api/oracle/session").set(AUTH);
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.sessionId).toBe("oracle-session-1");
+    expect(data.messages).toEqual([]);
+    expect(mockPrisma.oracleSession.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "user-123",
+        }),
+      }),
+    );
+  });
+
+  it("returns the existing session state", async () => {
+    const existingSession = {
+      ...baseSession,
+      messages: [
+        {
+          role: "user",
+          content: "What should I write about today?",
+          timestamp: "2026-04-10T08:01:00.000Z",
+        },
+      ],
+      context: {
+        page: "oracle",
+      },
+    };
+
+    (mockPrisma.oracleSession.findFirst as jest.Mock).mockResolvedValueOnce(existingSession);
+
+    const res = await request(app).get("/api/oracle/session").set(AUTH);
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.messages).toHaveLength(1);
+    expect(data.context.page).toBe("oracle");
+  });
+});
+
+describe("POST /api/oracle/message", () => {
+  it("returns 400 for empty content", async () => {
+    const res = await request(app)
+      .post("/api/oracle/message")
+      .set(AUTH)
+      .send({ content: "" });
+
+    expect(res.status).toBe(400);
+    expectErrorResponse(res.body, "Invalid request");
+  });
+
+  it("persists the user message and assistant reply", async () => {
+    (mockPrisma.oracleSession.findFirst as jest.Mock).mockResolvedValueOnce(baseSession);
+
+    const sessionAfterUserMessage = {
+      ...baseSession,
+      messages: [
+        {
+          role: "user",
+          content: "Give me a contrarian BTC take.",
+          timestamp: "2026-04-10T08:02:00.000Z",
+        },
+      ],
+      context: {
+        page: "oracle",
+      },
+    };
+
+    const sessionAfterAssistantReply = {
+      ...baseSession,
+      messages: [
+        ...sessionAfterUserMessage.messages,
+        {
+          role: "assistant",
+          content: "Everyone wants upside. The better trade is patience until conviction returns.",
+          timestamp: "2026-04-10T08:02:05.000Z",
+        },
+      ],
+      context: {
+        page: "oracle",
+      },
+    };
+
+    (mockPrisma.oracleSession.update as jest.Mock)
+      .mockResolvedValueOnce(sessionAfterUserMessage)
+      .mockResolvedValueOnce(sessionAfterAssistantReply);
+
+    mockAnthropicCreate.mockResolvedValueOnce({
+      content: [
+        {
+          type: "text",
+          text: "Everyone wants upside. The better trade is patience until conviction returns.",
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .post("/api/oracle/message")
+      .set(AUTH)
+      .send({
+        content: "Give me a contrarian BTC take.",
+        context: { page: "oracle" },
+      });
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.reply.role).toBe("assistant");
+    expect(data.reply.content).toContain("Everyone wants upside.");
+    expect(data.messages).toHaveLength(2);
+    expect(data.messages[0].role).toBe("user");
+    expect(data.messages[1].role).toBe("assistant");
+
+    expect(mockAnthropicCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "claude-sonnet-4-6",
+        system: expect.stringContaining("Oracle system prompt"),
+        messages: [
+          {
+            role: "user",
+            content: "Give me a contrarian BTC take.",
+          },
+        ],
+      }),
+    );
+
+    expect(mockPrisma.oracleSession.update).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: { id: "oracle-session-1" },
+        data: expect.objectContaining({
+          context: { page: "oracle" },
+        }),
+      }),
+    );
+    expect(mockPrisma.oracleSession.update).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { id: "oracle-session-1" },
+      }),
+    );
+  });
+});
+
+describe("DELETE /api/oracle/session", () => {
+  it("clears persisted session messages", async () => {
+    const populatedSession = {
+      ...baseSession,
+      messages: [
+        {
+          role: "user",
+          content: "Hello",
+          timestamp: "2026-04-10T08:01:00.000Z",
+        },
+      ],
+    };
+
+    (mockPrisma.oracleSession.findFirst as jest.Mock).mockResolvedValueOnce(populatedSession);
+    (mockPrisma.oracleSession.update as jest.Mock).mockResolvedValueOnce(baseSession);
+
+    const res = await request(app).delete("/api/oracle/session").set(AUTH);
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.messages).toEqual([]);
+    expect(mockPrisma.oracleSession.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "oracle-session-1" },
+        data: expect.objectContaining({
+          messages: [],
+        }),
+      }),
+    );
+  });
+});

--- a/services/api/src/lib/arena.ts
+++ b/services/api/src/lib/arena.ts
@@ -127,6 +127,13 @@ export function buildArenaLeaderboard(input: {
   publishedDrafts: ArenaPublishedDraft[];
   requestingUserId: string;
   period?: ArenaPeriod;
+  /**
+   * Optional map of userId → real consecutive-day activity streak computed
+   * from the full AnalyticsEvent history (drafts, feedback, voice refinement,
+   * session starts, etc.). When provided, replaces the post-dates proxy so
+   * the leaderboard reflects true cross-activity consistency.
+   */
+  streakByUserId?: ReadonlyMap<string, number>;
 }): ArenaLeaderboardResult {
   const statsByUser = new Map<string, {
     user: ArenaUser;
@@ -156,7 +163,11 @@ export function buildArenaLeaderboard(input: {
   const computed = [...statsByUser.values()]
     .map<LeaderboardComputation>((stats) => {
       const displayName = stats.user.displayName?.trim() || stats.user.handle;
-      const consistencyStreak = calculateConsistencyStreak(stats.postDates);
+      // Prefer the real cross-activity streak when the caller supplies it;
+      // fall back to the post-dates proxy so pure unit tests (and any
+      // legacy call sites) keep working without a DB round-trip.
+      const consistencyStreak = input.streakByUserId?.get(stats.user.id)
+        ?? calculateConsistencyStreak(stats.postDates);
       const postsPerWeek = roundToSingleDecimal((stats.tweetsPublished / 30) * 7);
 
       return {

--- a/services/api/src/lib/config.ts
+++ b/services/api/src/lib/config.ts
@@ -27,6 +27,7 @@ const envSchema = z.object({
   // AI providers
   GOOGLE_AI_API_KEY: z.string().optional(),
   GEMINI_MODEL: z.string().default("gemini-2.5-flash"),
+  GEMINI_IMAGE_MODEL: z.string().optional(),
   XAI_API_KEY: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
   ANTHROPIC_API_KEY: z.string().optional(),

--- a/services/api/src/lib/gemini.ts
+++ b/services/api/src/lib/gemini.ts
@@ -4,6 +4,9 @@ import { withRetry } from "./retry";
 
 let client: GoogleGenerativeAI | null = null;
 
+const DEFAULT_GEMINI_TEXT_MODEL = "gemini-2.5-flash";
+const DEFAULT_GEMINI_IMAGE_MODEL = "gemini-2.5-flash-image";
+
 export function getGeminiClient(): GoogleGenerativeAI {
   if (!client) {
     if (!config.GOOGLE_AI_API_KEY) {
@@ -28,6 +31,22 @@ export interface ImageGenResult {
   promptUsed: string;
 }
 
+interface GeminiInlineDataPart {
+  inlineData?: {
+    data?: string;
+    mimeType?: string;
+  };
+  text?: string;
+}
+
+interface GeminiGenerateContentResponse {
+  candidates?: Array<{
+    content?: {
+      parts?: GeminiInlineDataPart[];
+    };
+  }>;
+}
+
 const STYLE_PROMPTS: Record<ImageStyle, string> = {
   infographic:
     "Create a clean, modern infographic-style visual for a crypto/finance tweet. Dark background (#1a1a2e), teal accents (#4ecdc4). Include a simple chart or data visualization. Minimal text overlay. Professional and sleek.",
@@ -39,38 +58,116 @@ const STYLE_PROMPTS: Record<ImageStyle, string> = {
     "Create a thumbnail image for a crypto content piece. Eye-catching, dark theme with teal (#4ecdc4) accents. Modern, clean design suitable for social media preview cards.",
 };
 
-export async function generateImage(params: ImageGenParams): Promise<ImageGenResult> {
-  const { content, style, aspectRatio = "16:9" } = params;
+function resolveGeminiTextModel(): string {
+  const configuredModel = config.GEMINI_MODEL?.trim();
 
+  if (!configuredModel) return DEFAULT_GEMINI_TEXT_MODEL;
+  if (configuredModel.toLowerCase().includes("image")) return DEFAULT_GEMINI_TEXT_MODEL;
+
+  return configuredModel;
+}
+
+function resolveGeminiImageModel(): string {
+  const configuredImageModel = config.GEMINI_IMAGE_MODEL?.trim();
+  if (configuredImageModel) return configuredImageModel;
+
+  const legacyModel = config.GEMINI_MODEL?.trim();
+  if (legacyModel && legacyModel.toLowerCase().includes("image") && !legacyModel.startsWith("gemini-2.0")) {
+    return legacyModel;
+  }
+
+  return DEFAULT_GEMINI_IMAGE_MODEL;
+}
+
+function buildImagePrompt(content: string, style: ImageStyle, aspectRatio: ImageGenParams["aspectRatio"]): string {
   const stylePrompt = STYLE_PROMPTS[style] || STYLE_PROMPTS.quote_card;
-  const fullPrompt = `${stylePrompt}\n\nContext for the visual: "${content.slice(0, 200)}"`;
 
-  const client = getGeminiClient();
+  return `${stylePrompt}
 
-  // Use Gemini's image generation model
-  const model = client.getGenerativeModel({ model: config.GEMINI_MODEL });
+Create an original social image with no brand logos or watermarks.
+Keep any text in the image minimal and highly legible.
+Use aspect ratio ${aspectRatio}.
 
-  const result = await withRetry(
-    () =>
-      model.generateContent({
-        contents: [{ role: "user", parts: [{ text: `Generate an image: ${fullPrompt}. Aspect ratio: ${aspectRatio}.` }] }],
+Context for the visual: "${content.slice(0, 500)}"`;
+}
+
+async function postGeminiImageRequest(
+  model: string,
+  prompt: string,
+  aspectRatio: NonNullable<ImageGenParams["aspectRatio"]>,
+): Promise<GeminiGenerateContentResponse> {
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": config.GOOGLE_AI_API_KEY!,
+      },
+      body: JSON.stringify({
+        contents: [{
+          role: "user",
+          parts: [{ text: prompt }],
+        }],
         generationConfig: {
-          maxOutputTokens: 1000,
+          responseModalities: ["Image"],
+          imageConfig: {
+            aspectRatio,
+          },
         },
       }),
+    },
+  );
+
+  if (!response.ok) {
+    let message = `Gemini image request failed with status ${response.status}`;
+    const rawBody = await response.text();
+
+    if (rawBody) {
+      try {
+        const payload = JSON.parse(rawBody) as { error?: { message?: string } };
+        if (payload.error?.message) {
+          message = payload.error.message;
+        } else {
+          message = rawBody;
+        }
+      } catch {
+        message = rawBody;
+      }
+    }
+
+    const error = new Error(message) as Error & { status?: number };
+    error.status = response.status;
+    throw error;
+  }
+
+  return response.json() as Promise<GeminiGenerateContentResponse>;
+}
+
+export async function generateImage(params: ImageGenParams): Promise<ImageGenResult> {
+  const { content, style, aspectRatio = "16:9" } = params;
+  const fullPrompt = buildImagePrompt(content, style, aspectRatio);
+  const model = resolveGeminiImageModel();
+
+  const result = await withRetry(
+    () => postGeminiImageRequest(model, fullPrompt, aspectRatio),
     "gemini:generateImage",
   );
 
-  const response = result.response;
-  const text = response.text();
+  const parts = result.candidates?.flatMap((candidate) => candidate.content?.parts ?? []) ?? [];
+  const imagePart = parts.find((part) => part.inlineData?.data);
 
-  // Gemini text models return text descriptions, not actual images.
-  // For actual image generation, we'd need Imagen API.
-  // For now, return a structured description that the frontend can use
-  // to create a visual via CSS/SVG, or we can swap to Imagen when available.
+  if (!imagePart?.inlineData?.data) {
+    const textPart = parts.find((part) => part.text?.trim())?.text?.trim();
+    if (textPart) {
+      throw new Error(`Gemini image model returned text instead of an image: ${textPart.slice(0, 200)}`);
+    }
+    throw new Error(`Gemini image model "${model}" returned no inline image data`);
+  }
+
   return {
-    imageData: text,
-    mimeType: "text/plain",
+    imageData: imagePart.inlineData.data,
+    mimeType: imagePart.inlineData.mimeType ?? "image/png",
     promptUsed: fullPrompt,
   };
 }
@@ -87,7 +184,7 @@ export async function generateVisualConcept(tweetContent: string, style: ImageSt
   elements: string[];
 }> {
   const client = getGeminiClient();
-  const model = client.getGenerativeModel({ model: config.GEMINI_MODEL });
+  const model = client.getGenerativeModel({ model: resolveGeminiTextModel() });
 
   const result = await withRetry(
     () =>

--- a/services/api/src/lib/openclaw-router.ts
+++ b/services/api/src/lib/openclaw-router.ts
@@ -1,0 +1,155 @@
+/**
+ * OpenClaw Router — profile-based LLM routing for Atlas Oracle.
+ *
+ * Mirrors the OpenClaw RouterEngine pattern (see ../../../../../openclaw/src/router)
+ * but implemented locally on top of this backend's `routeCompletion` infra so the
+ * atlas-backend service doesn't need to pull OpenClaw as a runtime dependency
+ * (OpenClaw is ESM-only; this service is CJS).
+ *
+ * Profiles
+ * --------
+ *   smart — calibration, analysis, multi-sentence commentary, planning.
+ *           Higher token budget, slightly lower temperature. Routed through
+ *           oracle_smart in the underlying provider chain.
+ *
+ *   fast  — quick conversational replies, nudges, tooltips.
+ *           Small token budget, higher temperature for natural cadence.
+ *           Routed through oracle_fast in the underlying provider chain.
+ *
+ * Shape
+ * -----
+ *   runOracleCompletion({ profile, systemPrompt, userMessage, history? }) →
+ *     { reply, model, tokens, provider, latencyMs }
+ *
+ * The returned `tokens` field is the sum of input + output tokens reported by
+ * the underlying provider (0 when the provider does not surface usage).
+ */
+
+import { routeCompletion } from "./providers/router";
+import type {
+  CompletionRequest,
+  CompletionResponse,
+  Message,
+  TaskType,
+} from "./providers/types";
+import { withTimeout } from "./timeout";
+
+export type OracleProfile = "smart" | "fast";
+
+export interface OracleCompletionOptions {
+  /** Routing profile — smart (calibration/analysis) or fast (quick chat). */
+  profile: OracleProfile;
+  /** System prompt — personality + task framing. */
+  systemPrompt: string;
+  /** The current user message the Oracle should respond to. */
+  userMessage: string;
+  /**
+   * Optional prior conversation turns (oldest → newest). Caller is responsible
+   * for trimming history to a reasonable window.
+   */
+  history?: Array<{ role: "user" | "assistant"; content: string }>;
+  /** Override the profile's default max tokens. */
+  maxTokens?: number;
+  /** Override the profile's default temperature. */
+  temperature?: number;
+  /** Overall cap for the underlying provider chain (ms). Defaults to 10s. */
+  timeoutMs?: number;
+  /** Label for timeout / log correlation. Defaults to "oracle-openclaw". */
+  label?: string;
+}
+
+export interface OracleCompletionResult {
+  reply: string;
+  model: string;
+  provider: string;
+  tokens: number;
+  latencyMs: number;
+}
+
+interface ProfileConfig {
+  taskType: TaskType;
+  maxTokens: number;
+  temperature: number;
+}
+
+const PROFILE_CONFIG: Record<OracleProfile, ProfileConfig> = {
+  smart: {
+    taskType: "oracle_smart",
+    maxTokens: 600,
+    temperature: 0.7,
+  },
+  fast: {
+    taskType: "oracle_fast",
+    maxTokens: 180,
+    temperature: 0.8,
+  },
+};
+
+/**
+ * Execute an Oracle completion through the OpenClaw-style profile router.
+ *
+ * Internally delegates to `routeCompletion` (the shared provider fallback
+ * chain) so every profile automatically benefits from multi-provider failover.
+ */
+export async function runOracleCompletion(
+  options: OracleCompletionOptions,
+): Promise<OracleCompletionResult> {
+  const profile = PROFILE_CONFIG[options.profile];
+
+  const messages: Message[] = [
+    { role: "system", content: options.systemPrompt },
+    ...(options.history ?? []).map<Message>((turn) => ({
+      role: turn.role,
+      content: turn.content,
+    })),
+    { role: "user", content: options.userMessage },
+  ];
+
+  const request: CompletionRequest = {
+    taskType: profile.taskType,
+    maxTokens: options.maxTokens ?? profile.maxTokens,
+    temperature: options.temperature ?? profile.temperature,
+    messages,
+  };
+
+  const response: CompletionResponse = await withTimeout(
+    routeCompletion(request),
+    options.timeoutMs ?? 10_000,
+    options.label ?? "oracle-openclaw",
+  );
+
+  const reply = response.content.trim();
+  const usage = response.usage;
+  const tokens = usage ? usage.inputTokens + usage.outputTokens : 0;
+
+  return {
+    reply,
+    model: response.model,
+    provider: response.provider,
+    tokens,
+    latencyMs: response.latencyMs,
+  };
+}
+
+/**
+ * Pick the right profile given a phase hint from the caller.
+ *
+ * `phase` is a free-form string from the frontend describing what the Oracle
+ * is helping with. Calibration/analysis/planning phases prefer the smart
+ * profile; everything else defaults to fast for snappy conversation.
+ */
+export function resolveProfileForPhase(phase?: string | null): OracleProfile {
+  if (!phase) return "fast";
+  const p = phase.toLowerCase();
+  if (
+    p.includes("calibrat") ||
+    p.includes("analy") ||
+    p.includes("plan") ||
+    p.includes("blend") ||
+    p.includes("research") ||
+    p.includes("smart")
+  ) {
+    return "smart";
+  }
+  return "fast";
+}

--- a/services/api/src/lib/streak.ts
+++ b/services/api/src/lib/streak.ts
@@ -1,0 +1,176 @@
+import { prisma } from "./prisma";
+
+/**
+ * Streak tracking — real consecutive-day activity across the platform.
+ *
+ * An "active day" is any day (UTC) on which the user produced at least one
+ * AnalyticsEvent. This covers draft creation, posting, feedback, voice
+ * refinement, session starts, research, alerts, image generation, etc. —
+ * anything we already instrument via `analyticsEvent`.
+ *
+ * Replaces the old proxies:
+ *   - "session count" from `_count.sessions`
+ *   - "consistency streak" based on DRAFT_POSTED events only
+ */
+
+const MS_PER_DAY = 86_400_000;
+
+export type StreakStatus = "active" | "at_risk" | "broken";
+
+export interface StreakResult {
+  currentStreak: number;
+  longestStreak: number;
+  status: StreakStatus;
+  lastActivityAt: Date | null;
+}
+
+/**
+ * Convert a Date into the UTC-midnight timestamp of the day it falls on.
+ */
+export function toUtcDayStart(value: Date): number {
+  return Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate());
+}
+
+/**
+ * Compute the current and longest consecutive-day streak from a list of
+ * activity dates, relative to `now` (defaults to `new Date()`).
+ *
+ * Rules:
+ *   - "Days" are bucketed by UTC midnight.
+ *   - `currentStreak` counts consecutive days ending today, or yesterday if
+ *     there's no activity today yet (so a streak that's still "alive" shows).
+ *   - `longestStreak` is the maximum historical run of consecutive days.
+ *   - `status`:
+ *       `active`  — activity today
+ *       `at_risk` — activity yesterday but not today
+ *       `broken`  — last activity was >1 day ago (or never)
+ */
+export function calculateStreakFromDates(
+  dates: ReadonlyArray<Date>,
+  now: Date = new Date(),
+): StreakResult {
+  if (dates.length === 0) {
+    return {
+      currentStreak: 0,
+      longestStreak: 0,
+      status: "broken",
+      lastActivityAt: null,
+    };
+  }
+
+  const uniqueDays = [...new Set(dates.map(toUtcDayStart))].sort((a, b) => a - b);
+  const daySet = new Set(uniqueDays);
+
+  // Longest historical streak (walk sorted-ascending unique days).
+  let longestStreak = 1;
+  let runLength = 1;
+  for (let i = 1; i < uniqueDays.length; i += 1) {
+    const gap = uniqueDays[i] - uniqueDays[i - 1];
+    if (gap === MS_PER_DAY) {
+      runLength += 1;
+      if (runLength > longestStreak) {
+        longestStreak = runLength;
+      }
+    } else {
+      runLength = 1;
+    }
+  }
+
+  const today = toUtcDayStart(now);
+  const yesterday = today - MS_PER_DAY;
+  const hasToday = daySet.has(today);
+  const hasYesterday = daySet.has(yesterday);
+
+  // Current streak: walk back from today (or yesterday if today is empty).
+  let currentStreak = 0;
+  let cursor: number | null = null;
+  if (hasToday) {
+    cursor = today;
+  } else if (hasYesterday) {
+    cursor = yesterday;
+  }
+
+  while (cursor !== null && daySet.has(cursor)) {
+    currentStreak += 1;
+    cursor -= MS_PER_DAY;
+  }
+
+  // Status:
+  //   active  → activity today
+  //   at_risk → activity yesterday (but not today) — streak still alive for now
+  //   broken  → gap of more than one day since last activity, or never
+  let status: StreakStatus;
+  if (hasToday) {
+    status = "active";
+  } else if (hasYesterday) {
+    status = "at_risk";
+  } else {
+    status = "broken";
+  }
+
+  const mostRecentDay = uniqueDays[uniqueDays.length - 1];
+  // Surface the actual last event timestamp (not just the day bucket).
+  const lastActivityAt = dates.reduce<Date>((latest, d) => (d > latest ? d : latest), dates[0]);
+  void mostRecentDay;
+
+  return {
+    currentStreak,
+    longestStreak: Math.max(longestStreak, currentStreak),
+    status,
+    lastActivityAt,
+  };
+}
+
+/**
+ * Calculate a user's streak by querying all their AnalyticsEvent rows.
+ * Every analytics event counts as activity for that day — drafts, posts,
+ * feedback, voice refinements, session starts, etc.
+ */
+export async function calculateStreak(
+  userId: string,
+  now: Date = new Date(),
+): Promise<StreakResult> {
+  const events = await prisma.analyticsEvent.findMany({
+    where: { userId },
+    select: { createdAt: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  return calculateStreakFromDates(
+    events.map((e) => e.createdAt),
+    now,
+  );
+}
+
+/**
+ * Batch variant — fetch activity for many users in one query and return a
+ * map of userId → StreakResult. Used by the arena leaderboard so we don't
+ * fire off N queries.
+ */
+export async function calculateStreaksForUsers(
+  userIds: ReadonlyArray<string>,
+  now: Date = new Date(),
+): Promise<Map<string, StreakResult>> {
+  const result = new Map<string, StreakResult>();
+  if (userIds.length === 0) return result;
+
+  const events = await prisma.analyticsEvent.findMany({
+    where: { userId: { in: [...userIds] } },
+    select: { userId: true, createdAt: true },
+  });
+
+  const byUser = new Map<string, Date[]>();
+  for (const id of userIds) {
+    byUser.set(id, []);
+  }
+  for (const event of events) {
+    const bucket = byUser.get(event.userId);
+    if (bucket) bucket.push(event.createdAt);
+  }
+
+  for (const [userId, dates] of byUser.entries()) {
+    result.set(userId, calculateStreakFromDates(dates, now));
+  }
+
+  return result;
+}

--- a/services/api/src/routes/analytics.ts
+++ b/services/api/src/routes/analytics.ts
@@ -4,6 +4,7 @@ import { prisma } from "../lib/prisma";
 import { error, success } from "../lib/response";
 import { buildErrorResponse } from "../middleware/requestId";
 import { authenticate, AuthRequest } from "../middleware/auth";
+import { calculateStreak, calculateStreakFromDates } from "../lib/streak";
 
 export const analyticsRouter = Router();
 analyticsRouter.use(authenticate);
@@ -541,26 +542,10 @@ function clampScore(n: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, n));
 }
 
+// Delegates to the shared streak lib so Atlas Score matches the arena
+// leaderboard and the new /analytics/streak endpoint byte-for-byte.
 function computeStreak(dates: Date[]): number {
-  if (dates.length === 0) return 0;
-  const days = new Set<string>();
-  for (const d of dates) {
-    days.add(d.toISOString().slice(0, 10));
-  }
-
-  // Walk backwards from today; allow break only if today has no activity
-  // (so a streak ending yesterday still counts even if user hasn't posted today).
-  let streak = 0;
-  const cursor = new Date();
-  cursor.setHours(0, 0, 0, 0);
-  if (!days.has(cursor.toISOString().slice(0, 10))) {
-    cursor.setDate(cursor.getDate() - 1);
-  }
-  while (days.has(cursor.toISOString().slice(0, 10))) {
-    streak++;
-    cursor.setDate(cursor.getDate() - 1);
-  }
-  return streak;
+  return calculateStreakFromDates(dates).currentStreak;
 }
 
 function computeAtlasScore(u: ScoreUserInput): ScoreBreakdown {
@@ -661,6 +646,80 @@ async function loadScoreInput(userId: string): Promise<ScoreUserInput | null> {
     activityDates: user.tweetDrafts.map((d) => d.createdAt),
   };
 }
+
+// ============================================================
+// Streak — real consecutive-day activity tracking
+// ============================================================
+// Returns currentStreak, longestStreak, status, lastActivityAt
+// computed from the user's full AnalyticsEvent history. Replaces the
+// session-count proxy previously shown in the portal.
+// ============================================================
+
+analyticsRouter.get("/streak", async (req: AuthRequest, res) => {
+  try {
+    emptyQuerySchema.parse(req.query);
+
+    const streak = await calculateStreak(req.userId!);
+    res.json(success({
+      userId: req.userId,
+      currentStreak: streak.currentStreak,
+      longestStreak: streak.longestStreak,
+      status: streak.status,
+      lastActivityAt: streak.lastActivityAt,
+    }));
+  } catch (err: any) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json(error("Invalid request", 400, err.errors));
+    }
+    res.status(500).json(error("Failed to load streak", 500));
+  }
+});
+
+analyticsRouter.get("/streak/:userId", async (req: AuthRequest, res) => {
+  try {
+    emptyQuerySchema.parse(req.query);
+
+    const rawUserId = req.params.userId;
+    const targetUserId = Array.isArray(rawUserId) ? rawUserId[0] : rawUserId;
+    if (!targetUserId || typeof targetUserId !== "string") {
+      return res.status(400).json(error("Missing userId", 400));
+    }
+
+    // Analysts can only look up their own streak; managers/admins can
+    // inspect any teammate.
+    if (targetUserId !== req.userId) {
+      const viewer = await prisma.user.findUnique({
+        where: { id: req.userId },
+        select: { role: true },
+      });
+      if (!viewer || viewer.role === "ANALYST") {
+        return res.status(403).json(error("Manager access required", 403));
+      }
+    }
+
+    const target = await prisma.user.findUnique({
+      where: { id: targetUserId },
+      select: { id: true },
+    });
+    if (!target) {
+      return res.status(404).json(error("User not found", 404));
+    }
+
+    const streak = await calculateStreak(targetUserId);
+    res.json(success({
+      userId: targetUserId,
+      currentStreak: streak.currentStreak,
+      longestStreak: streak.longestStreak,
+      status: streak.status,
+      lastActivityAt: streak.lastActivityAt,
+    }));
+  } catch (err: any) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json(error("Invalid request", 400, err.errors));
+    }
+    res.status(500).json(error("Failed to load streak", 500));
+  }
+});
 
 // Get current user's Atlas Score with full breakdown
 analyticsRouter.get("/atlas-score", async (req: AuthRequest, res) => {
@@ -815,8 +874,45 @@ analyticsRouter.get("/team", async (req: AuthRequest, res) => {
       },
     });
 
+    // Real consecutive-day streaks (drafts + feedback + voice + sessions + ...)
+    // replace the session-count proxy the portal used to display. If the
+    // streak query fails we still return the base team payload — the streak
+    // fields just default to zero/broken.
+    const analystIds = analysts.map((a) => a.id);
+    const streakMap = new Map<string, { currentStreak: number; longestStreak: number; status: string }>();
+    if (analystIds.length > 0) {
+      try {
+        const events = await prisma.analyticsEvent.findMany({
+          where: { userId: { in: analystIds } },
+          select: { userId: true, createdAt: true },
+        });
+        const eventRows = Array.isArray(events) ? events : [];
+        const byUser = new Map<string, Date[]>();
+        for (const id of analystIds) byUser.set(id, []);
+        for (const e of eventRows) byUser.get(e.userId)?.push(e.createdAt);
+        for (const [uid, dates] of byUser.entries()) {
+          const s = calculateStreakFromDates(dates);
+          streakMap.set(uid, {
+            currentStreak: s.currentStreak,
+            longestStreak: s.longestStreak,
+            status: s.status,
+          });
+        }
+      } catch {
+        // swallow — streak is a nice-to-have, not load-bearing
+      }
+    }
+
     res.json(success({
-      analysts: analysts.map(({ passwordHash, ...a }) => a),
+      analysts: analysts.map(({ passwordHash, ...a }) => {
+        const streak = streakMap.get(a.id);
+        return {
+          ...a,
+          currentStreak: streak?.currentStreak ?? 0,
+          longestStreak: streak?.longestStreak ?? 0,
+          streakStatus: streak?.status ?? "broken",
+        };
+      }),
     }));
   } catch (err: any) {
     if (err instanceof z.ZodError) {

--- a/services/api/src/routes/arena.ts
+++ b/services/api/src/routes/arena.ts
@@ -4,6 +4,7 @@ import { prisma } from "../lib/prisma";
 import { error, success } from "../lib/response";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { buildArenaLeaderboard, type ArenaPublishedDraft } from "../lib/arena";
+import { calculateStreaksForUsers, type StreakResult } from "../lib/streak";
 
 export const arenaRouter = Router();
 arenaRouter.use(authenticate);

--- a/services/api/src/routes/arena.ts
+++ b/services/api/src/routes/arena.ts
@@ -4,7 +4,7 @@ import { prisma } from "../lib/prisma";
 import { error, success } from "../lib/response";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { buildArenaLeaderboard, type ArenaPublishedDraft } from "../lib/arena";
-import { calculateStreaksForUsers, type StreakResult } from "../lib/streak";
+import { calculateStreak, calculateStreaksForUsers } from "../lib/streak";
 
 export const arenaRouter = Router();
 arenaRouter.use(authenticate);
@@ -120,17 +120,44 @@ arenaRouter.get("/leaderboard", async (req: AuthRequest, res) => {
       });
     }
 
+    // Real consecutive-day streak across ALL analytics activity (drafts,
+    // feedback, voice refinement, session starts, etc.) — replaces the old
+    // proxy that only looked at DRAFT_POSTED events. Graceful fallback:
+    // if the streak query fails we still return a valid leaderboard using
+    // the post-dates proxy that buildArenaLeaderboard computes internally.
+    const streakResults = await calculateStreaksForUsers(userIds).catch(
+      () => new Map<string, { currentStreak: number; longestStreak: number; status: "active" | "at_risk" | "broken"; lastActivityAt: Date | null }>()
+    );
+    const streakByUserId = new Map<string, number>();
+    for (const [id, result] of streakResults.entries()) {
+      streakByUserId.set(id, result.currentStreak);
+    }
+
     const leaderboard = buildArenaLeaderboard({
       users,
       publishedDrafts,
       requestingUserId: req.userId!,
       period,
+      streakByUserId,
     });
+
+    // Surface full streak detail (current, longest, status) on every entry
+    // so the portal can render "On Fire", "At Risk", etc. without a second
+    // round-trip.
+    const entries = leaderboard.entries.map((entry) => {
+      const streak = streakResults.get(entry.userId);
+      return {
+        ...entry,
+        longestStreak: streak?.longestStreak ?? entry.consistencyStreak,
+        streakStatus: streak?.status ?? "broken",
+      };
+    });
+    const userRank = entries.find((entry) => entry.userId === req.userId) ?? null;
 
     res.json(success({
       period: leaderboard.period,
-      entries: leaderboard.entries,
-      userRank: leaderboard.userRank,
+      entries,
+      userRank,
     }));
   } catch (err: any) {
     res.status(500).json(error("Failed to load arena leaderboard", 500));
@@ -200,13 +227,36 @@ arenaRouter.get("/me", async (req: AuthRequest, res) => {
         });
       }
 
-      return buildArenaLeaderboard({ users: [user], publishedDrafts, requestingUserId: req.userId! });
+      // Real streak computed from every analytics event for this user,
+      // not just DRAFT_POSTED rows. Graceful fallback to a "broken" streak
+      // if the query fails so /me never 500s over a nice-to-have field.
+      const realStreak = await calculateStreak(req.userId!).catch(() => ({
+        currentStreak: 0,
+        longestStreak: 0,
+        status: "broken" as const,
+        lastActivityAt: null,
+      }));
+      const streakByUserId = new Map<string, number>([
+        [req.userId!, realStreak.currentStreak],
+      ]);
+
+      const built = buildArenaLeaderboard({
+        users: [user],
+        publishedDrafts,
+        requestingUserId: req.userId!,
+        streakByUserId,
+      });
+      return { built, realStreak };
     })();
 
-    if (!leaderboard || !leaderboard.userRank) {
+    if (!leaderboard || !leaderboard.built.userRank) {
       return res.status(404).json(error("User not found in arena", 404));
     }
-    res.json(success({ ...leaderboard.userRank }));
+    res.json(success({
+      ...leaderboard.built.userRank,
+      longestStreak: leaderboard.realStreak.longestStreak,
+      streakStatus: leaderboard.realStreak.status,
+    }));
   } catch (err: any) {
     res.status(500).json(error("Failed to load arena rank", 500));
   }

--- a/services/api/src/routes/images.ts
+++ b/services/api/src/routes/images.ts
@@ -4,7 +4,7 @@ import { prisma } from "../lib/prisma";
 import { config } from "../lib/config";
 import { error, success } from "../lib/response";
 import { authenticate, AuthRequest } from "../middleware/auth";
-import { generateVisualConcept, ImageStyle } from "../lib/gemini";
+import { generateImage, generateVisualConcept, ImageStyle } from "../lib/gemini";
 import { logger } from "../lib/logger";
 
 export const imagesRouter = Router();
@@ -20,6 +20,89 @@ const generateForDraftSchema = z.object({
   style: z.enum(["infographic", "quote_card", "avatar", "thumbnail"]).default("quote_card"),
 });
 
+const DEFAULT_COLOR_SCHEME = ["#4ecdc4", "#1a1a2e", "#2d3748"];
+const LAYOUT_BY_STYLE: Record<ImageStyle, string> = {
+  infographic: "chart-overlay",
+  quote_card: "centered-quote",
+  avatar: "minimal-gradient",
+  thumbnail: "split-stat",
+};
+
+const ASPECT_RATIO_BY_STYLE: Record<ImageStyle, "1:1" | "16:9" | "4:5"> = {
+  infographic: "16:9",
+  quote_card: "4:5",
+  avatar: "1:1",
+  thumbnail: "16:9",
+};
+
+function buildFallbackConcept(prompt: string, style: ImageStyle) {
+  const truncatedPrompt = prompt.trim().slice(0, 180);
+
+  return {
+    concept: truncatedPrompt
+      ? `AI-generated ${style.replace("_", " ")} inspired by: ${truncatedPrompt}`
+      : `AI-generated ${style.replace("_", " ")}`,
+    colorScheme: DEFAULT_COLOR_SCHEME,
+    layout: LAYOUT_BY_STYLE[style],
+    elements: ["gradient background", "bold focal visual", "high-contrast composition"],
+  };
+}
+
+function normalizeStoredImage<T extends { imageUrl: string; mimeType: string }>(image: T) {
+  if (image.mimeType !== "application/json") {
+    return image;
+  }
+
+  try {
+    return {
+      ...image,
+      concept: JSON.parse(image.imageUrl),
+    };
+  } catch {
+    return image;
+  }
+}
+
+async function createImageRecord(userId: string, prompt: string, style: ImageStyle, draftId?: string) {
+  const imageResult = await generateImage({
+    content: prompt,
+    style,
+    aspectRatio: ASPECT_RATIO_BY_STYLE[style],
+  });
+
+  const conceptResult = await generateVisualConcept(prompt, style).catch((err: unknown) => {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err), style },
+      "Falling back to deterministic visual concept",
+    );
+    return buildFallbackConcept(prompt, style);
+  });
+
+  const imageUrl = `data:${imageResult.mimeType};base64,${imageResult.imageData}`;
+
+  const image = await prisma.generatedImage.create({
+    data: {
+      userId,
+      ...(draftId ? { draftId } : {}),
+      prompt,
+      style,
+      imageUrl,
+      mimeType: imageResult.mimeType,
+    },
+  });
+
+  await prisma.analyticsEvent.create({
+    data: { userId, type: "IMAGE_GENERATED" },
+  });
+
+  return {
+    image: {
+      ...image,
+      concept: conceptResult,
+    },
+  };
+}
+
 // Standalone image concept generation
 imagesRouter.post("/generate", async (req: AuthRequest, res) => {
   try {
@@ -28,26 +111,9 @@ imagesRouter.post("/generate", async (req: AuthRequest, res) => {
     }
 
     const body = generateSchema.parse(req.body);
+    const result = await createImageRecord(req.userId!, body.prompt, body.style as ImageStyle);
 
-    const concept = await generateVisualConcept(body.prompt, body.style as ImageStyle);
-
-    // Persist
-    const image = await prisma.generatedImage.create({
-      data: {
-        userId: req.userId!,
-        prompt: body.prompt,
-        style: body.style,
-        imageUrl: JSON.stringify(concept), // Store concept as JSON
-        mimeType: "application/json",
-      },
-    });
-
-    // Log analytics
-    await prisma.analyticsEvent.create({
-      data: { userId: req.userId!, type: "IMAGE_GENERATED" },
-    });
-
-    res.json(success({ image: { ...image, concept } }));
+    res.json(success(result));
   } catch (err: any) {
     if (err instanceof z.ZodError) {
       return res.status(400).json(error("Invalid request", 400, err.errors));
@@ -72,26 +138,9 @@ imagesRouter.post("/generate-for-draft", async (req: AuthRequest, res) => {
     });
     if (!draft) return res.status(404).json(error("Draft not found"));
 
-    const concept = await generateVisualConcept(draft.content, body.style as ImageStyle);
+    const result = await createImageRecord(req.userId!, draft.content, body.style as ImageStyle, draft.id);
 
-    // Persist linked to draft
-    const image = await prisma.generatedImage.create({
-      data: {
-        userId: req.userId!,
-        draftId: draft.id,
-        prompt: draft.content,
-        style: body.style,
-        imageUrl: JSON.stringify(concept),
-        mimeType: "application/json",
-      },
-    });
-
-    // Log analytics
-    await prisma.analyticsEvent.create({
-      data: { userId: req.userId!, type: "IMAGE_GENERATED" },
-    });
-
-    res.json(success({ image: { ...image, concept } }));
+    res.json(success(result));
   } catch (err: any) {
     if (err instanceof z.ZodError) {
       return res.status(400).json(error("Invalid request", 400, err.errors));
@@ -108,7 +157,7 @@ imagesRouter.get("/for-draft/:draftId", async (req: AuthRequest, res) => {
       where: { draftId: req.params.draftId as string, userId: req.userId! },
       orderBy: { createdAt: "desc" },
     });
-    res.json(success({ images }));
+    res.json(success({ images: images.map(normalizeStoredImage) }));
   } catch (err: any) {
     logger.error({ err: err.message }, "Failed to load images");
     res.status(500).json(error("Failed to load images", 500, { message: err.message }));

--- a/services/api/src/routes/oracle.ts
+++ b/services/api/src/routes/oracle.ts
@@ -1,6 +1,8 @@
-import { Router } from "express";
+import { Prisma } from "@prisma/client";
+import { Response, Router } from "express";
 import { z } from "zod";
 import { authenticate, AuthRequest } from "../middleware/auth";
+import { getAnthropicClient } from "../lib/anthropic";
 import { routeCompletion } from "../lib/providers/router";
 import {
   buildCalibrationCommentary,
@@ -21,6 +23,19 @@ oracleRouter.use(authenticate);
 
 // ── Schema ───────────────────────────────────────────────────────
 
+const oracleSessionMessageSchema = z.object({
+  role: z.enum(["user", "assistant"]),
+  content: z.string(),
+  timestamp: z.string(),
+});
+
+const oracleSessionContextSchema = z.record(z.unknown());
+
+const oracleSessionRequestSchema = z.object({
+  content: z.string().trim().min(1).max(4000),
+  context: oracleSessionContextSchema.optional(),
+});
+
 const dimensionsSchema = z.object({
   humor: z.number(),
   formality: z.number(),
@@ -36,7 +51,7 @@ const dimensionsSchema = z.object({
   selfPromotionalIntensity: z.number().optional(),
 });
 
-const messageSchema = z.object({
+const legacyMessageSchema = z.object({
   track: z.enum(["a", "b"]),
   step: z.string(),
   action: z.string(),
@@ -61,11 +76,187 @@ const messageSchema = z.object({
     .optional(),
 });
 
+type OracleSessionMessage = z.infer<typeof oracleSessionMessageSchema>;
+type OracleSessionContext = z.infer<typeof oracleSessionContextSchema>;
+
+function normalizeOracleSessionMessages(raw: unknown): OracleSessionMessage[] {
+  const parsed = z.array(oracleSessionMessageSchema).safeParse(raw);
+  return parsed.success ? parsed.data : [];
+}
+
+function normalizeOracleSessionContext(raw: unknown): OracleSessionContext | null {
+  if (raw == null) {
+    return null;
+  }
+
+  const parsed = oracleSessionContextSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+function createOracleSessionMessage(
+  role: OracleSessionMessage["role"],
+  content: string,
+): OracleSessionMessage {
+  return {
+    role,
+    content,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+async function getOrCreateOracleSession(userId: string) {
+  const existingSession = await prisma.oracleSession.findFirst({
+    where: { userId },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  if (existingSession) {
+    return existingSession;
+  }
+
+  return prisma.oracleSession.create({
+    data: {
+      userId,
+      messages: [] as Prisma.InputJsonArray,
+    },
+  });
+}
+
+function buildOracleSessionSystemPrompt(context: OracleSessionContext | null): string {
+  const contextSuffix =
+    context && Object.keys(context).length > 0
+      ? `\n\nSession context:\n${JSON.stringify(context)}`
+      : "";
+
+  return (
+    `${buildOracleSystemPrompt()}\n\n` +
+    `You are in a persistent one-on-one chat with the authenticated Atlas user. ` +
+    `Use the saved conversation state when it matters. Keep responses concise unless the user asks for detail.` +
+    contextSuffix
+  );
+}
+
+async function handleSessionMessage(req: AuthRequest, res: Response) {
+  const body = oracleSessionRequestSchema.parse(req.body);
+  const session = await getOrCreateOracleSession(req.userId!);
+  const existingMessages = normalizeOracleSessionMessages(session.messages);
+  const userMessage = createOracleSessionMessage("user", body.content);
+  const messagesWithUser = [...existingMessages, userMessage];
+  const nextContext = body.context ?? normalizeOracleSessionContext(session.context);
+
+  await prisma.oracleSession.update({
+    where: { id: session.id },
+    data: {
+      messages: messagesWithUser as Prisma.InputJsonArray,
+      ...(body.context !== undefined
+        ? { context: body.context as Prisma.InputJsonObject }
+        : {}),
+    },
+  });
+
+  try {
+    const client = getAnthropicClient();
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 800,
+      system: buildOracleSessionSystemPrompt(nextContext),
+      messages: messagesWithUser.slice(-20).map((message) => ({
+        role: message.role,
+        content: message.content,
+      })),
+    });
+
+    const text = response.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("\n")
+      .trim();
+
+    if (!text) {
+      throw new Error("Empty response from Claude");
+    }
+
+    const assistantMessage = createOracleSessionMessage("assistant", text);
+    const persistedMessages = [...messagesWithUser, assistantMessage];
+
+    const updatedSession = await prisma.oracleSession.update({
+      where: { id: session.id },
+      data: {
+        messages: persistedMessages as Prisma.InputJsonArray,
+        ...(body.context !== undefined
+          ? { context: body.context as Prisma.InputJsonObject }
+          : {}),
+      },
+    });
+
+    res.json(
+      success({
+        sessionId: updatedSession.id,
+        reply: assistantMessage,
+        messages: normalizeOracleSessionMessages(updatedSession.messages),
+        context: normalizeOracleSessionContext(updatedSession.context),
+      }),
+    );
+  } catch (err) {
+    logger.error({ error: err }, "Oracle session message error");
+    res.status(502).json({ error: "Oracle response failed" });
+  }
+}
+
 // ── Route ────────────────────────────────────────────────────────
+
+oracleRouter.get("/session", async (req: AuthRequest, res) => {
+  try {
+    const session = await getOrCreateOracleSession(req.userId!);
+
+    res.json(
+      success({
+        sessionId: session.id,
+        messages: normalizeOracleSessionMessages(session.messages),
+        context: normalizeOracleSessionContext(session.context),
+      }),
+    );
+  } catch (err) {
+    logger.error({ error: err }, "Oracle session load error");
+    res.status(500).json({ error: "Failed to load oracle session" });
+  }
+});
+
+oracleRouter.delete("/session", async (req: AuthRequest, res) => {
+  try {
+    const session = await getOrCreateOracleSession(req.userId!);
+    const clearedSession = await prisma.oracleSession.update({
+      where: { id: session.id },
+      data: {
+        messages: [] as Prisma.InputJsonArray,
+      },
+    });
+
+    res.json(
+      success({
+        sessionId: clearedSession.id,
+        messages: normalizeOracleSessionMessages(clearedSession.messages),
+        context: normalizeOracleSessionContext(clearedSession.context),
+      }),
+    );
+  } catch (err) {
+    logger.error({ error: err }, "Oracle session clear error");
+    res.status(500).json({ error: "Failed to clear oracle session" });
+  }
+});
 
 oracleRouter.post("/message", async (req: AuthRequest, res) => {
   try {
-    const body = messageSchema.parse(req.body);
+    if (
+      typeof req.body === "object" &&
+      req.body !== null &&
+      "content" in req.body
+    ) {
+      await handleSessionMessage(req, res);
+      return;
+    }
+
+    const body = legacyMessageSchema.parse(req.body);
     const ctx = body.context ?? {};
 
     let messages: Array<{ content: string; role: "oracle" }> = [];
@@ -153,7 +344,7 @@ interface ResolvedPrompt {
 function resolvePrompt(
   action: string,
   step: string,
-  ctx: z.infer<typeof messageSchema>["context"] & {},
+  ctx: z.infer<typeof legacyMessageSchema>["context"] & {},
 ): ResolvedPrompt | null {
   // Calibration commentary — after voice scan completes
   if (

--- a/services/api/src/routes/oracle.ts
+++ b/services/api/src/routes/oracle.ts
@@ -3,6 +3,10 @@ import { Response, Router } from "express";
 import { z } from "zod";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { getAnthropicClient } from "../lib/anthropic";
+import {
+  runOracleCompletion,
+  resolveProfileForPhase,
+} from "../lib/openclaw-router";
 import { routeCompletion } from "../lib/providers/router";
 import {
   buildCalibrationCommentary,
@@ -405,7 +409,10 @@ function resolvePrompt(
 
 // ── General Chat ────────────────────────────────────────────────
 
-const chatSchema = z.object({
+// Legacy shape — used by the floating widget / crafting advisor:
+//   { messages: [{ role, content }], page?: string }
+// Response: { text }
+const chatLegacySchema = z.object({
   messages: z
     .array(z.object({ role: z.enum(["user", "oracle"]), content: z.string().max(2000) }))
     .min(1)
@@ -413,42 +420,165 @@ const chatSchema = z.object({
   page: z.string().optional(),
 });
 
-oracleRouter.post("/chat", async (req: AuthRequest, res) => {
+// New OpenClaw-routed shape:
+//   { message: string, userId?: string, context?: object, phase?: string }
+// Response: { reply, model, tokens }
+const chatOpenClawSchema = z.object({
+  message: z.string().trim().min(1).max(4000),
+  userId: z.string().optional(),
+  context: z.record(z.unknown()).optional(),
+  phase: z.string().max(64).optional(),
+});
+
+/**
+ * Build personalized context (voice profile + recent activity) for the
+ * Oracle. Mirrors how other routes build context — safe to call per request.
+ */
+async function buildOracleUserContext(userId: string): Promise<{
+  voiceHint: string;
+  activityHint: string;
+}> {
+  let voiceHint = "";
+  let activityHint = "";
+
   try {
-    const body = chatSchema.parse(req.body);
+    const profile = await prisma.voiceProfile.findUnique({ where: { userId } });
+    if (profile) {
+      voiceHint =
+        `\nVoice: Humor ${profile.humor}/100, Formality ${profile.formality}/100, ` +
+        `Brevity ${profile.brevity}/100, Contrarian ${profile.contrarianTone}/100.`;
+    }
+  } catch {
+    /* non-fatal */
+  }
 
-    const pageHint = body.page ? `\nThe user is on the ${body.page} page.` : "";
+  try {
+    const sevenDaysAgo = new Date(Date.now() - 7 * 86400000);
+    const [draftsRecent, postsRecent] = await Promise.all([
+      prisma.tweetDraft.count({
+        where: { userId, createdAt: { gte: sevenDaysAgo } },
+      }),
+      prisma.tweetDraft.count({
+        where: { userId, status: "POSTED", updatedAt: { gte: sevenDaysAgo } },
+      }),
+    ]);
+    if (draftsRecent > 0 || postsRecent > 0) {
+      activityHint = `\nLast 7 days: ${draftsRecent} drafts created, ${postsRecent} posted.`;
+    }
+  } catch {
+    /* non-fatal */
+  }
 
-    let voiceHint = "";
-    try {
-      const profile = await prisma.voiceProfile.findUnique({ where: { userId: req.userId! } });
-      if (profile) {
-        voiceHint = `\nVoice: Humor ${profile.humor}/100, Formality ${profile.formality}/100, Brevity ${profile.brevity}/100, Contrarian ${profile.contrarianTone}/100.`;
-      }
-    } catch {}
+  return { voiceHint, activityHint };
+}
 
-    const systemPrompt =
-      buildOracleSystemPrompt() +
-      `\n\nYou are in the floating chat widget inside Atlas.` +
-      pageHint + voiceHint +
-      `\n\nKeep responses under 50 words. Be helpful and personalized.`;
+/** New OpenClaw-routed handler — { reply, model, tokens } */
+async function handleOpenClawChat(req: AuthRequest, res: Response) {
+  const body = chatOpenClawSchema.parse(req.body);
+  const userId = req.userId!;
+  const profile = resolveProfileForPhase(body.phase);
+  const { voiceHint, activityHint } = await buildOracleUserContext(userId);
 
-    const llmMessages = [
-      { role: "system" as const, content: systemPrompt },
-      ...body.messages.map((m) => ({
-        role: (m.role === "oracle" ? "assistant" : "user") as "system" | "user" | "assistant",
-        content: m.content,
-      })),
-    ];
+  const contextSuffix =
+    body.context && Object.keys(body.context).length > 0
+      ? `\n\nSession context:\n${JSON.stringify(body.context).slice(0, 1500)}`
+      : "";
+  const phaseLine = body.phase ? `\nCurrent phase: ${body.phase}.` : "";
 
-    const response = await withTimeout(
-      routeCompletion({ taskType: "oracle_fast", maxTokens: 150, temperature: 0.7, messages: llmMessages }),
-      8_000,
-      "oracle-chat",
+  const systemPrompt =
+    buildOracleSystemPrompt() +
+    `\n\nYou are in a chat with the authenticated Atlas user.` +
+    phaseLine +
+    voiceHint +
+    activityHint +
+    `\n\nKeep responses concise unless the user asks for detail.` +
+    contextSuffix;
+
+  try {
+    const result = await runOracleCompletion({
+      profile,
+      systemPrompt,
+      userMessage: body.message,
+      label: "oracle-chat-openclaw",
+    });
+
+    logger.info(
+      {
+        profile,
+        provider: result.provider,
+        model: result.model,
+        latencyMs: result.latencyMs,
+        tokens: result.tokens,
+        phase: body.phase,
+      },
+      "Oracle OpenClaw chat response",
     );
 
-    logger.info({ provider: response.provider, latencyMs: response.latencyMs, page: body.page }, "Oracle chat response");
-    res.json(success({ text: response.content.trim() }));
+    res.json(
+      success({
+        reply: result.reply,
+        model: result.model,
+        tokens: result.tokens,
+      }),
+    );
+  } catch (err) {
+    logger.error({ error: err }, "Oracle OpenClaw chat error");
+    res.status(502).json(error("Oracle response failed", 502));
+  }
+}
+
+/** Legacy handler — preserves { text } response shape for existing callers. */
+async function handleLegacyChat(req: AuthRequest, res: Response) {
+  const body = chatLegacySchema.parse(req.body);
+
+  const pageHint = body.page ? `\nThe user is on the ${body.page} page.` : "";
+
+  let voiceHint = "";
+  try {
+    const profile = await prisma.voiceProfile.findUnique({ where: { userId: req.userId! } });
+    if (profile) {
+      voiceHint = `\nVoice: Humor ${profile.humor}/100, Formality ${profile.formality}/100, Brevity ${profile.brevity}/100, Contrarian ${profile.contrarianTone}/100.`;
+    }
+  } catch {}
+
+  const systemPrompt =
+    buildOracleSystemPrompt() +
+    `\n\nYou are in the floating chat widget inside Atlas.` +
+    pageHint + voiceHint +
+    `\n\nKeep responses under 50 words. Be helpful and personalized.`;
+
+  const llmMessages = [
+    { role: "system" as const, content: systemPrompt },
+    ...body.messages.map((m) => ({
+      role: (m.role === "oracle" ? "assistant" : "user") as "system" | "user" | "assistant",
+      content: m.content,
+    })),
+  ];
+
+  const response = await withTimeout(
+    routeCompletion({ taskType: "oracle_fast", maxTokens: 150, temperature: 0.7, messages: llmMessages }),
+    8_000,
+    "oracle-chat",
+  );
+
+  logger.info({ provider: response.provider, latencyMs: response.latencyMs, page: body.page }, "Oracle chat response");
+  res.json(success({ text: response.content.trim() }));
+}
+
+oracleRouter.post("/chat", async (req: AuthRequest, res) => {
+  try {
+    // Discriminate by body shape — the new OpenClaw route uses `message`
+    // (singular string); the legacy widget path uses `messages` (array).
+    if (
+      typeof req.body === "object" &&
+      req.body !== null &&
+      typeof (req.body as { message?: unknown }).message === "string"
+    ) {
+      await handleOpenClawChat(req, res);
+      return;
+    }
+
+    await handleLegacyChat(req, res);
   } catch (err) {
     if (err instanceof z.ZodError) {
       res.status(400).json({ ok: false, error: "Invalid request", details: err.errors });

--- a/services/api/src/routes/oracle.ts
+++ b/services/api/src/routes/oracle.ts
@@ -12,7 +12,7 @@ import {
   buildOracleSystemPrompt,
 } from "../lib/oracle-prompt";
 import { ORACLE_TOOLS, CONFIRMATION_REQUIRED, SERVER_EXECUTABLE } from "../lib/oracle-tools";
-import { success } from "../lib/response";
+import { error, success } from "../lib/response";
 import { logger } from "../lib/logger";
 import { prisma } from "../lib/prisma";
 import { withTimeout } from "../lib/timeout";
@@ -78,6 +78,8 @@ const legacyMessageSchema = z.object({
 
 type OracleSessionMessage = z.infer<typeof oracleSessionMessageSchema>;
 type OracleSessionContext = z.infer<typeof oracleSessionContextSchema>;
+type OraclePromptDimensions = Parameters<typeof buildCalibrationCommentary>[0];
+type OracleBlendVoices = Parameters<typeof buildBlendPreview>[1];
 
 function normalizeOracleSessionMessages(raw: unknown): OracleSessionMessage[] {
   const parsed = z.array(oracleSessionMessageSchema).safeParse(raw);
@@ -166,11 +168,13 @@ async function handleSessionMessage(req: AuthRequest, res: Response) {
       })),
     });
 
-    const text = response.content
-      .filter((block): block is { type: "text"; text: string } => block.type === "text")
-      .map((block) => block.text)
-      .join("\n")
-      .trim();
+    const text = response.content.reduce((combinedText, block) => {
+      if (block.type !== "text") {
+        return combinedText;
+      }
+
+      return combinedText ? `${combinedText}\n${block.text}` : block.text;
+    }, "").trim();
 
     if (!text) {
       throw new Error("Empty response from Claude");
@@ -199,7 +203,7 @@ async function handleSessionMessage(req: AuthRequest, res: Response) {
     );
   } catch (err) {
     logger.error({ error: err }, "Oracle session message error");
-    res.status(502).json({ error: "Oracle response failed" });
+    res.status(502).json(error("Oracle response failed", 502));
   }
 }
 
@@ -218,7 +222,7 @@ oracleRouter.get("/session", async (req: AuthRequest, res) => {
     );
   } catch (err) {
     logger.error({ error: err }, "Oracle session load error");
-    res.status(500).json({ error: "Failed to load oracle session" });
+    res.status(500).json(error("Failed to load oracle session", 500));
   }
 });
 
@@ -241,7 +245,7 @@ oracleRouter.delete("/session", async (req: AuthRequest, res) => {
     );
   } catch (err) {
     logger.error({ error: err }, "Oracle session clear error");
-    res.status(500).json({ error: "Failed to clear oracle session" });
+    res.status(500).json(error("Failed to clear oracle session", 500));
   }
 });
 
@@ -323,11 +327,11 @@ oracleRouter.post("/message", async (req: AuthRequest, res) => {
     res.json(success({ messages, llmGenerated }));
   } catch (err) {
     if (err instanceof z.ZodError) {
-      res.status(400).json({ ok: false, error: "Invalid request", details: err.errors });
+      res.status(400).json(error("Invalid request", 400, err.errors));
       return;
     }
     logger.error({ error: err }, "Oracle message error");
-    res.status(500).json({ ok: false, error: "Internal server error" });
+    res.status(500).json(error("Internal server error", 500));
   }
 });
 
@@ -346,14 +350,16 @@ function resolvePrompt(
   step: string,
   ctx: z.infer<typeof legacyMessageSchema>["context"] & {},
 ): ResolvedPrompt | null {
+  const parsedDimensions = ctx.dimensions as OraclePromptDimensions | undefined;
+
   // Calibration commentary — after voice scan completes
   if (
     action === "scan-complete" &&
     ctx.calibrationResult &&
-    ctx.dimensions
+    parsedDimensions
   ) {
     const { system, userMessage } = buildCalibrationCommentary(
-      ctx.dimensions,
+      parsedDimensions,
       ctx.calibrationResult.tweetsAnalyzed,
       ctx.handle,
     );
@@ -361,17 +367,17 @@ function resolvePrompt(
   }
 
   // Blend preview tweet
-  if (action === "blend-preview" && ctx.dimensions && ctx.blendVoices) {
+  if (action === "blend-preview" && parsedDimensions && ctx.blendVoices) {
     const { system, userMessage } = buildBlendPreview(
-      ctx.dimensions,
-      ctx.blendVoices,
+      parsedDimensions,
+      ctx.blendVoices as OracleBlendVoices,
     );
     return { system, userMessage, taskType: "oracle_smart", maxTokens: 300, temperature: 0.7 };
   }
 
   // Dimension reaction for unusual combos
-  if (action === "dims-continue" && ctx.dimensions) {
-    const reaction = buildDimensionReaction(ctx.dimensions);
+  if (action === "dims-continue" && parsedDimensions) {
+    const reaction = buildDimensionReaction(parsedDimensions);
     if (reaction) {
       return {
         system: reaction.system,
@@ -388,7 +394,7 @@ function resolvePrompt(
     const { system, userMessage } = buildFreeTextResponse(ctx.freeText, {
       track: undefined, // will be set from body.track in a future pass
       step,
-      dimensions: ctx.dimensions,
+      dimensions: parsedDimensions,
     });
     return { system, userMessage, taskType: "oracle_fast", maxTokens: 100, temperature: 0.7 };
   }


### PR DESCRIPTION
## Summary

Catch-up PR — this branch has drifted 16 commits ahead of `main`. It bundles several independent features and fixes that are already running in dev and need to ship together.

### Features
- **Real streak tracking** (`lib/streak.ts`) — consecutive-day activity streaks computed from the full `AnalyticsEvent` history (drafts, posts, feedback, voice refinements, sessions, etc.), replacing the old `DRAFT_POSTED`-only proxy. Single + batch variants, unit tests, and wiring hooks on `lib/arena.ts` (`streakByUserId` input) and `routes/arena.ts`.
- **Gemini image generation** — `lib/gemini.ts` rewritten to call the `v1beta/generateContent` endpoint against `gemini-2.5-flash-image`, return real inline PNG bytes, and surface upstream errors. New `GEMINI_IMAGE_MODEL` env override separates the text and image models.
- **Real image pipeline for /api/images** — `routes/images.ts` now persists real base64 data URLs via a shared `createImageRecord` helper, logs analytics, and hydrates legacy JSON-concept records on read for backwards compatibility. Falls back to a deterministic visual concept if concept generation fails.
- **Oracle persistent sessions** — new `OracleSession` Prisma model + `GET`/`POST`/`DELETE /api/oracle/session` endpoints backing a one-on-one persistent copilot chat (Claude Sonnet 4.6, last-20-message window). Hardened error responses via the shared `error()` helper and tighter prompt-dimension typing in `resolvePrompt`.
- **Arena periods + /me endpoint** (#d59c300) — `last_7_days` / `all_time` period support plus a `GET /api/arena/me` endpoint.
- **X OAuth scope** (#9f56fb4) — add `follows.read` scope.
- **Avoid repeating tweet angles** (#acc2614) — the draft generator checks recent draft history to avoid repeating angles.

### Fixes
- **X OAuth hardening** (#a947bb7) — harden token handling and duplicate-handle resolution.
- **Duplicate-handle login + error redirect path** (#b495bfe, PR #135).
- **Twitter API error surfacing** (#02eae1e) — calibration endpoint now surfaces upstream Twitter errors.
- **Analytics fallback** (#0cda1af, #b71ac08) — count `tweetDraft` rows when the events table is empty; test mocks updated.
- **Rate-limit config** (#240a076) — inline rate-limit constants since `config` has no `RATE_LIMIT_AUTH_*` fields.
- **Auth cookie clearing** (#e1b098d) — `clearAuthCookies` now matches the `SameSite`/`Secure` attributes set by `setAuthCookies`.
- **Smoke / analytics test mocks** (#a4a295c, #49f814f).

### Schema
- New `OracleSession` model (`prisma/schema.prisma`) — `id`, `userId`, `messages` (Json), `context` (Json?), `createdAt`, `updatedAt`; cascade on user delete. Railway will pick it up via the startup `prisma db push`.

### Tests
New: `__tests__/lib/gemini.test.ts`, `__tests__/lib/streak.test.ts`, `__tests__/routes/oracle.test.ts`. Expanded: `__tests__/routes/images.test.ts` (new image pipeline + legacy JSON hydration path).

## Test plan
- [ ] CI type-check + tests pass
- [ ] Railway staging deploys cleanly and `prisma db push` creates `oracle_sessions`
- [ ] `POST /api/oracle/session` round-trips a persistent conversation
- [ ] `POST /api/images/generate` returns a real `data:image/png;base64,...` URL
- [ ] `GET /api/images/for-draft/:id` still hydrates old `application/json` concept rows
- [ ] `GET /api/arena/leaderboard?period=last_7_days` and `all_time` return results
- [ ] X login with a duplicate handle no longer crashes; error redirect lands on the right path
- [ ] Draft generator does not repeat recent angles

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>