### PR TITLE
fix(cors): harden origin middleware (C-4)

### DIFF
--- a/services/api/src/__tests__/lib/cors.test.ts
+++ b/services/api/src/__tests__/lib/cors.test.ts
@@ -1,0 +1,195 @@
+import type { CorsOptions } from "cors";
+import {
+  assertCorsConfig,
+  buildCorsOptions,
+  buildOriginMatcher,
+  DEFAULT_ALLOWED_HEADERS,
+  DEFAULT_ALLOWED_METHODS,
+  DEFAULT_EXPOSED_HEADERS,
+} from "../../lib/cors";
+
+/**
+ * Extract the `origin` callback from a CorsOptions so we can exercise it
+ * like cors itself would — `(origin, cb)` where the second arg reports
+ * `(err, allow)`. Keeps tests decoupled from the cors middleware surface.
+ */
+function originResolver(opts: CorsOptions) {
+  const origin = opts.origin;
+  if (typeof origin !== "function") {
+    throw new Error("expected origin to be a function");
+  }
+  return (incoming: string | undefined) =>
+    new Promise<{ err: Error | null; allow: boolean | string | RegExp | undefined }>((resolve) => {
+      // cors's origin-callback signature: (err, allow)
+      const cb = (err: Error | null, allow?: boolean | string | RegExp) => {
+        resolve({ err, allow });
+      };
+      // The real cors package passes `undefined` when there is no Origin
+      // header — match that exactly.
+      (origin as (
+        origin: string | undefined,
+        callback: (err: Error | null, allow?: boolean | string | RegExp) => void,
+      ) => void)(incoming, cb);
+    });
+}
+
+describe("buildOriginMatcher — regex metacharacter escaping (Bug #1)", () => {
+  it("treats `.` in an allowlist entry as a literal, not any-char", () => {
+    const match = buildOriginMatcher(["https://*.vercel.app"]);
+
+    // Legit preview subdomain — must still match.
+    expect(match("https://preview.vercel.app")).toBe(true);
+    expect(match("https://feature-branch.vercel.app")).toBe(true);
+
+    // The old regex (unescaped `.`) would let this through because
+    // `.vercel.app` would match the literal string `xvercelxapp`.
+    expect(match("https://x.vercelxapp")).toBe(false);
+    expect(match("https://preview-vercelxapp")).toBe(false);
+  });
+
+  it("escapes other regex metacharacters in literal entries", () => {
+    // `?` and `+` would otherwise alter the regex semantics. We want a
+    // literal string match for entries without `*`.
+    const match = buildOriginMatcher([
+      "https://foo.app?q=1",
+      "https://weird+host.test",
+    ]);
+
+    expect(match("https://foo.app?q=1")).toBe(true);
+    expect(match("https://weird+host.test")).toBe(true);
+
+    // Without escaping, `?` would make the prior char optional and accept
+    // `https://foo.ap`.
+    expect(match("https://foo.ap")).toBe(false);
+    // Without escaping, `+` would make `t` one-or-more.
+    expect(match("https://weirdhost.test")).toBe(false);
+  });
+
+  it("anchors patterns so partial matches are rejected", () => {
+    const match = buildOriginMatcher(["https://*.vercel.app"]);
+    expect(match("https://preview.vercel.app.evil.com")).toBe(false);
+    expect(match("http://preview.vercel.app")).toBe(false);
+  });
+
+  it("handles exact-match entries", () => {
+    const match = buildOriginMatcher(["https://delphi-atlas.vercel.app"]);
+    expect(match("https://delphi-atlas.vercel.app")).toBe(true);
+    expect(match("https://delphi-atlas.vercel.app/")).toBe(false);
+    expect(match("https://evil.com")).toBe(false);
+  });
+});
+
+describe("buildCorsOptions — origin callback (Bug #2)", () => {
+  const allow = ["https://delphi-atlas.vercel.app", "https://*.vercel.app"];
+
+  it("rejects no-origin requests explicitly instead of silently allowing", async () => {
+    const opts = buildCorsOptions(allow);
+    const resolve = originResolver(opts);
+
+    const { err, allow: verdict } = await resolve(undefined);
+    expect(err).toBeNull();
+    // The old code returned `true` here — that meant any tool without an
+    // Origin header (including curl, server-to-server) was handed full
+    // CORS credentials. Explicit `false` is the correct answer.
+    expect(verdict).toBe(false);
+  });
+
+  it("rejects unknown origins with callback(null, false) — never undefined", async () => {
+    const opts = buildCorsOptions(allow);
+    const resolve = originResolver(opts);
+
+    const { err, allow: verdict } = await resolve("https://evil.com");
+    expect(err).toBeNull();
+    // Specifically NOT `undefined` — that was the original bug.
+    expect(verdict).toBe(false);
+    expect(verdict).not.toBeUndefined();
+  });
+
+  it("accepts exact-match origins", async () => {
+    const opts = buildCorsOptions(allow);
+    const resolve = originResolver(opts);
+
+    const { err, allow: verdict } = await resolve("https://delphi-atlas.vercel.app");
+    expect(err).toBeNull();
+    expect(verdict).toBe(true);
+  });
+
+  it("accepts wildcard-match origins", async () => {
+    const opts = buildCorsOptions(allow);
+    const resolve = originResolver(opts);
+
+    const { err, allow: verdict } = await resolve("https://feature-xyz.vercel.app");
+    expect(err).toBeNull();
+    expect(verdict).toBe(true);
+  });
+
+  it("still rejects near-miss wildcard origins after metachar escape", async () => {
+    const opts = buildCorsOptions(allow);
+    const resolve = originResolver(opts);
+
+    const { allow: verdict } = await resolve("https://x.vercelxapp");
+    expect(verdict).toBe(false);
+  });
+});
+
+describe("assertCorsConfig — boot-time guard (Bug #3)", () => {
+  it("throws in production if the allowlist is empty", () => {
+    expect(() =>
+      assertCorsConfig({ allowedOrigins: [], nodeEnv: "production" }),
+    ).toThrow(/FRONTEND_URL is empty in production/);
+  });
+
+  it("is a no-op in development with an empty allowlist", () => {
+    expect(() =>
+      assertCorsConfig({ allowedOrigins: [], nodeEnv: "development" }),
+    ).not.toThrow();
+  });
+
+  it("is a no-op in staging with an empty allowlist", () => {
+    // Staging deploys occasionally boot before FRONTEND_URL is wired up —
+    // don't let the guard take down the staging API.
+    expect(() =>
+      assertCorsConfig({ allowedOrigins: [], nodeEnv: "staging" }),
+    ).not.toThrow();
+  });
+
+  it("is a no-op in production when at least one origin is configured", () => {
+    expect(() =>
+      assertCorsConfig({
+        allowedOrigins: ["https://delphi-atlas.vercel.app"],
+        nodeEnv: "production",
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("buildCorsOptions — explicit methods / headers hardening", () => {
+  const opts = buildCorsOptions(["https://delphi-atlas.vercel.app"]);
+
+  it("declares an explicit methods allowlist", () => {
+    expect(opts.methods).toEqual(DEFAULT_ALLOWED_METHODS);
+    expect(opts.methods).toEqual(
+      expect.arrayContaining(["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]),
+    );
+  });
+
+  it("declares an explicit allowedHeaders list", () => {
+    expect(opts.allowedHeaders).toEqual(DEFAULT_ALLOWED_HEADERS);
+    expect(opts.allowedHeaders).toEqual(
+      expect.arrayContaining(["Content-Type", "Authorization", "X-Request-Id"]),
+    );
+  });
+
+  it("exposes the request-id header so the client can correlate logs", () => {
+    expect(opts.exposedHeaders).toEqual(DEFAULT_EXPOSED_HEADERS);
+    expect(opts.exposedHeaders).toContain("X-Request-Id");
+  });
+
+  it("keeps credentials enabled", () => {
+    expect(opts.credentials).toBe(true);
+  });
+
+  it("sets a reasonable preflight cache maxAge", () => {
+    expect(opts.maxAge).toBeGreaterThan(0);
+  });
+});

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -38,6 +38,7 @@ import { rateLimit, rateLimitByUser } from "./middleware/rateLimit";
 import { requestLogger } from "./middleware/requestLogger";
 import { logger } from "./lib/logger";
 import { formatErrorResponse } from "./lib/errors";
+import { assertCorsConfig, buildCorsOptions } from "./lib/cors";
 import { prisma } from "./lib/prisma";
 import { getRedis } from "./lib/redis";
 import { initBot } from "./lib/telegram";
@@ -57,20 +58,12 @@ const allowedOrigins = config.FRONTEND_URL.split(",")
   .map((origin) => origin.trim())
   .filter(Boolean);
 
-app.use(
-  cors({
-    origin: (origin, callback) => {
-      if (!origin) return callback(null, true);
-      const allowed = allowedOrigins.some((ao) =>
-        ao.includes("*")
-          ? new RegExp("^" + ao.replace(/\*/g, ".*") + "$").test(origin)
-          : ao === origin
-      );
-      callback(null, allowed || undefined);
-    },
-    credentials: true,
-  })
-);
+// Refuse to boot a production API with an empty CORS allowlist. Under the
+// old middleware an empty list silently rejected every browser request —
+// fail loudly instead so the bad deploy is caught before traffic hits it.
+assertCorsConfig({ allowedOrigins, nodeEnv: config.NODE_ENV });
+
+app.use(cors(buildCorsOptions(allowedOrigins)));
 app.use(express.json({ limit: "10mb" }));
 app.use(cookieParser());
 app.use(requestIdMiddleware);

--- a/services/api/src/lib/cors.ts
+++ b/services/api/src/lib/cors.ts
@@ -1,0 +1,111 @@
+import type { CorsOptions } from "cors";
+
+/**
+ * CORS hardening — extracted so the origin-matching logic is unit-testable.
+ *
+ * The previous inline middleware had three sharp edges:
+ *
+ *   1. Wildcard compilation escaped `*` but nothing else, so an entry like
+ *      `https://*.vercel.app` silently became the regex
+ *      `^https://.*.vercel.app$` — where the literal dots are any-char
+ *      metachars. That over-matched `https://x.vercelxapp` and friends.
+ *
+ *   2. The origin callback ended with `callback(null, allowed || undefined)`.
+ *      Passing `undefined` as the second arg to cors is ambiguous, and the
+ *      `!origin → callback(null, true)` bypass unconditionally allowed any
+ *      request that lacked an Origin header even though `credentials: true`
+ *      was in effect. Both paths should reject explicitly.
+ *
+ *   3. `FRONTEND_URL.split(",").filter(Boolean)` can evaluate to `[]` in
+ *      production when someone forgets to set the env var, leaving the API
+ *      booted with zero allowed origins. That should fail loudly at boot,
+ *      not silently accept nothing.
+ */
+
+// Metacharacters that must be escaped before we substitute `*` → `.*`.
+// NOTE: `*` is intentionally absent — we want to convert it to `.*` after
+// everything else is literalised.
+const REGEX_METACHARS = /[.+?^${}()|[\]\\]/g;
+
+function globToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(REGEX_METACHARS, "\\$&");
+  return new RegExp("^" + escaped.replace(/\*/g, ".*") + "$");
+}
+
+/**
+ * Build an origin predicate. Patterns are compiled once so we don't rebuild
+ * a RegExp on every request.
+ */
+export function buildOriginMatcher(
+  allowedOrigins: readonly string[],
+): (origin: string) => boolean {
+  const matchers = allowedOrigins.map((ao) => {
+    if (ao.includes("*")) {
+      const re = globToRegExp(ao);
+      return (origin: string) => re.test(origin);
+    }
+    return (origin: string) => ao === origin;
+  });
+  return (origin: string) => matchers.some((match) => match(origin));
+}
+
+// Explicit allowlists — keep the attack surface small and obvious.
+export const DEFAULT_ALLOWED_METHODS = [
+  "GET",
+  "HEAD",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "OPTIONS",
+];
+
+export const DEFAULT_ALLOWED_HEADERS = [
+  "Content-Type",
+  "Authorization",
+  "X-Requested-With",
+  "X-Request-Id",
+];
+
+export const DEFAULT_EXPOSED_HEADERS = ["X-Request-Id"];
+
+/**
+ * Build the full cors options object for the API. The origin callback
+ * rejects no-origin requests explicitly via `callback(null, false)` — with
+ * `credentials: true` we never want to hand out CORS headers to a request
+ * that didn't declare an origin.
+ */
+export function buildCorsOptions(
+  allowedOrigins: readonly string[],
+): CorsOptions {
+  const isAllowed = buildOriginMatcher(allowedOrigins);
+  return {
+    origin: (origin, callback) => {
+      if (!origin) return callback(null, false);
+      return callback(null, isAllowed(origin));
+    },
+    credentials: true,
+    methods: DEFAULT_ALLOWED_METHODS,
+    allowedHeaders: DEFAULT_ALLOWED_HEADERS,
+    exposedHeaders: DEFAULT_EXPOSED_HEADERS,
+    maxAge: 600,
+  };
+}
+
+/**
+ * Boot-time guard: refuse to start a production API with no allowed
+ * origins. `.filter(Boolean)` on a malformed `FRONTEND_URL` can quietly
+ * collapse to `[]` and we'd rather crash now than drift into an API that
+ * rejects every browser client at runtime.
+ */
+export function assertCorsConfig(params: {
+  allowedOrigins: readonly string[];
+  nodeEnv: string;
+}): void {
+  const { allowedOrigins, nodeEnv } = params;
+  if (nodeEnv === "production" && allowedOrigins.length === 0) {
+    throw new Error(
+      "CORS: FRONTEND_URL is empty in production. Refusing to boot with no allowed origins.",
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Fixes three sharp edges in the CORS middleware at `services/api/src/index.ts:60-73` and extracts the logic into `lib/cors.ts` for unit testing.

- **Bug #1 — Regex metachar escaping.** Wildcard compilation only escaped `*` and left `.`, `?`, `+`, etc. as metacharacters. Entry `https://*.vercel.app` became `^https://.*.vercel.app$`, which over-matched strings like `https://x.vercelxapp`. Now all metachars are escaped before the `*` → `.*` substitution.
- **Bug #2 — Silent allow on no-origin / unknown origin.** Callback ended with `callback(null, allowed || undefined)` and had an unconditional `!origin → callback(null, true)` bypass — with `credentials: true` both handed out CORS access to requests that shouldn't get it. Replaced with explicit `callback(null, false)` rejections.
- **Bug #3 — Empty allowlist in prod.** `FRONTEND_URL.split(",").filter(Boolean)` could collapse to `[]` in production. `assertCorsConfig()` now throws at boot if `NODE_ENV === "production"` and the allowlist is empty.

Also hardens the middleware with explicit `methods`, `allowedHeaders`, `exposedHeaders` (exposing `X-Request-Id` for log correlation), and a 600s preflight `maxAge`.

## Test plan
- [x] `npx jest services/api/src/__tests__/lib/cors.test.ts` — 18 tests green, covering all 3 bugs + hardening surface
- [x] `npx tsc --noEmit` — clean
- [ ] CI (type-check + test job) green on push
- [ ] Post-merge: verify `api-production-9bef.up.railway.app/health` still responds and at least one browser request from `delphi-atlas.vercel.app` completes a preflight

🤖 Generated with [Claude Code](https://claude.com/claude-code)