### PR TITLE
feat(oracle): add oracle session + message endpoints

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
   analyticsEvents   AnalyticsEvent[]
   alertSubscriptions AlertSubscription[]
   sessions          Session[]
+  oracleSessions    OracleSession[]
   researchResults   ResearchResult[]
   generatedImages   GeneratedImage[]
   alerts            Alert[]
@@ -71,6 +72,18 @@ model Session {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("sessions")
+}
+
+model OracleSession {
+  id        String   @id @default(cuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  messages  Json     @default("[]")
+  context   Json?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("oracle_sessions")
 }
 
 model VoiceProfile {

--- a/services/api/src/__tests__/routes/oracle.test.ts
+++ b/services/api/src/__tests__/routes/oracle.test.ts
@@ -1,0 +1,280 @@
+import express from "express";
+import request from "supertest";
+import { requestIdMiddleware } from "../../middleware/requestId";
+import { expectErrorResponse, expectSuccessResponse } from "../helpers/response";
+
+jest.mock("../../middleware/auth", () => ({
+  authenticate: jest.fn((req: any, res: any, next: any) => {
+    const header = req.headers.authorization;
+    if (!header?.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Missing authorization token" });
+    }
+
+    req.userId = "user-123";
+    next();
+  }),
+  AuthRequest: {},
+}));
+
+jest.mock("../../lib/prisma", () => ({
+  prisma: {
+    oracleSession: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../lib/anthropic", () => ({
+  getAnthropicClient: jest.fn(),
+}));
+
+jest.mock("../../lib/providers/router", () => ({
+  routeCompletion: jest.fn(),
+}));
+
+jest.mock("../../lib/oracle-prompt", () => ({
+  buildOracleSystemPrompt: jest.fn(() => "Oracle system prompt"),
+  buildCalibrationCommentary: jest.fn(),
+  buildBlendPreview: jest.fn(),
+  buildDimensionReaction: jest.fn(),
+  buildFreeTextResponse: jest.fn(),
+}));
+
+jest.mock("../../lib/oracle-tools", () => ({
+  ORACLE_TOOLS: [],
+  CONFIRMATION_REQUIRED: new Set(),
+  SERVER_EXECUTABLE: new Set(),
+}));
+
+jest.mock("../../lib/timeout", () => ({
+  withTimeout: jest.fn((promise: Promise<unknown>) => promise),
+}));
+
+jest.mock("../../lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import { prisma } from "../../lib/prisma";
+import { getAnthropicClient } from "../../lib/anthropic";
+import { oracleRouter } from "../../routes/oracle";
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockGetAnthropicClient = getAnthropicClient as jest.Mock;
+const mockAnthropicCreate = jest.fn();
+
+const app = express();
+app.use(express.json());
+app.use(requestIdMiddleware);
+app.use("/api/oracle", oracleRouter);
+
+const AUTH = { Authorization: "Bearer mock-token" };
+
+const baseSession = {
+  id: "oracle-session-1",
+  userId: "user-123",
+  messages: [],
+  context: null,
+  createdAt: new Date("2026-04-10T08:00:00.000Z"),
+  updatedAt: new Date("2026-04-10T08:00:00.000Z"),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetAnthropicClient.mockReturnValue({
+    messages: {
+      create: mockAnthropicCreate,
+    },
+  });
+});
+
+describe("GET /api/oracle/session", () => {
+  it("returns 401 without auth", async () => {
+    const res = await request(app).get("/api/oracle/session");
+    expect(res.status).toBe(401);
+  });
+
+  it("creates a session when one does not exist", async () => {
+    (mockPrisma.oracleSession.findFirst as jest.Mock).mockResolvedValueOnce(null);
+    (mockPrisma.oracleSession.create as jest.Mock).mockResolvedValueOnce(baseSession);
+
+    const res = await request(app).get("/api/oracle/session").set(AUTH);
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.sessionId).toBe("oracle-session-1");
+    expect(data.messages).toEqual([]);
+    expect(mockPrisma.oracleSession.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "user-123",
+        }),
+      }),
+    );
+  });
+
+  it("returns the existing session state", async () => {
+    const existingSession = {
+      ...baseSession,
+      messages: [
+        {
+          role: "user",
+          content: "What should I write about today?",
+          timestamp: "2026-04-10T08:01:00.000Z",
+        },
+      ],
+      context: {
+        page: "oracle",
+      },
+    };
+
+    (mockPrisma.oracleSession.findFirst as jest.Mock).mockResolvedValueOnce(existingSession);
+
+    const res = await request(app).get("/api/oracle/session").set(AUTH);
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.messages).toHaveLength(1);
+    expect(data.context.page).toBe("oracle");
+  });
+});
+
+describe("POST /api/oracle/message", () => {
+  it("returns 400 for empty content", async () => {
+    const res = await request(app)
+      .post("/api/oracle/message")
+      .set(AUTH)
+      .send({ content: "" });
+
+    expect(res.status).toBe(400);
+    expectErrorResponse(res.body, "Invalid request");
+  });
+
+  it("persists the user message and assistant reply", async () => {
+    (mockPrisma.oracleSession.findFirst as jest.Mock).mockResolvedValueOnce(baseSession);
+
+    const sessionAfterUserMessage = {
+      ...baseSession,
+      messages: [
+        {
+          role: "user",
+          content: "Give me a contrarian BTC take.",
+          timestamp: "2026-04-10T08:02:00.000Z",
+        },
+      ],
+      context: {
+        page: "oracle",
+      },
+    };
+
+    const sessionAfterAssistantReply = {
+      ...baseSession,
+      messages: [
+        ...sessionAfterUserMessage.messages,
+        {
+          role: "assistant",
+          content: "Everyone wants upside. The better trade is patience until conviction returns.",
+          timestamp: "2026-04-10T08:02:05.000Z",
+        },
+      ],
+      context: {
+        page: "oracle",
+      },
+    };
+
+    (mockPrisma.oracleSession.update as jest.Mock)
+      .mockResolvedValueOnce(sessionAfterUserMessage)
+      .mockResolvedValueOnce(sessionAfterAssistantReply);
+
+    mockAnthropicCreate.mockResolvedValueOnce({
+      content: [
+        {
+          type: "text",
+          text: "Everyone wants upside. The better trade is patience until conviction returns.",
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .post("/api/oracle/message")
+      .set(AUTH)
+      .send({
+        content: "Give me a contrarian BTC take.",
+        context: { page: "oracle" },
+      });
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.reply.role).toBe("assistant");
+    expect(data.reply.content).toContain("Everyone wants upside.");
+    expect(data.messages).toHaveLength(2);
+    expect(data.messages[0].role).toBe("user");
+    expect(data.messages[1].role).toBe("assistant");
+
+    expect(mockAnthropicCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "claude-sonnet-4-6",
+        system: expect.stringContaining("Oracle system prompt"),
+        messages: [
+          {
+            role: "user",
+            content: "Give me a contrarian BTC take.",
+          },
+        ],
+      }),
+    );
+
+    expect(mockPrisma.oracleSession.update).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: { id: "oracle-session-1" },
+        data: expect.objectContaining({
+          context: { page: "oracle" },
+        }),
+      }),
+    );
+    expect(mockPrisma.oracleSession.update).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { id: "oracle-session-1" },
+      }),
+    );
+  });
+});
+
+describe("DELETE /api/oracle/session", () => {
+  it("clears persisted session messages", async () => {
+    const populatedSession = {
+      ...baseSession,
+      messages: [
+        {
+          role: "user",
+          content: "Hello",
+          timestamp: "2026-04-10T08:01:00.000Z",
+        },
+      ],
+    };
+
+    (mockPrisma.oracleSession.findFirst as jest.Mock).mockResolvedValueOnce(populatedSession);
+    (mockPrisma.oracleSession.update as jest.Mock).mockResolvedValueOnce(baseSession);
+
+    const res = await request(app).delete("/api/oracle/session").set(AUTH);
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.messages).toEqual([]);
+    expect(mockPrisma.oracleSession.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "oracle-session-1" },
+        data: expect.objectContaining({
+          messages: [],
+        }),
+      }),
+    );
+  });
+});

--- a/services/api/src/routes/oracle.ts
+++ b/services/api/src/routes/oracle.ts
@@ -1,6 +1,8 @@
-import { Router } from "express";
+import { Prisma } from "@prisma/client";
+import { Response, Router } from "express";
 import { z } from "zod";
 import { authenticate, AuthRequest } from "../middleware/auth";
+import { getAnthropicClient } from "../lib/anthropic";
 import { routeCompletion } from "../lib/providers/router";
 import {
   buildCalibrationCommentary,
@@ -10,7 +12,7 @@ import {
   buildOracleSystemPrompt,
 } from "../lib/oracle-prompt";
 import { ORACLE_TOOLS, CONFIRMATION_REQUIRED, SERVER_EXECUTABLE } from "../lib/oracle-tools";
-import { success } from "../lib/response";
+import { error, success } from "../lib/response";
 import { logger } from "../lib/logger";
 import { prisma } from "../lib/prisma";
 import { withTimeout } from "../lib/timeout";
@@ -20,6 +22,19 @@ export const oracleRouter = Router();
 oracleRouter.use(authenticate);
 
 // ── Schema ───────────────────────────────────────────────────────
+
+const oracleSessionMessageSchema = z.object({
+  role: z.enum(["user", "assistant"]),
+  content: z.string(),
+  timestamp: z.string(),
+});
+
+const oracleSessionContextSchema = z.record(z.unknown());
+
+const oracleSessionRequestSchema = z.object({
+  content: z.string().trim().min(1).max(4000),
+  context: oracleSessionContextSchema.optional(),
+});
 
 const dimensionsSchema = z.object({
   humor: z.number(),
@@ -36,7 +51,7 @@ const dimensionsSchema = z.object({
   selfPromotionalIntensity: z.number().optional(),
 });
 
-const messageSchema = z.object({
+const legacyMessageSchema = z.object({
   track: z.enum(["a", "b"]),
   step: z.string(),
   action: z.string(),
@@ -61,11 +76,191 @@ const messageSchema = z.object({
     .optional(),
 });
 
+type OracleSessionMessage = z.infer<typeof oracleSessionMessageSchema>;
+type OracleSessionContext = z.infer<typeof oracleSessionContextSchema>;
+type OraclePromptDimensions = Parameters<typeof buildCalibrationCommentary>[0];
+type OracleBlendVoices = Parameters<typeof buildBlendPreview>[1];
+
+function normalizeOracleSessionMessages(raw: unknown): OracleSessionMessage[] {
+  const parsed = z.array(oracleSessionMessageSchema).safeParse(raw);
+  return parsed.success ? parsed.data : [];
+}
+
+function normalizeOracleSessionContext(raw: unknown): OracleSessionContext | null {
+  if (raw == null) {
+    return null;
+  }
+
+  const parsed = oracleSessionContextSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+function createOracleSessionMessage(
+  role: OracleSessionMessage["role"],
+  content: string,
+): OracleSessionMessage {
+  return {
+    role,
+    content,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+async function getOrCreateOracleSession(userId: string) {
+  const existingSession = await prisma.oracleSession.findFirst({
+    where: { userId },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  if (existingSession) {
+    return existingSession;
+  }
+
+  return prisma.oracleSession.create({
+    data: {
+      userId,
+      messages: [] as Prisma.InputJsonArray,
+    },
+  });
+}
+
+function buildOracleSessionSystemPrompt(context: OracleSessionContext | null): string {
+  const contextSuffix =
+    context && Object.keys(context).length > 0
+      ? `\n\nSession context:\n${JSON.stringify(context)}`
+      : "";
+
+  return (
+    `${buildOracleSystemPrompt()}\n\n` +
+    `You are in a persistent one-on-one chat with the authenticated Atlas user. ` +
+    `Use the saved conversation state when it matters. Keep responses concise unless the user asks for detail.` +
+    contextSuffix
+  );
+}
+
+async function handleSessionMessage(req: AuthRequest, res: Response) {
+  const body = oracleSessionRequestSchema.parse(req.body);
+  const session = await getOrCreateOracleSession(req.userId!);
+  const existingMessages = normalizeOracleSessionMessages(session.messages);
+  const userMessage = createOracleSessionMessage("user", body.content);
+  const messagesWithUser = [...existingMessages, userMessage];
+  const nextContext = body.context ?? normalizeOracleSessionContext(session.context);
+
+  await prisma.oracleSession.update({
+    where: { id: session.id },
+    data: {
+      messages: messagesWithUser as Prisma.InputJsonArray,
+      ...(body.context !== undefined
+        ? { context: body.context as Prisma.InputJsonObject }
+        : {}),
+    },
+  });
+
+  try {
+    const client = getAnthropicClient();
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 800,
+      system: buildOracleSessionSystemPrompt(nextContext),
+      messages: messagesWithUser.slice(-20).map((message) => ({
+        role: message.role,
+        content: message.content,
+      })),
+    });
+
+    const text = response.content.reduce((combinedText, block) => {
+      if (block.type !== "text") {
+        return combinedText;
+      }
+
+      return combinedText ? `${combinedText}\n${block.text}` : block.text;
+    }, "").trim();
+
+    if (!text) {
+      throw new Error("Empty response from Claude");
+    }
+
+    const assistantMessage = createOracleSessionMessage("assistant", text);
+    const persistedMessages = [...messagesWithUser, assistantMessage];
+
+    const updatedSession = await prisma.oracleSession.update({
+      where: { id: session.id },
+      data: {
+        messages: persistedMessages as Prisma.InputJsonArray,
+        ...(body.context !== undefined
+          ? { context: body.context as Prisma.InputJsonObject }
+          : {}),
+      },
+    });
+
+    res.json(
+      success({
+        sessionId: updatedSession.id,
+        reply: assistantMessage,
+        messages: normalizeOracleSessionMessages(updatedSession.messages),
+        context: normalizeOracleSessionContext(updatedSession.context),
+      }),
+    );
+  } catch (err) {
+    logger.error({ error: err }, "Oracle session message error");
+    res.status(502).json(error("Oracle response failed", 502));
+  }
+}
+
 // ── Route ────────────────────────────────────────────────────────
+
+oracleRouter.get("/session", async (req: AuthRequest, res) => {
+  try {
+    const session = await getOrCreateOracleSession(req.userId!);
+
+    res.json(
+      success({
+        sessionId: session.id,
+        messages: normalizeOracleSessionMessages(session.messages),
+        context: normalizeOracleSessionContext(session.context),
+      }),
+    );
+  } catch (err) {
+    logger.error({ error: err }, "Oracle session load error");
+    res.status(500).json(error("Failed to load oracle session", 500));
+  }
+});
+
+oracleRouter.delete("/session", async (req: AuthRequest, res) => {
+  try {
+    const session = await getOrCreateOracleSession(req.userId!);
+    const clearedSession = await prisma.oracleSession.update({
+      where: { id: session.id },
+      data: {
+        messages: [] as Prisma.InputJsonArray,
+      },
+    });
+
+    res.json(
+      success({
+        sessionId: clearedSession.id,
+        messages: normalizeOracleSessionMessages(clearedSession.messages),
+        context: normalizeOracleSessionContext(clearedSession.context),
+      }),
+    );
+  } catch (err) {
+    logger.error({ error: err }, "Oracle session clear error");
+    res.status(500).json(error("Failed to clear oracle session", 500));
+  }
+});
 
 oracleRouter.post("/message", async (req: AuthRequest, res) => {
   try {
-    const body = messageSchema.parse(req.body);
+    if (
+      typeof req.body === "object" &&
+      req.body !== null &&
+      "content" in req.body
+    ) {
+      await handleSessionMessage(req, res);
+      return;
+    }
+
+    const body = legacyMessageSchema.parse(req.body);
     const ctx = body.context ?? {};
 
     let messages: Array<{ content: string; role: "oracle" }> = [];
@@ -132,11 +327,11 @@ oracleRouter.post("/message", async (req: AuthRequest, res) => {
     res.json(success({ messages, llmGenerated }));
   } catch (err) {
     if (err instanceof z.ZodError) {
-      res.status(400).json({ ok: false, error: "Invalid request", details: err.errors });
+      res.status(400).json(error("Invalid request", 400, err.errors));
       return;
     }
     logger.error({ error: err }, "Oracle message error");
-    res.status(500).json({ ok: false, error: "Internal server error" });
+    res.status(500).json(error("Internal server error", 500));
   }
 });
 
@@ -153,16 +348,18 @@ interface ResolvedPrompt {
 function resolvePrompt(
   action: string,
   step: string,
-  ctx: z.infer<typeof messageSchema>["context"] & {},
+  ctx: z.infer<typeof legacyMessageSchema>["context"] & {},
 ): ResolvedPrompt | null {
+  const parsedDimensions = ctx.dimensions as OraclePromptDimensions | undefined;
+
   // Calibration commentary — after voice scan completes
   if (
     action === "scan-complete" &&
     ctx.calibrationResult &&
-    ctx.dimensions
+    parsedDimensions
   ) {
     const { system, userMessage } = buildCalibrationCommentary(
-      ctx.dimensions,
+      parsedDimensions,
       ctx.calibrationResult.tweetsAnalyzed,
       ctx.handle,
     );
@@ -170,17 +367,17 @@ function resolvePrompt(
   }
 
   // Blend preview tweet
-  if (action === "blend-preview" && ctx.dimensions && ctx.blendVoices) {
+  if (action === "blend-preview" && parsedDimensions && ctx.blendVoices) {
     const { system, userMessage } = buildBlendPreview(
-      ctx.dimensions,
-      ctx.blendVoices,
+      parsedDimensions,
+      ctx.blendVoices as OracleBlendVoices,
     );
     return { system, userMessage, taskType: "oracle_smart", maxTokens: 300, temperature: 0.7 };
   }
 
   // Dimension reaction for unusual combos
-  if (action === "dims-continue" && ctx.dimensions) {
-    const reaction = buildDimensionReaction(ctx.dimensions);
+  if (action === "dims-continue" && parsedDimensions) {
+    const reaction = buildDimensionReaction(parsedDimensions);
     if (reaction) {
       return {
         system: reaction.system,
@@ -197,7 +394,7 @@ function resolvePrompt(
     const { system, userMessage } = buildFreeTextResponse(ctx.freeText, {
       track: undefined, // will be set from body.track in a future pass
       step,
-      dimensions: ctx.dimensions,
+      dimensions: parsedDimensions,
     });
     return { system, userMessage, taskType: "oracle_fast", maxTokens: 100, temperature: 0.7 };
   }


### PR DESCRIPTION
## What changed
- add `OracleSession` to persist per-user Oracle messages and context
- add `GET /api/oracle/session`, `POST /api/oracle/message`, and `DELETE /api/oracle/session`
- call Claude Sonnet 4.6 for persisted Oracle replies and save both user and assistant messages
- add route coverage for session create/load, message persistence, and session clearing

## Testing
- `/Users/a13xperi/projects/atlas-backend/node_modules/.bin/prisma generate`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/atlas /Users/a13xperi/projects/atlas-backend/node_modules/.bin/prisma validate`
- `/Users/a13xperi/projects/atlas-backend/node_modules/.bin/jest services/api/src/__tests__/routes/oracle.test.ts --runInBand`
- `/Users/a13xperi/projects/atlas-backend/node_modules/.bin/tsc --noEmit`