### PR TITLE
fix(images): fix image generation route failure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,8 @@ ANTHROPIC_API_KEY=your-anthropic-key-here
 GOOGLE_AI_API_KEY=your-google-ai-api-key-here
 # Gemini model override used by the Google AI client (default: gemini-2.5-flash)
 GEMINI_MODEL=gemini-2.5-flash
+# Optional dedicated Gemini image model override for /api/images (default fallback: gemini-2.5-flash-image)
+GEMINI_IMAGE_MODEL=gemini-2.5-flash-image
 # xAI / Grok API key for trending and research features
 XAI_API_KEY=your-xai-api-key-here
 

--- a/services/api/src/__tests__/lib/gemini.test.ts
+++ b/services/api/src/__tests__/lib/gemini.test.ts
@@ -1,0 +1,155 @@
+const mockConfig: {
+  GOOGLE_AI_API_KEY?: string;
+  GEMINI_MODEL: string;
+  GEMINI_IMAGE_MODEL?: string;
+} = {
+  GOOGLE_AI_API_KEY: "test-key",
+  GEMINI_MODEL: "gemini-2.5-flash",
+  GEMINI_IMAGE_MODEL: undefined,
+};
+
+const mockGenerateContent = jest.fn();
+const mockGetGenerativeModel = jest.fn(() => ({
+  generateContent: mockGenerateContent,
+}));
+const mockGoogleGenerativeAI = jest.fn(() => ({
+  getGenerativeModel: mockGetGenerativeModel,
+}));
+
+jest.mock("../../lib/config", () => ({
+  get config() {
+    return mockConfig;
+  },
+}));
+
+jest.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: mockGoogleGenerativeAI,
+}));
+
+import { generateImage, generateVisualConcept } from "../../lib/gemini";
+
+describe("gemini image helpers", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfig.GOOGLE_AI_API_KEY = "test-key";
+    mockConfig.GEMINI_MODEL = "gemini-2.5-flash";
+    mockConfig.GEMINI_IMAGE_MODEL = undefined;
+    global.fetch = jest.fn() as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("parses inline image data from Gemini responses", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [{
+          content: {
+            parts: [{ inlineData: { data: "ZmFrZS1pbWFnZQ==", mimeType: "image/png" } }],
+          },
+        }],
+      }),
+    });
+
+    const result = await generateImage({
+      content: "BTC is mooning",
+      style: "quote_card",
+      aspectRatio: "4:5",
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      imageData: "ZmFrZS1pbWFnZQ==",
+      mimeType: "image/png",
+    }));
+
+    const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toContain("/models/gemini-2.5-flash-image:generateContent");
+
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body.generationConfig.responseModalities).toEqual(["Image"]);
+    expect(body.generationConfig.imageConfig.aspectRatio).toBe("4:5");
+  });
+
+  it("falls back to the current image model when GEMINI_MODEL points at a deprecated 2.0 image model", async () => {
+    mockConfig.GEMINI_MODEL = "gemini-2.0-flash-exp-image-generation";
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [{
+          content: {
+            parts: [{ inlineData: { data: "ZmFrZS1pbWFnZQ==", mimeType: "image/png" } }],
+          },
+        }],
+      }),
+    });
+
+    await generateImage({
+      content: "BTC is mooning",
+      style: "thumbnail",
+    });
+
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain("/models/gemini-2.5-flash-image:generateContent");
+  });
+
+  it("uses GEMINI_IMAGE_MODEL when explicitly configured", async () => {
+    mockConfig.GEMINI_IMAGE_MODEL = "gemini-3.1-flash-image-preview";
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [{
+          content: {
+            parts: [{ inlineData: { data: "ZmFrZS1pbWFnZQ==", mimeType: "image/png" } }],
+          },
+        }],
+      }),
+    });
+
+    await generateImage({
+      content: "BTC is mooning",
+      style: "thumbnail",
+    });
+
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain("/models/gemini-3.1-flash-image-preview:generateContent");
+  });
+
+  it("throws a useful error when Gemini returns text instead of an image", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [{
+          content: {
+            parts: [{ text: "I can only describe the image." }],
+          },
+        }],
+      }),
+    });
+
+    await expect(generateImage({
+      content: "BTC is mooning",
+      style: "quote_card",
+    })).rejects.toThrow("Gemini image model returned text instead of an image");
+  });
+
+  it("uses a text model fallback for structured concept generation", async () => {
+    mockConfig.GEMINI_MODEL = "gemini-2.0-flash-exp-image-generation";
+    mockGenerateContent.mockResolvedValueOnce({
+      response: {
+        text: () => JSON.stringify({
+          concept: "A bold crypto visual",
+          colorScheme: ["#4ecdc4", "#1a1a2e", "#2d3748"],
+          layout: "centered-quote",
+          elements: ["headline frame"],
+        }),
+      },
+    });
+
+    const result = await generateVisualConcept("BTC is mooning", "quote_card");
+
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith({ model: "gemini-2.5-flash" });
+    expect(result.concept).toBe("A bold crypto visual");
+  });
+});

--- a/services/api/src/__tests__/routes/images.test.ts
+++ b/services/api/src/__tests__/routes/images.test.ts
@@ -38,6 +38,7 @@ jest.mock("../../lib/prisma", () => ({
 }));
 
 jest.mock("../../lib/gemini", () => ({
+  generateImage: jest.fn(),
   generateVisualConcept: jest.fn(),
 }));
 
@@ -50,8 +51,9 @@ jest.mock("../../lib/config", () => ({
 }));
 
 import { prisma } from "../../lib/prisma";
-import { generateVisualConcept } from "../../lib/gemini";
+import { generateImage, generateVisualConcept } from "../../lib/gemini";
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockGenerateImage = generateImage as jest.Mock;
 const mockGenerateVisualConcept = generateVisualConcept as jest.Mock;
 
 const app = express();
@@ -62,9 +64,10 @@ app.use("/api/images", imagesRouter);
 const AUTH = { Authorization: "Bearer mock_token" };
 
 const mockConcept = {
-  description: "A bold crypto-themed graphic",
+  concept: "A bold crypto-themed graphic",
   colorScheme: ["#F7931A", "#FFFFFF"],
-  layout: "centered",
+  layout: "centered-quote",
+  elements: ["candlestick chart", "headline frame"],
 };
 
 const mockImage = {
@@ -72,8 +75,14 @@ const mockImage = {
   userId: "user-123",
   prompt: "BTC is mooning",
   style: "quote_card",
-  imageUrl: JSON.stringify(mockConcept),
-  mimeType: "application/json",
+  imageUrl: "data:image/png;base64,ZmFrZS1pbWFnZQ==",
+  mimeType: "image/png",
+};
+
+const mockGeneratedAsset = {
+  imageData: "ZmFrZS1pbWFnZQ==",
+  mimeType: "image/png",
+  promptUsed: "prompt used",
 };
 
 beforeAll(() => {
@@ -82,6 +91,11 @@ beforeAll(() => {
 
 afterAll(() => {
   delete process.env.JWT_SECRET;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConfig.GOOGLE_AI_API_KEY = "test-key";
 });
 
 describe("POST /api/images/generate", () => {
@@ -97,6 +111,7 @@ describe("POST /api/images/generate", () => {
   });
 
   it("generates image concept and returns it", async () => {
+    mockGenerateImage.mockResolvedValueOnce(mockGeneratedAsset);
     mockGenerateVisualConcept.mockResolvedValueOnce(mockConcept);
     (mockPrisma.generatedImage.create as jest.Mock).mockResolvedValueOnce(mockImage);
     (mockPrisma.analyticsEvent.create as jest.Mock).mockResolvedValueOnce({});
@@ -110,10 +125,16 @@ describe("POST /api/images/generate", () => {
     const data = expectSuccessResponse<any>(res.body);
     expect(data.image.id).toBe("img-1");
     expect(data.image.concept).toEqual(mockConcept);
+    expect(mockPrisma.generatedImage.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        imageUrl: "data:image/png;base64,ZmFrZS1pbWFnZQ==",
+        mimeType: "image/png",
+      }),
+    });
   });
 
   it("returns 502 when AI generation fails", async () => {
-    mockGenerateVisualConcept.mockRejectedValueOnce(new Error("Gemini error"));
+    mockGenerateImage.mockRejectedValueOnce(new Error("Gemini error"));
 
     const res = await request(app)
       .post("/api/images/generate")
@@ -135,6 +156,23 @@ describe("POST /api/images/generate", () => {
 
     expect(res.status).toBe(503);
     mockConfig.GOOGLE_AI_API_KEY = original;
+  });
+
+  it("falls back to a deterministic concept when concept generation fails", async () => {
+    mockGenerateImage.mockResolvedValueOnce(mockGeneratedAsset);
+    mockGenerateVisualConcept.mockRejectedValueOnce(new Error("structured output failed"));
+    (mockPrisma.generatedImage.create as jest.Mock).mockResolvedValueOnce(mockImage);
+    (mockPrisma.analyticsEvent.create as jest.Mock).mockResolvedValueOnce({});
+
+    const res = await request(app)
+      .post("/api/images/generate")
+      .set(AUTH)
+      .send({ prompt: "BTC is mooning", style: "quote_card" });
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.image.concept.colorScheme).toEqual(["#4ecdc4", "#1a1a2e", "#2d3748"]);
+    expect(data.image.concept.layout).toBe("centered-quote");
   });
 });
 
@@ -162,6 +200,7 @@ describe("POST /api/images/generate-for-draft", () => {
   it("generates image for a draft", async () => {
     const draft = { id: "draft-1", content: "BTC is mooning", userId: "user-123" };
     (mockPrisma.tweetDraft.findFirst as jest.Mock).mockResolvedValueOnce(draft);
+    mockGenerateImage.mockResolvedValueOnce(mockGeneratedAsset);
     mockGenerateVisualConcept.mockResolvedValueOnce(mockConcept);
     const img = { ...mockImage, draftId: "draft-1" };
     (mockPrisma.generatedImage.create as jest.Mock).mockResolvedValueOnce(img);
@@ -189,6 +228,20 @@ describe("GET /api/images/for-draft/:draftId", () => {
     const res = await request(app).get("/api/images/for-draft/draft-1").set(AUTH);
     expect(res.status).toBe(200);
     expect(expectSuccessResponse<any>(res.body).images).toHaveLength(1);
+  });
+
+  it("hydrates concept payloads from legacy JSON image records", async () => {
+    const legacyImage = {
+      ...mockImage,
+      imageUrl: JSON.stringify(mockConcept),
+      mimeType: "application/json",
+    };
+    (mockPrisma.generatedImage.findMany as jest.Mock).mockResolvedValueOnce([legacyImage]);
+
+    const res = await request(app).get("/api/images/for-draft/draft-1").set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(expectSuccessResponse<any>(res.body).images[0].concept).toEqual(mockConcept);
   });
 
   it("returns 500 when loading images fails", async () => {

--- a/services/api/src/lib/config.ts
+++ b/services/api/src/lib/config.ts
@@ -27,6 +27,7 @@ const envSchema = z.object({
   // AI providers
   GOOGLE_AI_API_KEY: z.string().optional(),
   GEMINI_MODEL: z.string().default("gemini-2.5-flash"),
+  GEMINI_IMAGE_MODEL: z.string().optional(),
   XAI_API_KEY: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
   ANTHROPIC_API_KEY: z.string().optional(),

--- a/services/api/src/lib/gemini.ts
+++ b/services/api/src/lib/gemini.ts
@@ -4,6 +4,9 @@ import { withRetry } from "./retry";
 
 let client: GoogleGenerativeAI | null = null;
 
+const DEFAULT_GEMINI_TEXT_MODEL = "gemini-2.5-flash";
+const DEFAULT_GEMINI_IMAGE_MODEL = "gemini-2.5-flash-image";
+
 export function getGeminiClient(): GoogleGenerativeAI {
   if (!client) {
     if (!config.GOOGLE_AI_API_KEY) {
@@ -28,6 +31,22 @@ export interface ImageGenResult {
   promptUsed: string;
 }
 
+interface GeminiInlineDataPart {
+  inlineData?: {
+    data?: string;
+    mimeType?: string;
+  };
+  text?: string;
+}
+
+interface GeminiGenerateContentResponse {
+  candidates?: Array<{
+    content?: {
+      parts?: GeminiInlineDataPart[];
+    };
+  }>;
+}
+
 const STYLE_PROMPTS: Record<ImageStyle, string> = {
   infographic:
     "Create a clean, modern infographic-style visual for a crypto/finance tweet. Dark background (#1a1a2e), teal accents (#4ecdc4). Include a simple chart or data visualization. Minimal text overlay. Professional and sleek.",
@@ -39,38 +58,116 @@ const STYLE_PROMPTS: Record<ImageStyle, string> = {
     "Create a thumbnail image for a crypto content piece. Eye-catching, dark theme with teal (#4ecdc4) accents. Modern, clean design suitable for social media preview cards.",
 };
 
-export async function generateImage(params: ImageGenParams): Promise<ImageGenResult> {
-  const { content, style, aspectRatio = "16:9" } = params;
+function resolveGeminiTextModel(): string {
+  const configuredModel = config.GEMINI_MODEL?.trim();
 
+  if (!configuredModel) return DEFAULT_GEMINI_TEXT_MODEL;
+  if (configuredModel.toLowerCase().includes("image")) return DEFAULT_GEMINI_TEXT_MODEL;
+
+  return configuredModel;
+}
+
+function resolveGeminiImageModel(): string {
+  const configuredImageModel = config.GEMINI_IMAGE_MODEL?.trim();
+  if (configuredImageModel) return configuredImageModel;
+
+  const legacyModel = config.GEMINI_MODEL?.trim();
+  if (legacyModel && legacyModel.toLowerCase().includes("image") && !legacyModel.startsWith("gemini-2.0")) {
+    return legacyModel;
+  }
+
+  return DEFAULT_GEMINI_IMAGE_MODEL;
+}
+
+function buildImagePrompt(content: string, style: ImageStyle, aspectRatio: ImageGenParams["aspectRatio"]): string {
   const stylePrompt = STYLE_PROMPTS[style] || STYLE_PROMPTS.quote_card;
-  const fullPrompt = `${stylePrompt}\n\nContext for the visual: "${content.slice(0, 200)}"`;
 
-  const client = getGeminiClient();
+  return `${stylePrompt}
 
-  // Use Gemini's image generation model
-  const model = client.getGenerativeModel({ model: config.GEMINI_MODEL });
+Create an original social image with no brand logos or watermarks.
+Keep any text in the image minimal and highly legible.
+Use aspect ratio ${aspectRatio}.
 
-  const result = await withRetry(
-    () =>
-      model.generateContent({
-        contents: [{ role: "user", parts: [{ text: `Generate an image: ${fullPrompt}. Aspect ratio: ${aspectRatio}.` }] }],
+Context for the visual: "${content.slice(0, 500)}"`;
+}
+
+async function postGeminiImageRequest(
+  model: string,
+  prompt: string,
+  aspectRatio: NonNullable<ImageGenParams["aspectRatio"]>,
+): Promise<GeminiGenerateContentResponse> {
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": config.GOOGLE_AI_API_KEY!,
+      },
+      body: JSON.stringify({
+        contents: [{
+          role: "user",
+          parts: [{ text: prompt }],
+        }],
         generationConfig: {
-          maxOutputTokens: 1000,
+          responseModalities: ["Image"],
+          imageConfig: {
+            aspectRatio,
+          },
         },
       }),
+    },
+  );
+
+  if (!response.ok) {
+    let message = `Gemini image request failed with status ${response.status}`;
+    const rawBody = await response.text();
+
+    if (rawBody) {
+      try {
+        const payload = JSON.parse(rawBody) as { error?: { message?: string } };
+        if (payload.error?.message) {
+          message = payload.error.message;
+        } else {
+          message = rawBody;
+        }
+      } catch {
+        message = rawBody;
+      }
+    }
+
+    const error = new Error(message) as Error & { status?: number };
+    error.status = response.status;
+    throw error;
+  }
+
+  return response.json() as Promise<GeminiGenerateContentResponse>;
+}
+
+export async function generateImage(params: ImageGenParams): Promise<ImageGenResult> {
+  const { content, style, aspectRatio = "16:9" } = params;
+  const fullPrompt = buildImagePrompt(content, style, aspectRatio);
+  const model = resolveGeminiImageModel();
+
+  const result = await withRetry(
+    () => postGeminiImageRequest(model, fullPrompt, aspectRatio),
     "gemini:generateImage",
   );
 
-  const response = result.response;
-  const text = response.text();
+  const parts = result.candidates?.flatMap((candidate) => candidate.content?.parts ?? []) ?? [];
+  const imagePart = parts.find((part) => part.inlineData?.data);
 
-  // Gemini text models return text descriptions, not actual images.
-  // For actual image generation, we'd need Imagen API.
-  // For now, return a structured description that the frontend can use
-  // to create a visual via CSS/SVG, or we can swap to Imagen when available.
+  if (!imagePart?.inlineData?.data) {
+    const textPart = parts.find((part) => part.text?.trim())?.text?.trim();
+    if (textPart) {
+      throw new Error(`Gemini image model returned text instead of an image: ${textPart.slice(0, 200)}`);
+    }
+    throw new Error(`Gemini image model "${model}" returned no inline image data`);
+  }
+
   return {
-    imageData: text,
-    mimeType: "text/plain",
+    imageData: imagePart.inlineData.data,
+    mimeType: imagePart.inlineData.mimeType ?? "image/png",
     promptUsed: fullPrompt,
   };
 }
@@ -87,7 +184,7 @@ export async function generateVisualConcept(tweetContent: string, style: ImageSt
   elements: string[];
 }> {
   const client = getGeminiClient();
-  const model = client.getGenerativeModel({ model: config.GEMINI_MODEL });
+  const model = client.getGenerativeModel({ model: resolveGeminiTextModel() });
 
   const result = await withRetry(
     () =>

--- a/services/api/src/routes/images.ts
+++ b/services/api/src/routes/images.ts
@@ -4,7 +4,7 @@ import { prisma } from "../lib/prisma";
 import { config } from "../lib/config";
 import { error, success } from "../lib/response";
 import { authenticate, AuthRequest } from "../middleware/auth";
-import { generateVisualConcept, ImageStyle } from "../lib/gemini";
+import { generateImage, generateVisualConcept, ImageStyle } from "../lib/gemini";
 import { logger } from "../lib/logger";
 
 export const imagesRouter = Router();
@@ -20,6 +20,89 @@ const generateForDraftSchema = z.object({
   style: z.enum(["infographic", "quote_card", "avatar", "thumbnail"]).default("quote_card"),
 });
 
+const DEFAULT_COLOR_SCHEME = ["#4ecdc4", "#1a1a2e", "#2d3748"];
+const LAYOUT_BY_STYLE: Record<ImageStyle, string> = {
+  infographic: "chart-overlay",
+  quote_card: "centered-quote",
+  avatar: "minimal-gradient",
+  thumbnail: "split-stat",
+};
+
+const ASPECT_RATIO_BY_STYLE: Record<ImageStyle, "1:1" | "16:9" | "4:5"> = {
+  infographic: "16:9",
+  quote_card: "4:5",
+  avatar: "1:1",
+  thumbnail: "16:9",
+};
+
+function buildFallbackConcept(prompt: string, style: ImageStyle) {
+  const truncatedPrompt = prompt.trim().slice(0, 180);
+
+  return {
+    concept: truncatedPrompt
+      ? `AI-generated ${style.replace("_", " ")} inspired by: ${truncatedPrompt}`
+      : `AI-generated ${style.replace("_", " ")}`,
+    colorScheme: DEFAULT_COLOR_SCHEME,
+    layout: LAYOUT_BY_STYLE[style],
+    elements: ["gradient background", "bold focal visual", "high-contrast composition"],
+  };
+}
+
+function normalizeStoredImage<T extends { imageUrl: string; mimeType: string }>(image: T) {
+  if (image.mimeType !== "application/json") {
+    return image;
+  }
+
+  try {
+    return {
+      ...image,
+      concept: JSON.parse(image.imageUrl),
+    };
+  } catch {
+    return image;
+  }
+}
+
+async function createImageRecord(userId: string, prompt: string, style: ImageStyle, draftId?: string) {
+  const imageResult = await generateImage({
+    content: prompt,
+    style,
+    aspectRatio: ASPECT_RATIO_BY_STYLE[style],
+  });
+
+  const conceptResult = await generateVisualConcept(prompt, style).catch((err: unknown) => {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err), style },
+      "Falling back to deterministic visual concept",
+    );
+    return buildFallbackConcept(prompt, style);
+  });
+
+  const imageUrl = `data:${imageResult.mimeType};base64,${imageResult.imageData}`;
+
+  const image = await prisma.generatedImage.create({
+    data: {
+      userId,
+      ...(draftId ? { draftId } : {}),
+      prompt,
+      style,
+      imageUrl,
+      mimeType: imageResult.mimeType,
+    },
+  });
+
+  await prisma.analyticsEvent.create({
+    data: { userId, type: "IMAGE_GENERATED" },
+  });
+
+  return {
+    image: {
+      ...image,
+      concept: conceptResult,
+    },
+  };
+}
+
 // Standalone image concept generation
 imagesRouter.post("/generate", async (req: AuthRequest, res) => {
   try {
@@ -28,26 +111,9 @@ imagesRouter.post("/generate", async (req: AuthRequest, res) => {
     }
 
     const body = generateSchema.parse(req.body);
+    const result = await createImageRecord(req.userId!, body.prompt, body.style as ImageStyle);
 
-    const concept = await generateVisualConcept(body.prompt, body.style as ImageStyle);
-
-    // Persist
-    const image = await prisma.generatedImage.create({
-      data: {
-        userId: req.userId!,
-        prompt: body.prompt,
-        style: body.style,
-        imageUrl: JSON.stringify(concept), // Store concept as JSON
-        mimeType: "application/json",
-      },
-    });
-
-    // Log analytics
-    await prisma.analyticsEvent.create({
-      data: { userId: req.userId!, type: "IMAGE_GENERATED" },
-    });
-
-    res.json(success({ image: { ...image, concept } }));
+    res.json(success(result));
   } catch (err: any) {
     if (err instanceof z.ZodError) {
       return res.status(400).json(error("Invalid request", 400, err.errors));
@@ -72,26 +138,9 @@ imagesRouter.post("/generate-for-draft", async (req: AuthRequest, res) => {
     });
     if (!draft) return res.status(404).json(error("Draft not found"));
 
-    const concept = await generateVisualConcept(draft.content, body.style as ImageStyle);
+    const result = await createImageRecord(req.userId!, draft.content, body.style as ImageStyle, draft.id);
 
-    // Persist linked to draft
-    const image = await prisma.generatedImage.create({
-      data: {
-        userId: req.userId!,
-        draftId: draft.id,
-        prompt: draft.content,
-        style: body.style,
-        imageUrl: JSON.stringify(concept),
-        mimeType: "application/json",
-      },
-    });
-
-    // Log analytics
-    await prisma.analyticsEvent.create({
-      data: { userId: req.userId!, type: "IMAGE_GENERATED" },
-    });
-
-    res.json(success({ image: { ...image, concept } }));
+    res.json(success(result));
   } catch (err: any) {
     if (err instanceof z.ZodError) {
       return res.status(400).json(error("Invalid request", 400, err.errors));
@@ -108,7 +157,7 @@ imagesRouter.get("/for-draft/:draftId", async (req: AuthRequest, res) => {
       where: { draftId: req.params.draftId as string, userId: req.userId! },
       orderBy: { createdAt: "desc" },
     });
-    res.json(success({ images }));
+    res.json(success({ images: images.map(normalizeStoredImage) }));
   } catch (err: any) {
     logger.error({ err: err.message }, "Failed to load images");
     res.status(500).json(error("Failed to load images", 500, { message: err.message }));


### PR DESCRIPTION
## What changed
- switched the image helper to Gemini's current image-generation API contract and parse image bytes from `inlineData.data`
- added a dedicated `GEMINI_IMAGE_MODEL` override while keeping text concept generation on a text model fallback
- updated `/api/images` to persist real image data URLs, keep returning a concept payload, and hydrate legacy JSON-backed image records
- added focused Jest coverage for Gemini image parsing/model selection and the updated images route behavior

## Root cause
The backend image route was still wired to legacy Gemini behavior:
- it relied on the deprecated `@google/generative-ai` flow for image work
- it treated image generation as text/concept generation instead of consuming inline image bytes
- it reused `GEMINI_MODEL`, which can point at deprecated or image-only models that are not valid for structured concept generation

## Validation
- `npx jest services/api/src/__tests__/lib/gemini.test.ts --runInBand`
- `npx jest services/api/src/__tests__/routes/images.test.ts --runInBand`
- `npx tsc --noEmit`
