### PR TITLE
fix(auth): normalize onboardingTrack case-insensitively (#788)

### DIFF
--- a/scripts/seed-anil.ts
+++ b/scripts/seed-anil.ts
@@ -25,7 +25,7 @@
 
 import "dotenv/config";
 
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, OnboardingTrack } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
@@ -200,7 +200,7 @@ async function ensureUser() {
     email: ANIL_EMAIL,
     displayName: "Anil",
     role: "MANAGER" as const,
-    onboardingTrack: "TRACK_A" as const,
+    onboardingTrack: OnboardingTrack.TRACK_A,
     xHandle: ANIL_X_HANDLE,
     tourCompleted: true,
     tourStep: 0,

--- a/services/api/src/__tests__/auth.test.ts
+++ b/services/api/src/__tests__/auth.test.ts
@@ -157,6 +157,7 @@ describe("GET /api/auth/me", () => {
         id: true,
         handle: true,
         role: true,
+        onboardingTrack: true,
         xBio: true,
         xAvatarUrl: true,
         xFollowerCount: true,

--- a/services/api/src/__tests__/lib/onboardingTrack.test.ts
+++ b/services/api/src/__tests__/lib/onboardingTrack.test.ts
@@ -1,0 +1,87 @@
+import { OnboardingTrack } from "@prisma/client";
+import { normalizeOnboardingTrack } from "../../lib/onboardingTrack";
+
+describe("normalizeOnboardingTrack", () => {
+  describe("canonical enum values", () => {
+    it("accepts TRACK_A", () => {
+      expect(normalizeOnboardingTrack("TRACK_A")).toBe(OnboardingTrack.TRACK_A);
+    });
+
+    it("accepts TRACK_B", () => {
+      expect(normalizeOnboardingTrack("TRACK_B")).toBe(OnboardingTrack.TRACK_B);
+    });
+  });
+
+  describe("short-form values", () => {
+    it('accepts "A" as TRACK_A', () => {
+      expect(normalizeOnboardingTrack("A")).toBe(OnboardingTrack.TRACK_A);
+    });
+
+    it('accepts "B" as TRACK_B', () => {
+      expect(normalizeOnboardingTrack("B")).toBe(OnboardingTrack.TRACK_B);
+    });
+  });
+
+  describe("case insensitivity (the bug this fixes)", () => {
+    it("accepts lowercase track_a", () => {
+      expect(normalizeOnboardingTrack("track_a")).toBe(OnboardingTrack.TRACK_A);
+    });
+
+    it("accepts lowercase track_b", () => {
+      expect(normalizeOnboardingTrack("track_b")).toBe(OnboardingTrack.TRACK_B);
+    });
+
+    it("accepts mixed case Track_A", () => {
+      expect(normalizeOnboardingTrack("Track_A")).toBe(OnboardingTrack.TRACK_A);
+    });
+
+    it('accepts lowercase "a"', () => {
+      expect(normalizeOnboardingTrack("a")).toBe(OnboardingTrack.TRACK_A);
+    });
+
+    it('accepts lowercase "b"', () => {
+      expect(normalizeOnboardingTrack("b")).toBe(OnboardingTrack.TRACK_B);
+    });
+  });
+
+  describe("whitespace tolerance", () => {
+    it("trims surrounding whitespace", () => {
+      expect(normalizeOnboardingTrack("  TRACK_A  ")).toBe(
+        OnboardingTrack.TRACK_A,
+      );
+    });
+
+    it("trims mixed-case with whitespace", () => {
+      expect(normalizeOnboardingTrack(" track_b ")).toBe(
+        OnboardingTrack.TRACK_B,
+      );
+    });
+  });
+
+  describe("invalid input", () => {
+    it("returns null for undefined", () => {
+      expect(normalizeOnboardingTrack(undefined)).toBeNull();
+    });
+
+    it("returns null for null", () => {
+      expect(normalizeOnboardingTrack(null)).toBeNull();
+    });
+
+    it("returns null for empty string", () => {
+      expect(normalizeOnboardingTrack("")).toBeNull();
+    });
+
+    it("returns null for unknown strings", () => {
+      expect(normalizeOnboardingTrack("TRACK_C")).toBeNull();
+      expect(normalizeOnboardingTrack("C")).toBeNull();
+      expect(normalizeOnboardingTrack("foo")).toBeNull();
+    });
+
+    it("returns null for non-string types", () => {
+      expect(normalizeOnboardingTrack(1)).toBeNull();
+      expect(normalizeOnboardingTrack({})).toBeNull();
+      expect(normalizeOnboardingTrack([])).toBeNull();
+      expect(normalizeOnboardingTrack(true)).toBeNull();
+    });
+  });
+});

--- a/services/api/src/lib/onboardingTrack.ts
+++ b/services/api/src/lib/onboardingTrack.ts
@@ -1,0 +1,21 @@
+import { OnboardingTrack } from "@prisma/client";
+
+/**
+ * Normalize an incoming onboardingTrack value (from HTTP body, seed script,
+ * or admin tool) into a typed Prisma OnboardingTrack enum value.
+ *
+ * Accepts: "A", "B", "TRACK_A", "TRACK_B" in any case (with or without
+ * surrounding whitespace). Returns null for undefined/null/unrecognized
+ * input so callers can cleanly skip the field instead of sending a string
+ * that Prisma will reject at runtime.
+ */
+export function normalizeOnboardingTrack(
+  value: unknown,
+): OnboardingTrack | null {
+  if (typeof value !== "string") return null;
+
+  const v = value.trim().toUpperCase();
+  if (v === "A" || v === "TRACK_A") return OnboardingTrack.TRACK_A;
+  if (v === "B" || v === "TRACK_B") return OnboardingTrack.TRACK_B;
+  return null;
+}

--- a/services/api/src/routes/auth.ts
+++ b/services/api/src/routes/auth.ts
@@ -10,6 +10,7 @@ import { error, success } from "../lib/response";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { rateLimit } from "../middleware/rateLimit";
 import { setAuthCookies, clearAuthCookies, getRefreshToken } from "../lib/cookies";
+import { normalizeOnboardingTrack } from "../lib/onboardingTrack";
 
 function signLegacyToken(userId: string): string {
   return jwt.sign({ userId }, config.JWT_SECRET, { expiresIn: "7d" });
@@ -28,7 +29,10 @@ const registerSchema = z.object({
   handle: z.string().min(1),
   email: z.string().email(),
   password: z.string().min(6),
-  onboardingTrack: z.enum(["A", "B", "TRACK_A", "TRACK_B"]).optional(),
+  // Accept any string — normalized downstream via normalizeOnboardingTrack().
+  // This keeps register lenient for legacy/alt frontends that may send
+  // "a" / "track_a" instead of the canonical "TRACK_A".
+  onboardingTrack: z.string().optional(),
 });
 
 const loginSchema = z.object({
@@ -95,18 +99,14 @@ authRouter.post("/register", async (req, res) => {
     // Hash password for legacy fallback (always store for dual-mode support)
     const passwordHash = await bcrypt.hash(body.password, 10);
 
+    const normalizedTrack = normalizeOnboardingTrack(body.onboardingTrack);
     const user = await prisma.user.create({
       data: {
         supabaseId,
         handle: body.handle,
         email: body.email,
         passwordHash,
-        ...(body.onboardingTrack && {
-          onboardingTrack:
-            body.onboardingTrack === "TRACK_A" || body.onboardingTrack === "A"
-              ? "TRACK_A"
-              : "TRACK_B",
-        }),
+        ...(normalizedTrack && { onboardingTrack: normalizedTrack }),
         voiceProfile: { create: {} },
       },
       include: { voiceProfile: true },
@@ -319,6 +319,7 @@ authRouter.get("/me", authenticate, async (req: AuthRequest, res) => {
         id: true,
         handle: true,
         role: true,
+        onboardingTrack: true,
         xBio: true,
         xAvatarUrl: true,
         xFollowerCount: true,

--- a/services/api/src/routes/x-auth.ts
+++ b/services/api/src/routes/x-auth.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import jwt from "jsonwebtoken";
+import { OnboardingTrack } from "@prisma/client";
 import { prisma } from "../lib/prisma";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { generateOAuthUrl, generateLoginOAuthUrl, exchangeCodeForTokens, exchangeLoginCodeForTokens, lookupUser, fetchTwitterUserProfile } from "../lib/twitter";
@@ -152,7 +153,7 @@ xAuthRouter.get("/callback", async (req, res) => {
           xBio,
           xAvatarUrl,
           xFollowerCount,
-          onboardingTrack: "TRACK_B",
+          onboardingTrack: OnboardingTrack.TRACK_B,
           voiceProfile: { create: {} },
         },
       });
@@ -396,7 +397,7 @@ twitterLoginRouter.get("/callback", async (req, res) => {
           xBio,
           xAvatarUrl,
           xFollowerCount,
-          onboardingTrack: "TRACK_B", // Twitter-first = Track B (Anil's flow)
+          onboardingTrack: OnboardingTrack.TRACK_B, // Twitter-first = Track B (Anil's flow)
           voiceProfile: { create: {} },
         },
       });

--- a/services/api/src/scripts/seed-anil.ts
+++ b/services/api/src/scripts/seed-anil.ts
@@ -19,7 +19,7 @@
 import * as dotenv from "dotenv";
 dotenv.config();
 
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, OnboardingTrack } from "@prisma/client";
 import { createClient } from "@supabase/supabase-js";
 import bcrypt from "bcryptjs";
 
@@ -84,7 +84,7 @@ async function main() {
       passwordHash,
       supabaseId,
       role: "MANAGER",
-      onboardingTrack: "TRACK_A",
+      onboardingTrack: OnboardingTrack.TRACK_A,
       voiceProfile: {
         create: {
           humor: 35,


### PR DESCRIPTION
## Summary
- Prisma's `OnboardingTrack` enum requires exact-case values (`TRACK_A`/`TRACK_B`). The register route's Zod schema only accepted 4 exact strings, and any mismatched-case write would throw at the Prisma layer at runtime.
- Adds `normalizeOnboardingTrack()` helper — case-insensitive, whitespace-tolerant, returns a typed Prisma enum or `null`. Used by `/api/auth/register`.
- Refactors `x-auth.ts` and both seed-anil scripts to use the `OnboardingTrack` enum import instead of loose string literals (catches future enum renames at compile time).
- Includes `onboardingTrack` in the `/me` select so the frontend actually sees which track the user is on.

## Test plan
- [x] 16 new unit tests in `services/api/src/__tests__/lib/onboardingTrack.test.ts` covering canonical / short / lowercase / mixed-case / whitespace / invalid input paths
- [x] Existing auth test updated to reflect new `/me` select shape
- [x] Full jest suite: **521/521 passing**
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)