### PR TITLE
feat(voice-lab): sort followed creator list by follower count

### DIFF
--- a/services/api/src/routes/twitter.ts
+++ b/services/api/src/routes/twitter.ts
@@ -202,16 +202,23 @@ twitterRouter.get("/follows", authenticate, async (req: AuthRequest, res) => {
 });
 
 function mapFollows(users: TwitterFollowUser[]) {
-  return users.map((u) => ({
-    id: u.id,
-    handle: u.username,
-    display_name: u.name,
-    bio: u.description || null,
-    avatar_url: u.profile_image_url
-      ? u.profile_image_url.replace("_normal", "_400x400")
-      : null,
-    follower_count: u.public_metrics?.followers_count ?? 0,
-  }));
+  return users
+    .map((u) => ({
+      id: u.id,
+      handle: u.username,
+      display_name: u.name,
+      bio: u.description || null,
+      avatar_url: u.profile_image_url
+        ? u.profile_image_url.replace("_normal", "_400x400")
+        : null,
+      follower_count: u.public_metrics?.followers_count ?? 0,
+    }))
+    .sort((a, b) => {
+      if (b.follower_count !== a.follower_count) {
+        return b.follower_count - a.follower_count;
+      }
+      return a.handle.localeCompare(b.handle);
+    });
 }
 
 // ── GET /api/twitter/likes ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Sort the `mapFollows` output by `follower_count` descending (with handle alpha tiebreak) before storing in Redis cache
- Ensures the cache stores pre-sorted data so all clients receive a consistently ordered list
- Client-side sorts in `VoiceLabInspirationPicker`, `ImportFromXFollowsModal`, and `VoiceEditorModal` remain as defensive fallbacks

## Test plan
- [ ] Connect X account and navigate to Voice Lab → follows list should show highest-follower-count accounts first
- [ ] Open "Import from X follows" modal → same ordering
- [ ] Invalidate Redis cache (`DEL twitter:follows:*`) and re-fetch to confirm sorted order is persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)