### PR TITLE
feat(queue): draft queue CRUD + scheduled publish endpoint

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/a13xperi/projects/atlas-backend/node_modules

--- a/prisma/migrations/20260409235500_add_draft_queue_items/migration.sql
+++ b/prisma/migrations/20260409235500_add_draft_queue_items/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "draft_queue_items" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "scheduledAt" TIMESTAMP(3),
+    "status" TEXT NOT NULL DEFAULT 'queued',
+    "platform" TEXT NOT NULL DEFAULT 'twitter',
+    "tweetId" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "draft_queue_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "draft_queue_items_userId_status_idx" ON "draft_queue_items"("userId", "status");
+
+-- CreateIndex
+CREATE INDEX "draft_queue_items_status_scheduledAt_idx" ON "draft_queue_items"("status", "scheduledAt");
+
+-- CreateIndex
+CREATE INDEX "draft_queue_items_userId_createdAt_idx" ON "draft_queue_items"("userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "draft_queue_items" ADD CONSTRAINT "draft_queue_items_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   referenceVoices   ReferenceVoice[]
   savedBlends       SavedBlend[]
   tweetDrafts       TweetDraft[]
+  draftQueueItems   DraftQueueItem[]
   analyticsEvents   AnalyticsEvent[]
   alertSubscriptions AlertSubscription[]
   sessions          Session[]
@@ -175,6 +176,26 @@ model TweetDraft {
   @@index([campaignId])
   @@index([userId, sortOrder])
   @@map("tweet_drafts")
+}
+
+model DraftQueueItem {
+  id          String   @id @default(cuid())
+  userId      String
+  content     String
+  scheduledAt DateTime?
+  status      String   @default("queued")
+  platform    String   @default("twitter")
+  tweetId     String?
+  metadata    Json?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, status])
+  @@index([status, scheduledAt])
+  @@index([userId, createdAt])
+  @@map("draft_queue_items")
 }
 
 enum DraftStatus {

--- a/services/api/src/__tests__/routes/queue.test.ts
+++ b/services/api/src/__tests__/routes/queue.test.ts
@@ -1,0 +1,308 @@
+import request from "supertest";
+import express from "express";
+import { requestIdMiddleware } from "../../middleware/requestId";
+import { expectSuccessResponse } from "../helpers/response";
+
+jest.mock("../../middleware/auth", () => ({
+  authenticate: jest.fn((req: any, res: any, next: any) => {
+    const header = req.headers.authorization;
+    if (!header?.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Missing authorization token" });
+    }
+
+    req.userId = "user-123";
+    next();
+  }),
+  AuthRequest: {},
+}));
+
+jest.mock("../../lib/prisma", () => ({
+  prisma: {
+    draftQueueItem: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    analyticsEvent: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../lib/twitter", () => ({
+  postTweet: jest.fn(),
+  refreshAccessToken: jest.fn(),
+}));
+
+import { prisma } from "../../lib/prisma";
+import { postTweet, refreshAccessToken } from "../../lib/twitter";
+import { queueRouter } from "../../routes/queue";
+
+const mockPrisma = prisma as any;
+const mockPostTweet = postTweet as jest.MockedFunction<typeof postTweet>;
+const mockRefreshAccessToken = refreshAccessToken as jest.MockedFunction<typeof refreshAccessToken>;
+
+const app = express();
+app.use(express.json());
+app.use(requestIdMiddleware);
+app.use("/api/queue", queueRouter);
+
+const AUTH = { Authorization: "Bearer mock_token" };
+const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+
+const mockQueueItem = {
+  id: "queue-1",
+  userId: "user-123",
+  content: "Queued tweet",
+  scheduledAt: null,
+  status: "queued",
+  platform: "twitter",
+  tweetId: null,
+  metadata: { tone: "direct" },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+    xAccessToken: "access-token",
+    xRefreshToken: "refresh-token",
+    xTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+  });
+  (mockPrisma.user.update as jest.Mock).mockResolvedValue({});
+  (mockPrisma.analyticsEvent.create as jest.Mock).mockResolvedValue({});
+  mockRefreshAccessToken.mockResolvedValue({
+    accessToken: "refreshed-access-token",
+    refreshToken: "refreshed-refresh-token",
+    expiresIn: 3600,
+  });
+  mockPostTweet.mockResolvedValue({ id: "tweet-123", text: "Queued tweet" });
+});
+
+describe("GET /api/queue", () => {
+  it("returns 401 without auth", async () => {
+    const res = await request(app).get("/api/queue");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Missing authorization token");
+  });
+
+  it("lists queue items and passes status filter", async () => {
+    (mockPrisma.draftQueueItem.findMany as jest.Mock).mockResolvedValueOnce([mockQueueItem]);
+
+    const res = await request(app)
+      .get("/api/queue?status=queued")
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<{ items: typeof mockQueueItem[] }>(res.body);
+
+    expect(data.items).toHaveLength(1);
+    expect(mockPrisma.draftQueueItem.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: "user-123",
+        status: "queued",
+      },
+      orderBy: [{ scheduledAt: "asc" }, { createdAt: "desc" }],
+    });
+  });
+});
+
+describe("GET /api/queue/scheduled", () => {
+  it("returns future scheduled items", async () => {
+    (mockPrisma.draftQueueItem.findMany as jest.Mock).mockResolvedValueOnce([
+      { ...mockQueueItem, status: "scheduled", scheduledAt: futureDate },
+    ]);
+
+    const res = await request(app)
+      .get("/api/queue/scheduled")
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+
+    expect(data.items[0].status).toBe("scheduled");
+    expect(mockPrisma.draftQueueItem.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: "user-123",
+        status: "scheduled",
+        scheduledAt: { gt: expect.any(Date) },
+      },
+      orderBy: { scheduledAt: "asc" },
+    });
+  });
+});
+
+describe("POST /api/queue", () => {
+  it("creates a queued item with defaults", async () => {
+    (mockPrisma.draftQueueItem.create as jest.Mock).mockResolvedValueOnce(mockQueueItem);
+
+    const res = await request(app)
+      .post("/api/queue")
+      .set(AUTH)
+      .send({ content: "Queued tweet" });
+
+    expect(res.status).toBe(201);
+    const data = expectSuccessResponse<{ item: typeof mockQueueItem }>(res.body);
+
+    expect(data.item.status).toBe("queued");
+    expect(mockPrisma.draftQueueItem.create).toHaveBeenCalledWith({
+      data: {
+        userId: "user-123",
+        content: "Queued tweet",
+        scheduledAt: undefined,
+        status: "queued",
+        platform: "twitter",
+      },
+    });
+    expect(mockPrisma.analyticsEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "DRAFT_CREATED",
+          metadata: expect.objectContaining({
+            source: "draft_queue",
+            queueItemId: "queue-1",
+            scheduled: false,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("creates a scheduled item when scheduledAt is in the future", async () => {
+    (mockPrisma.draftQueueItem.create as jest.Mock).mockResolvedValueOnce({
+      ...mockQueueItem,
+      status: "scheduled",
+      scheduledAt: futureDate,
+    });
+
+    const res = await request(app)
+      .post("/api/queue")
+      .set(AUTH)
+      .send({ content: "Scheduled tweet", scheduledAt: futureDate.toISOString() });
+
+    expect(res.status).toBe(201);
+    expect(mockPrisma.draftQueueItem.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        status: "scheduled",
+        scheduledAt: expect.any(Date),
+      }),
+    });
+  });
+});
+
+describe("PATCH /api/queue/:id", () => {
+  it("updates content and reschedules the queue item", async () => {
+    (mockPrisma.draftQueueItem.findFirst as jest.Mock).mockResolvedValueOnce(mockQueueItem);
+    (mockPrisma.draftQueueItem.update as jest.Mock).mockResolvedValueOnce({
+      ...mockQueueItem,
+      content: "Updated queued tweet",
+      status: "scheduled",
+      scheduledAt: futureDate,
+    });
+
+    const res = await request(app)
+      .patch("/api/queue/queue-1")
+      .set(AUTH)
+      .send({ content: "Updated queued tweet", scheduledAt: futureDate.toISOString() });
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+
+    expect(data.item.content).toBe("Updated queued tweet");
+    expect(mockPrisma.draftQueueItem.update).toHaveBeenCalledWith({
+      where: { id: "queue-1" },
+      data: {
+        content: "Updated queued tweet",
+        scheduledAt: expect.any(Date),
+        status: "scheduled",
+      },
+    });
+  });
+});
+
+describe("DELETE /api/queue/:id", () => {
+  it("deletes the queue item", async () => {
+    (mockPrisma.draftQueueItem.findFirst as jest.Mock).mockResolvedValueOnce(mockQueueItem);
+    (mockPrisma.draftQueueItem.delete as jest.Mock).mockResolvedValueOnce(mockQueueItem);
+
+    const res = await request(app)
+      .delete("/api/queue/queue-1")
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<{ deleted: boolean }>(res.body);
+
+    expect(data.deleted).toBe(true);
+    expect(mockPrisma.draftQueueItem.delete).toHaveBeenCalledWith({
+      where: { id: "queue-1" },
+    });
+  });
+});
+
+describe("POST /api/queue/:id/publish", () => {
+  it("publishes immediately to X and stores the tweet id", async () => {
+    (mockPrisma.draftQueueItem.findFirst as jest.Mock).mockResolvedValueOnce(mockQueueItem);
+    (mockPrisma.draftQueueItem.update as jest.Mock).mockResolvedValueOnce({
+      ...mockQueueItem,
+      status: "published",
+      tweetId: "tweet-123",
+    });
+
+    const res = await request(app)
+      .post("/api/queue/queue-1/publish")
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+
+    expect(data.item.status).toBe("published");
+    expect(data.tweet.id).toBe("tweet-123");
+    expect(mockPostTweet).toHaveBeenCalledWith("access-token", "Queued tweet");
+    expect(mockPrisma.draftQueueItem.update).toHaveBeenCalledWith({
+      where: { id: "queue-1" },
+      data: {
+        status: "published",
+        tweetId: "tweet-123",
+        scheduledAt: null,
+      },
+    });
+    expect(mockPrisma.analyticsEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "DRAFT_POSTED",
+          metadata: expect.objectContaining({
+            source: "draft_queue",
+            queueItemId: "queue-1",
+            tweetId: "tweet-123",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("returns 400 when X account is not linked", async () => {
+    (mockPrisma.draftQueueItem.findFirst as jest.Mock).mockResolvedValueOnce(mockQueueItem);
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+      xAccessToken: null,
+      xRefreshToken: null,
+      xTokenExpiresAt: null,
+    });
+
+    const res = await request(app)
+      .post("/api/queue/queue-1/publish")
+      .set(AUTH);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("X account not linked. Connect your X account first.");
+    expect(mockPostTweet).not.toHaveBeenCalled();
+  });
+});

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -26,6 +26,7 @@ import { transcribeRouter } from "./routes/transcribe";
 import { qaRouter } from "./routes/qa";
 import { adminRouter } from "./routes/admin";
 import { twitterRouter } from "./routes/twitter";
+import { queueRouter } from "./routes/queue";
 import { buildErrorResponse, requestIdMiddleware } from "./middleware/requestId";
 import { rateLimit } from "./middleware/rateLimit";
 import { requestLogger } from "./middleware/requestLogger";
@@ -128,6 +129,7 @@ app.use("/api/transcribe", transcribeRouter);
 app.use("/api/qa", qaRouter);
 app.use("/api/admin", adminRouter);
 app.use("/api/twitter", twitterRouter);
+app.use("/api/queue", queueRouter);
 
 // 404 handler — catch unknown routes before error handlers
 app.use((req, res) => {

--- a/services/api/src/routes/queue.ts
+++ b/services/api/src/routes/queue.ts
@@ -1,0 +1,291 @@
+import { Router } from "express";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+import { prisma } from "../lib/prisma";
+import { authenticate, AuthRequest } from "../middleware/auth";
+import { buildErrorResponse } from "../middleware/requestId";
+import { success } from "../lib/response";
+import { logger } from "../lib/logger";
+import { postTweet, refreshAccessToken } from "../lib/twitter";
+
+export const queueRouter = Router();
+queueRouter.use(authenticate);
+
+const queueStatusSchema = z.enum(["queued", "scheduled", "published", "failed"]);
+
+const createQueueItemSchema = z.object({
+  content: z.string().min(1),
+  scheduledAt: z.string().datetime().optional(),
+  platform: z.string().min(1).max(50).optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+const updateQueueItemSchema = z
+  .object({
+    content: z.string().min(1).optional(),
+    scheduledAt: z.string().datetime().nullable().optional(),
+    platform: z.string().min(1).max(50).optional(),
+    metadata: z.record(z.unknown()).optional(),
+  })
+  .refine((value) => Object.values(value).some((entry) => entry !== undefined), {
+    message: "At least one field must be provided",
+  });
+
+function getQueueStatus(scheduledAt: Date | null): "queued" | "scheduled" {
+  return scheduledAt ? "scheduled" : "queued";
+}
+
+async function getPublishAccessToken(userId: string): Promise<string> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { xAccessToken: true, xRefreshToken: true, xTokenExpiresAt: true },
+  });
+
+  if (!user?.xAccessToken) {
+    throw new Error("X account not linked. Connect your X account first.");
+  }
+
+  if (!user.xTokenExpiresAt || user.xTokenExpiresAt >= new Date() || !user.xRefreshToken) {
+    return user.xAccessToken;
+  }
+
+  const refreshed = await refreshAccessToken(user.xRefreshToken);
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      xAccessToken: refreshed.accessToken,
+      xRefreshToken: refreshed.refreshToken,
+      xTokenExpiresAt: new Date(Date.now() + refreshed.expiresIn * 1000),
+    },
+  });
+
+  return refreshed.accessToken;
+}
+
+queueRouter.get("/", async (req: AuthRequest, res) => {
+  try {
+    const status = req.query.status ? queueStatusSchema.parse(req.query.status) : undefined;
+
+    const items = await prisma.draftQueueItem.findMany({
+      where: {
+        userId: req.userId,
+        ...(status ? { status } : {}),
+      },
+      orderBy: [{ scheduledAt: "asc" }, { createdAt: "desc" }],
+    });
+
+    res.json(success({ items }));
+  } catch (err: any) {
+    if (err instanceof z.ZodError) {
+      return res
+        .status(400)
+        .json(buildErrorResponse(req, "Invalid request", { details: err.errors }));
+    }
+
+    logger.error({ err: err.message, userId: req.userId }, "Failed to list queue items");
+    res.status(500).json(buildErrorResponse(req, "Failed to load queue items"));
+  }
+});
+
+queueRouter.get("/scheduled", async (req: AuthRequest, res) => {
+  try {
+    const items = await prisma.draftQueueItem.findMany({
+      where: {
+        userId: req.userId,
+        status: "scheduled",
+        scheduledAt: { gt: new Date() },
+      },
+      orderBy: { scheduledAt: "asc" },
+    });
+
+    res.json(success({ items }));
+  } catch (err: any) {
+    logger.error({ err: err.message, userId: req.userId }, "Failed to list scheduled queue items");
+    res.status(500).json(buildErrorResponse(req, "Failed to load scheduled queue items"));
+  }
+});
+
+queueRouter.post("/", async (req: AuthRequest, res) => {
+  try {
+    const body = createQueueItemSchema.parse(req.body);
+    const scheduledAt = body.scheduledAt ? new Date(body.scheduledAt) : null;
+    const metadata = body.metadata as Prisma.InputJsonValue | undefined;
+
+    if (scheduledAt && scheduledAt <= new Date()) {
+      return res.status(400).json(buildErrorResponse(req, "Scheduled time must be in the future"));
+    }
+
+    const item = await prisma.draftQueueItem.create({
+      data: {
+        userId: req.userId!,
+        content: body.content,
+        scheduledAt: scheduledAt ?? undefined,
+        status: getQueueStatus(scheduledAt),
+        platform: body.platform ?? "twitter",
+        ...(metadata !== undefined ? { metadata } : {}),
+      },
+    });
+
+    await prisma.analyticsEvent.create({
+      data: {
+        userId: req.userId!,
+        type: "DRAFT_CREATED",
+        metadata: {
+          source: "draft_queue",
+          queueItemId: item.id,
+          scheduled: item.status === "scheduled",
+        },
+      },
+    });
+
+    logger.info({ userId: req.userId, queueItemId: item.id }, "Draft queue item created");
+    res.status(201).json(success({ item }));
+  } catch (err: any) {
+    if (err instanceof z.ZodError) {
+      return res
+        .status(400)
+        .json(buildErrorResponse(req, "Invalid request", { details: err.errors }));
+    }
+
+    logger.error({ err: err.message, userId: req.userId }, "Failed to create draft queue item");
+    res.status(500).json(buildErrorResponse(req, "Failed to create queue item"));
+  }
+});
+
+queueRouter.patch("/:id", async (req: AuthRequest, res) => {
+  try {
+    const body = updateQueueItemSchema.parse(req.body);
+    const metadata = body.metadata as Prisma.InputJsonValue | undefined;
+
+    const existing = await prisma.draftQueueItem.findFirst({
+      where: { id: req.params.id as string, userId: req.userId },
+    });
+
+    if (!existing) {
+      return res.status(404).json(buildErrorResponse(req, "Queue item not found"));
+    }
+
+    if (existing.status === "published") {
+      return res.status(400).json(buildErrorResponse(req, "Published queue items cannot be updated"));
+    }
+
+    let scheduledAt = existing.scheduledAt;
+    if (body.scheduledAt !== undefined) {
+      scheduledAt = body.scheduledAt ? new Date(body.scheduledAt) : null;
+      if (scheduledAt && scheduledAt <= new Date()) {
+        return res.status(400).json(buildErrorResponse(req, "Scheduled time must be in the future"));
+      }
+    }
+
+    const shouldResetStatus = body.scheduledAt !== undefined || existing.status === "failed";
+    const item = await prisma.draftQueueItem.update({
+      where: { id: existing.id },
+      data: {
+        ...(body.content !== undefined ? { content: body.content } : {}),
+        ...(body.platform !== undefined ? { platform: body.platform } : {}),
+        ...(metadata !== undefined ? { metadata } : {}),
+        ...(body.scheduledAt !== undefined ? { scheduledAt: scheduledAt ?? null } : {}),
+        ...(shouldResetStatus ? { status: getQueueStatus(scheduledAt) } : {}),
+      },
+    });
+
+    logger.info({ userId: req.userId, queueItemId: item.id }, "Draft queue item updated");
+    res.json(success({ item }));
+  } catch (err: any) {
+    if (err instanceof z.ZodError) {
+      return res
+        .status(400)
+        .json(buildErrorResponse(req, "Invalid request", { details: err.errors }));
+    }
+
+    logger.error({ err: err.message, userId: req.userId }, "Failed to update draft queue item");
+    res.status(500).json(buildErrorResponse(req, "Failed to update queue item"));
+  }
+});
+
+queueRouter.delete("/:id", async (req: AuthRequest, res) => {
+  try {
+    const existing = await prisma.draftQueueItem.findFirst({
+      where: { id: req.params.id as string, userId: req.userId },
+    });
+
+    if (!existing) {
+      return res.status(404).json(buildErrorResponse(req, "Queue item not found"));
+    }
+
+    await prisma.draftQueueItem.delete({ where: { id: existing.id } });
+
+    logger.info({ userId: req.userId, queueItemId: existing.id }, "Draft queue item deleted");
+    res.json(success({ deleted: true }));
+  } catch (err: any) {
+    logger.error({ err: err.message, userId: req.userId }, "Failed to delete draft queue item");
+    res.status(500).json(buildErrorResponse(req, "Failed to delete queue item"));
+  }
+});
+
+queueRouter.post("/:id/publish", async (req: AuthRequest, res) => {
+  try {
+    const item = await prisma.draftQueueItem.findFirst({
+      where: { id: req.params.id as string, userId: req.userId },
+    });
+
+    if (!item) {
+      return res.status(404).json(buildErrorResponse(req, "Queue item not found"));
+    }
+
+    if (item.status === "published") {
+      return res.status(400).json(buildErrorResponse(req, "Queue item has already been published"));
+    }
+
+    if (item.platform !== "twitter") {
+      return res.status(400).json(buildErrorResponse(req, `Unsupported platform: ${item.platform}`));
+    }
+
+    const accessToken = await getPublishAccessToken(req.userId!);
+
+    try {
+      const tweet = await postTweet(accessToken, item.content);
+
+      const updated = await prisma.draftQueueItem.update({
+        where: { id: item.id },
+        data: {
+          status: "published",
+          tweetId: tweet.id,
+          scheduledAt: null,
+        },
+      });
+
+      await prisma.analyticsEvent.create({
+        data: {
+          userId: req.userId!,
+          type: "DRAFT_POSTED",
+          metadata: {
+            source: "draft_queue",
+            queueItemId: item.id,
+            tweetId: tweet.id,
+          },
+        },
+      });
+
+      logger.info({ userId: req.userId, queueItemId: item.id, tweetId: tweet.id }, "Draft queue item published");
+      return res.json(success({ item: updated, tweet }));
+    } catch (err: any) {
+      await prisma.draftQueueItem.update({
+        where: { id: item.id },
+        data: { status: "failed" },
+      });
+
+      logger.error({ err: err.message, userId: req.userId, queueItemId: item.id }, "Failed to publish draft queue item");
+      return res
+        .status(502)
+        .json(buildErrorResponse(req, `Failed to publish queue item: ${err.message}`));
+    }
+  } catch (err: any) {
+    if (err.message === "X account not linked. Connect your X account first.") {
+      return res.status(400).json(buildErrorResponse(req, err.message));
+    }
+
+    logger.error({ err: err.message, userId: req.userId }, "Failed to publish draft queue item");
+    res.status(500).json(buildErrorResponse(req, "Failed to publish queue item"));
+  }
+});


### PR DESCRIPTION
## Summary

Adds a draft queue backend so the frontend can schedule, edit, and publish tweets through Atlas.

- New `DraftQueueItem` Prisma model — queue items table with `userId`, `content`, `scheduledAt`, `status`, `platform`, `tweetId`, `metadata`, `createdAt`, `updatedAt`.
- New `services/api/src/routes/queue.ts` (291 lines) — full CRUD + publish-to-Twitter router mounted at `/api/queue` in `services/api/src/index.ts`.
- New `services/api/src/__tests__/routes/queue.test.ts` (308 lines) — route test coverage.

## Endpoints (`/api/queue`)

- `GET    /api/queue` — list items (filter by `status`)
- `GET    /api/queue/scheduled` — list scheduled items
- `POST   /api/queue` — create item
- `PATCH  /api/queue/:id` — update item
- `DELETE /api/queue/:id` — delete item
- `POST   /api/queue/:id/publish` — publish to Twitter (handles OAuth token refresh)

## Frontend

Frontend client methods are already wired in `atlas-portal/src/lib/api.ts` under `api.queue.*` (line 521+). No frontend changes required for this PR.

## Post-merge steps

1. Run the Prisma migration on Railway:
   ```
   railway run npx prisma migrate deploy
   ```
2. Verify `DraftQueueItem` table exists in production DB.
3. Smoke-test `GET /api/queue` with a logged-in user.

## Heads-up for reviewer

This branch was cut from `72c0b5b` and has **not been rebased onto current `main`**. The raw diff against `main` includes a large number of unrelated reversions from main commits landed after the branch point. Before merge, rebase onto `main` (or cherry-pick commit `16ce3bd` onto a fresh branch) so only the queue changes remain.

## Test plan

- [ ] Rebase branch onto `main` and confirm diff reduces to queue files only
- [ ] `npm test` — new `queue.test.ts` passes
- [ ] Local: `POST /api/queue` creates an item, `GET /api/queue` lists it
- [ ] Local: `POST /api/queue/:id/publish` publishes to X with a valid user token
- [ ] Migrate Railway DB, hit `/api/queue` in production
- [ ] Frontend Draft Queue view loads and can create/edit/delete items