### PR TITLE
fix(security): trust proxy + req.ip for rate limiter (C-2)

### DIFF
--- a/services/api/src/__tests__/middleware/rateLimit.test.ts
+++ b/services/api/src/__tests__/middleware/rateLimit.test.ts
@@ -12,6 +12,11 @@ type RedisExecResult = [[null, number], [null, number]];
 
 function createIpLimitedApp(limiter: RequestHandler) {
   const app = express();
+  // Mirror production: Railway is 1 proxy hop, so we trust 1 hop and let
+  // Express derive req.ip from X-Forwarded-For. Without this, every supertest
+  // request bucket-keys on the loopback socket, and the tests that set
+  // X-Forwarded-For to differentiate IPs would all collide.
+  app.set("trust proxy", 1);
   app.use(express.json());
   app.use(requestIdMiddleware);
   app.get("/limited", limiter, (_req, res) => {
@@ -22,6 +27,7 @@ function createIpLimitedApp(limiter: RequestHandler) {
 
 function createUserLimitedApp(limiter: RequestHandler) {
   const app = express();
+  app.set("trust proxy", 1);
   app.use(express.json());
   app.use(requestIdMiddleware);
   app.use((req, _res, next) => {
@@ -31,6 +37,20 @@ function createUserLimitedApp(limiter: RequestHandler) {
     }
     next();
   });
+  app.get("/limited", limiter, (_req, res) => {
+    res.json({ ok: true });
+  });
+  return app;
+}
+
+// App without trust proxy — used by the spoof-guard test to prove that when
+// Express is NOT configured to trust XFF, a client cannot change its rate
+// limit bucket by rotating the header. This matches the default-safe posture
+// in any environment where Railway's proxy hop isn't in front of us.
+function createUntrustedApp(limiter: RequestHandler) {
+  const app = express();
+  app.use(express.json());
+  app.use(requestIdMiddleware);
   app.get("/limited", limiter, (_req, res) => {
     res.json({ ok: true });
   });
@@ -217,6 +237,7 @@ describe("rateLimit middleware", () => {
     const tightLimiter = rateLimit(2, 15 * 60 * 1000, "login"); // per-route 2/15min
 
     const app = express();
+    app.set("trust proxy", 1); // mirror production so XFF → req.ip
     app.use(express.json());
     app.use(requestIdMiddleware);
     app.post("/login", wideLimiter, tightLimiter, (_req, res) => {
@@ -231,6 +252,36 @@ describe("rateLimit middleware", () => {
     expect(second.status).toBe(200);
     // tight limiter (ns=login, max=2) trips even though wide (max=10) still has budget
     expect(third.status).toBe(429);
+  });
+
+  it("spoof-guard: rotating X-Forwarded-For from one socket cannot dodge the limiter", async () => {
+    // C-2 regression guard. Before the trust-proxy fix, the rate limiter
+    // manually parsed X-Forwarded-For via a handmade helper, so any attacker
+    // hitting Express directly could rotate the header and allocate themselves
+    // infinite buckets. The fix drops the manual parser and delegates to
+    // req.ip, which — when Express is NOT configured to trust a proxy hop —
+    // falls back to the socket peer and is stable across requests from the
+    // same source. This test locks that behavior in: 10 requests with 10
+    // different XFF values from the same loopback socket must all land in
+    // the same bucket and trip the limiter at max.
+    const { rateLimit, clearRateLimitStore } = loadRateLimitModule();
+    clearRateLimitStore();
+
+    const limiter = rateLimit(5, 60 * 1000);
+    const app = createUntrustedApp(limiter); // deliberately no trust proxy
+
+    const statuses: number[] = [];
+    for (let i = 0; i < 10; i += 1) {
+      const res = await request(app)
+        .get("/limited")
+        .set("X-Forwarded-For", `9.9.9.${i}`); // rotating spoofed IP
+      statuses.push(res.status);
+    }
+
+    // First 5 should pass, remaining 5 should be 429 — proving the spoofed
+    // XFF values were ignored and all 10 requests shared one bucket.
+    expect(statuses.slice(0, 5)).toEqual([200, 200, 200, 200, 200]);
+    expect(statuses.slice(5)).toEqual([429, 429, 429, 429, 429]);
   });
 
   it("namespaced limiters do not trip the default-namespace counter for the same route", async () => {

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -46,6 +46,10 @@ import { startScheduler } from "./lib/scheduler";
 dotenv.config();
 
 const app = express();
+// Railway terminates TLS and forwards one hop. With trust proxy set,
+// Express parses X-Forwarded-For safely and exposes the validated client
+// IP as req.ip — so rate limiters can key on a value the client cannot spoof.
+app.set("trust proxy", 1);
 const PORT = config.PORT;
 
 const allowedOrigins = config.FRONTEND_URL.split(",")

--- a/services/api/src/middleware/rateLimiter.ts
+++ b/services/api/src/middleware/rateLimiter.ts
@@ -28,12 +28,6 @@ if (config.NODE_ENV !== "test") {
   cleanup.unref();
 }
 
-function getClientIp(req: Request): string {
-  const forwarded = req.headers["x-forwarded-for"];
-  const ip = typeof forwarded === "string" ? forwarded.split(",")[0].trim() : req.ip;
-  return ip || "unknown";
-}
-
 async function redisIncr(key: string, windowMs: number): Promise<{ count: number; ttl: number } | null> {
   const redis = getRedis();
   if (!redis) {
@@ -130,7 +124,7 @@ export function rateLimit(maxRequests: number, windowMs: number, namespace?: str
   return createRateLimit(
     maxRequests,
     windowMs,
-    (req) => `${prefix}:${getClientIp(req)}:${req.baseUrl}${req.path}`,
+    (req) => `${prefix}:${req.ip ?? "unknown"}:${req.baseUrl}${req.path}`,
   );
 }
 
@@ -138,6 +132,6 @@ export function rateLimitByUser(maxRequests: number, windowMs: number) {
   return createRateLimit(
     maxRequests,
     windowMs,
-    (req) => `rl:user:${(req as any).userId || getClientIp(req)}:${req.baseUrl}${req.path}`,
+    (req) => `rl:user:${(req as any).userId || (req.ip ?? "unknown")}:${req.baseUrl}${req.path}`,
   );
 }


### PR DESCRIPTION
## Summary
Closes Atlas audit **C-2**. Before this fix, the rate limiter manually parsed \`X-Forwarded-For\` via a hand-rolled \`getClientIp()\` that took the leftmost value with no proxy-hop validation — so any attacker hitting Express directly could rotate the header per request and allocate themselves infinite buckets, defeating the per-IP limits shipped in PR #159.

- \`index.ts\` → \`app.set("trust proxy", 1)\` right after \`express()\`. Railway = 1 hop, so Express's \`proxy-addr\` parser now derives the validated client IP.
- \`rateLimiter.ts\` → deleted \`getClientIp()\` entirely. Both key resolvers (\`rateLimit\`, \`rateLimitByUser\`) use \`req.ip ?? "unknown"\`. No manual header parsing, no attack surface.
- \`rateLimit.test.ts\`:
  - Existing helpers set \`trust proxy: 1\` so supertest \`.set("X-Forwarded-For")\` continues to differentiate IPs as the existing tests expect.
  - **New spoof-guard test**: 10 requests with 10 different spoofed XFF values from the same socket, on an app WITHOUT trust proxy — asserts first 5 pass and last 5 return 429, proving rotating XFF cannot dodge the limiter when Express isn't configured to trust it.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx jest\` — **526/526 passing** (was 525 → +1 spoof-guard)
- [x] \`grep -R "getClientIp" services/api/src\` — zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)