### PR TITLE
feat(api): stricter per-route rate limiters for /register, /login, /api/docs

### DIFF
--- a/services/api/src/__tests__/middleware/rateLimit.test.ts
+++ b/services/api/src/__tests__/middleware/rateLimit.test.ts
@@ -205,4 +205,53 @@ describe("rateLimit middleware", () => {
     expect(first.status).toBe(200);
     expect(second.status).toBe(429);
   });
+
+  it("namespaced limiters keep independent counters from un-namespaced ones", async () => {
+    // Regression guard for the stacked-limiter bug: without a namespace arg,
+    // two limiters on the same route share one counter and the tighter window
+    // is silently overridden by whichever limiter ran first.
+    const { rateLimit, clearRateLimitStore } = loadRateLimitModule();
+    clearRateLimitStore();
+
+    const wideLimiter = rateLimit(10, 60 * 1000); // router-level 10/min
+    const tightLimiter = rateLimit(2, 15 * 60 * 1000, "login"); // per-route 2/15min
+
+    const app = express();
+    app.use(express.json());
+    app.use(requestIdMiddleware);
+    app.post("/login", wideLimiter, tightLimiter, (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    const first = await request(app).post("/login").set("X-Forwarded-For", "6.6.6.6");
+    const second = await request(app).post("/login").set("X-Forwarded-For", "6.6.6.6");
+    const third = await request(app).post("/login").set("X-Forwarded-For", "6.6.6.6");
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    // tight limiter (ns=login, max=2) trips even though wide (max=10) still has budget
+    expect(third.status).toBe(429);
+  });
+
+  it("namespaced limiters do not trip the default-namespace counter for the same route", async () => {
+    const { rateLimit, clearRateLimitStore } = loadRateLimitModule();
+    clearRateLimitStore();
+
+    const defaultLimiter = rateLimit(3, 60 * 1000); // default namespace
+    const namespacedLimiter = rateLimit(3, 60 * 1000, "register");
+
+    const appDefault = createIpLimitedApp(defaultLimiter);
+    const appNamespaced = createIpLimitedApp(namespacedLimiter);
+
+    // Burn the default-namespace counter for IP 7.7.7.7
+    await request(appDefault).get("/limited").set("X-Forwarded-For", "7.7.7.7");
+    await request(appDefault).get("/limited").set("X-Forwarded-For", "7.7.7.7");
+    await request(appDefault).get("/limited").set("X-Forwarded-For", "7.7.7.7");
+    const burned = await request(appDefault).get("/limited").set("X-Forwarded-For", "7.7.7.7");
+    expect(burned.status).toBe(429);
+
+    // Namespaced limiter for the same IP and route must start fresh
+    const fresh = await request(appNamespaced).get("/limited").set("X-Forwarded-For", "7.7.7.7");
+    expect(fresh.status).toBe(200);
+  });
 });

--- a/services/api/src/__tests__/routes/auth.test.ts
+++ b/services/api/src/__tests__/routes/auth.test.ts
@@ -192,6 +192,63 @@ describe("POST /api/auth/login", () => {
     expect(res.status).toBe(401);
     expectErrorResponse(res.body, "Invalid credentials");
   });
+
+  it("trips the per-route login limiter (5/window) before the router limit (10/window)", async () => {
+    // Queue up 5 invalid-credential responses so each attempt fails cleanly
+    // without touching any non-mocked dependency.
+    for (let i = 0; i < 5; i += 1) {
+      mockSupabaseAuth.signInWithPassword.mockResolvedValueOnce({
+        data: { session: null },
+        error: { message: "Invalid login credentials" },
+      });
+    }
+
+    const unique = "1.2.3.100"; // dedicated IP so no collision with other tests
+    for (let i = 0; i < 5; i += 1) {
+      const res = await request(app)
+        .post("/api/auth/login")
+        .set("X-Forwarded-For", unique)
+        .send({ email: "atlas@example.com", password: "wrong-password" });
+      expect(res.status).toBe(401);
+    }
+
+    // 6th attempt should be rate-limited by the dedicated loginRateLimiter
+    // (namespace "login", max=5). The router-level limiter (max=10) still has
+    // budget, so a 429 here proves the per-route limit is being enforced.
+    const limited = await request(app)
+      .post("/api/auth/login")
+      .set("X-Forwarded-For", unique)
+      .send({ email: "atlas@example.com", password: "wrong-password" });
+
+    expect(limited.status).toBe(429);
+    expect(limited.headers["retry-after"]).toEqual(expect.any(String));
+    expect(limited.body.error).toBe("Too many requests. Please try again later.");
+  });
+});
+
+describe("POST /api/auth/register — rate limiter", () => {
+  it("trips the per-route register limiter (5/window) before the router limit", async () => {
+    // Return 409 on each attempt — fast rejection path, still consumes the
+    // per-route counter (middleware runs before handler).
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({ id: "dup" });
+
+    const unique = "1.2.3.200";
+    for (let i = 0; i < 5; i += 1) {
+      const res = await request(app)
+        .post("/api/auth/register")
+        .set("X-Forwarded-For", unique)
+        .send({ handle: "dup", email: "dup@example.com", password: "secret123" });
+      expect(res.status).toBe(409);
+    }
+
+    const limited = await request(app)
+      .post("/api/auth/register")
+      .set("X-Forwarded-For", unique)
+      .send({ handle: "dup", email: "dup@example.com", password: "secret123" });
+
+    expect(limited.status).toBe(429);
+    expect(limited.body.error).toBe("Too many requests. Please try again later.");
+  });
 });
 
 describe("POST /api/auth/refresh", () => {

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -33,7 +33,7 @@ import { adminFlagsRouter } from "./routes/admin-flags";
 import { adminBackupRouter } from "./routes/admin-backup";
 import { twitterRouter } from "./routes/twitter";
 import { buildErrorResponse, requestIdMiddleware } from "./middleware/requestId";
-import { rateLimitByUser } from "./middleware/rateLimit";
+import { rateLimit, rateLimitByUser } from "./middleware/rateLimit";
 import { requestLogger } from "./middleware/requestLogger";
 import { logger } from "./lib/logger";
 import { formatErrorResponse } from "./lib/errors";
@@ -76,6 +76,15 @@ const generalApiLimiter = rateLimitByUser(
   config.RATE_LIMIT_GENERAL_WINDOW_MS,
 );
 
+// Protect the unauthenticated swagger UI — it parses a YAML file on every
+// request, so a burst of hits is expensive. IP-scoped, separate namespace
+// from any future auth-router limit.
+const docsRateLimiter = rateLimit(
+  config.RATE_LIMIT_DOCS_MAX_REQUESTS,
+  config.RATE_LIMIT_DOCS_WINDOW_MS,
+  "docs",
+);
+
 // Health check
 app.get("/health", async (_req, res) => {
   let database: "ok" | "error" = "ok";
@@ -111,7 +120,7 @@ app.get("/health", async (_req, res) => {
 });
 
 // Routes
-app.use("/api/docs", docsRouter);
+app.use("/api/docs", docsRateLimiter, docsRouter);
 app.use("/api/auth/x", xAuthRouter);
 app.use("/api/auth", authRouter);
 app.use("/api", generalApiLimiter);

--- a/services/api/src/lib/config.ts
+++ b/services/api/src/lib/config.ts
@@ -19,6 +19,15 @@ const envSchema = z.object({
   // Rate limiting
   RATE_LIMIT_AUTH_MAX_REQUESTS: z.coerce.number().int().positive().default(10),
   RATE_LIMIT_AUTH_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
+  // Stricter per-endpoint limits layered on top of the router-level auth limit
+  // to raise the cost of credential stuffing / mass-registration attacks.
+  RATE_LIMIT_LOGIN_MAX_REQUESTS: z.coerce.number().int().positive().default(5),
+  RATE_LIMIT_LOGIN_WINDOW_MS: z.coerce.number().int().positive().default(15 * 60_000),
+  RATE_LIMIT_REGISTER_MAX_REQUESTS: z.coerce.number().int().positive().default(5),
+  RATE_LIMIT_REGISTER_WINDOW_MS: z.coerce.number().int().positive().default(15 * 60_000),
+  // Docs (swagger UI) — unauthenticated and file-backed, keep it cheap per IP.
+  RATE_LIMIT_DOCS_MAX_REQUESTS: z.coerce.number().int().positive().default(30),
+  RATE_LIMIT_DOCS_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
   RATE_LIMIT_AI_GENERATION_MAX_REQUESTS: z.coerce.number().int().positive().default(20),
   RATE_LIMIT_AI_GENERATION_WINDOW_MS: z.coerce.number().int().positive().default(60 * 60 * 1000),
   RATE_LIMIT_GENERAL_MAX_REQUESTS: z.coerce.number().int().positive().default(100),

--- a/services/api/src/middleware/rateLimiter.ts
+++ b/services/api/src/middleware/rateLimiter.ts
@@ -116,11 +116,21 @@ function createRateLimit(maxRequests: number, windowMs: number, resolveKey: KeyR
   };
 }
 
-export function rateLimit(maxRequests: number, windowMs: number) {
+/**
+ * IP-based rate limiter.
+ *
+ * @param namespace Optional key-space prefix. Use this when stacking multiple
+ *   limiters on the same route (e.g. a tight per-route login limit on top of
+ *   the general auth router limit) so each limiter keeps its own counter.
+ *   Limiters that share a namespace share a counter, which causes the two
+ *   windows to collide and the tighter one to be silently ignored.
+ */
+export function rateLimit(maxRequests: number, windowMs: number, namespace?: string) {
+  const prefix = namespace ? `rl:${namespace}` : "rl";
   return createRateLimit(
     maxRequests,
     windowMs,
-    (req) => `rl:${getClientIp(req)}:${req.baseUrl}${req.path}`,
+    (req) => `${prefix}:${getClientIp(req)}:${req.baseUrl}${req.path}`,
   );
 }
 

--- a/services/api/src/routes/auth.ts
+++ b/services/api/src/routes/auth.ts
@@ -23,6 +23,21 @@ const authRateLimiter = rateLimit(
 );
 authRouter.use(authRateLimiter);
 
+// Stricter per-route limiters layered on top of authRateLimiter. Each uses
+// a distinct namespace so its counter doesn't collide with the router-level
+// limiter (same-namespace limiters would share a key and the tighter window
+// would be silently overridden by the wider window).
+const registerRateLimiter = rateLimit(
+  config.RATE_LIMIT_REGISTER_MAX_REQUESTS,
+  config.RATE_LIMIT_REGISTER_WINDOW_MS,
+  "register",
+);
+const loginRateLimiter = rateLimit(
+  config.RATE_LIMIT_LOGIN_MAX_REQUESTS,
+  config.RATE_LIMIT_LOGIN_WINDOW_MS,
+  "login",
+);
+
 // --- Schemas ---
 
 const registerSchema = z.object({
@@ -55,7 +70,7 @@ const linkAccountSchema = z.object({
 // --- Routes ---
 
 // Register — Supabase auth with legacy bcrypt fallback
-authRouter.post("/register", async (req, res) => {
+authRouter.post("/register", registerRateLimiter, async (req, res) => {
   try {
     const body = registerSchema.parse(req.body);
 
@@ -136,7 +151,7 @@ authRouter.post("/register", async (req, res) => {
 });
 
 // Login — Supabase auth with legacy bcrypt fallback
-authRouter.post("/login", async (req, res) => {
+authRouter.post("/login", loginRateLimiter, async (req, res) => {
   try {
     const body = loginSchema.parse(req.body);
 


### PR DESCRIPTION
## Summary
Adds tighter per-route rate limiters on public auth routes and the previously unprotected swagger docs endpoint.

- **Problem:** The router-level `authRateLimiter` (10/min per IP per path) was the only gate on `/register` and `/login`, and `/api/docs` (which parses a YAML file on every request) had no rate limit at all. The existing `rateLimit()` helper couldn't be safely stacked — two limiters on the same route shared a key and the tighter window was silently overridden.
- **Fix:**
  - `rateLimit()` takes a new optional `namespace` arg so stacked limiters keep independent counters.
  - New per-route `registerRateLimiter` (5/15min, ns=register) and `loginRateLimiter` (5/15min, ns=login) layered on top of the existing router-level limiter.
  - New `docsRateLimiter` (30/min, ns=docs) applied to `/api/docs` before `docsRouter`.
  - All thresholds/windows configurable via `RATE_LIMIT_{LOGIN,REGISTER,DOCS}_{MAX_REQUESTS,WINDOW_MS}` env vars.
- Uses existing in-memory fallback — no Redis dependency added.

## Test plan
- [x] 2 new regression guards in `rateLimit.test.ts` — namespace isolation (stacked limiters + cross-namespace)
- [x] 2 new route tests verifying `/login` and `/register` trip at 5/window before the router limit
- [x] Existing `/refresh` 10/min test still passes (unaffected)
- [x] `npx jest` — **525/525 passing**
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)