### PR TITLE
chore(api): replace console.error with pino logger in routes

### DIFF
--- a/services/api/src/routes/admin-flags.ts
+++ b/services/api/src/routes/admin-flags.ts
@@ -2,6 +2,7 @@ import { Router, Response } from "express";
 import { prisma } from "../lib/prisma";
 import { error, success } from "../lib/response";
 import { authenticate, AuthRequest } from "../middleware/auth";
+import { logger } from "../lib/logger";
 
 export const adminFlagsRouter = Router();
 adminFlagsRouter.use(authenticate);
@@ -59,7 +60,7 @@ adminFlagsRouter.get("/", async (req: AuthRequest, res) => {
 
     res.json(success({ flags: merged }));
   } catch (err: any) {
-    console.error("GET /api/admin/feature-flags error:", err);
+    logger.error({ err: err.message }, "GET /api/admin/feature-flags error");
     res.status(500).json(error("Failed to fetch feature flags", 500));
   }
 });
@@ -97,7 +98,10 @@ adminFlagsRouter.patch("/:key", async (req: AuthRequest, res) => {
 
     res.json(success({ flag }));
   } catch (err: any) {
-    console.error(`PATCH /api/admin/feature-flags/${String(req.params.key)} error:`, err);
+    logger.error(
+      { err: err.message, key: String(req.params.key) },
+      "PATCH /api/admin/feature-flags error",
+    );
     res.status(500).json(error("Failed to update feature flag", 500));
   }
 });

--- a/services/api/src/routes/analytics.ts
+++ b/services/api/src/routes/analytics.ts
@@ -5,6 +5,7 @@ import { error, success } from "../lib/response";
 import { buildErrorResponse } from "../middleware/requestId";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { calculateStreak, calculateStreakFromDates } from "../lib/streak";
+import { logger } from "../lib/logger";
 
 export const analyticsRouter = Router();
 analyticsRouter.use(authenticate);
@@ -893,7 +894,7 @@ analyticsRouter.get("/atlas-score", async (req: AuthRequest, res) => {
     if (err instanceof z.ZodError) {
       return res.status(400).json(error("Invalid request", 400, err.errors));
     }
-    console.error("atlas-score error:", err);
+    logger.error({ err: err.message }, "atlas-score error");
     res.status(500).json(error("Failed to compute Atlas Score", 500));
   }
 });
@@ -981,7 +982,7 @@ analyticsRouter.get("/leaderboard", async (req: AuthRequest, res) => {
     if (err instanceof z.ZodError) {
       return res.status(400).json(error("Invalid request", 400, err.errors));
     }
-    console.error("leaderboard error:", err);
+    logger.error({ err: err.message }, "leaderboard error");
     res.status(500).json(error("Failed to load leaderboard", 500));
   }
 });

--- a/services/api/src/routes/users.ts
+++ b/services/api/src/routes/users.ts
@@ -115,7 +115,10 @@ usersRouter.patch("/:userId/role", async (req: AuthRequest, res) => {
     if (err instanceof z.ZodError) {
       return res.status(400).json(error("Invalid role", 400, err.errors));
     }
-    console.error("PATCH /api/users/:userId/role error:", err);
+    logger.error(
+      { err: err.message, userId: req.params.userId },
+      "PATCH /api/users/:userId/role error",
+    );
     res.status(500).json(error("Failed to update role"));
   }
 });


### PR DESCRIPTION
## Summary
Five server-route error paths were logging via raw \`console.error\` instead of the shared \`pino\` logger — bypassing the structured-log pipeline and missing Railway's structured log search.

Replaced in:
- \`routes/admin-flags.ts\` (GET + PATCH handlers)
- \`routes/users.ts\` (role update handler)
- \`routes/analytics.ts\` (atlas-score, leaderboard handlers)

Each call now passes \`err.message\` and the relevant request context (user/key/etc.) as the structured field object.

**Left alone:**
- \`lib/config.ts\` — bootstrap code that runs before \`logger\` can be imported (the logger depends on config)
- \`services/api/src/scripts/*\` — standalone CLI seed/smoke scripts that intentionally use console for terminal output

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx jest\` — **525/525 passing**
- [x] Grep confirms no remaining \`console.*\` in non-script server code except the config bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)