### PR TITLE
security(x-auth): remove JWT from redirect query string

### DIFF
--- a/services/api/src/__tests__/routes/x-auth.test.ts
+++ b/services/api/src/__tests__/routes/x-auth.test.ts
@@ -25,14 +25,18 @@ jest.mock("../../lib/prisma", () => ({
   prisma: {
     user: {
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
       update: jest.fn(),
+      create: jest.fn(),
     },
   },
 }));
 
 jest.mock("../../lib/twitter", () => ({
   generateOAuthUrl: jest.fn(),
+  generateLoginOAuthUrl: jest.fn(),
   exchangeCodeForTokens: jest.fn(),
+  exchangeLoginCodeForTokens: jest.fn(),
   fetchTwitterUserProfile: jest.fn(),
   lookupUser: jest.fn(),
 }));
@@ -43,18 +47,25 @@ const setIntervalSpy = jest.spyOn(global, "setInterval").mockImplementation(
 );
 
 import { prisma } from "../../lib/prisma";
-import { generateOAuthUrl, exchangeCodeForTokens, fetchTwitterUserProfile } from "../../lib/twitter";
-import { xAuthRouter } from "../../routes/x-auth";
+import {
+  generateOAuthUrl,
+  exchangeCodeForTokens,
+  exchangeLoginCodeForTokens,
+  fetchTwitterUserProfile,
+} from "../../lib/twitter";
+import { xAuthRouter, twitterLoginRouter } from "../../routes/x-auth";
 
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockGenerateOAuthUrl = generateOAuthUrl as jest.MockedFunction<typeof generateOAuthUrl>;
 const mockExchangeCodeForTokens = exchangeCodeForTokens as jest.MockedFunction<typeof exchangeCodeForTokens>;
+const mockExchangeLoginCodeForTokens = exchangeLoginCodeForTokens as jest.MockedFunction<typeof exchangeLoginCodeForTokens>;
 const mockFetchTwitterUserProfile = fetchTwitterUserProfile as jest.MockedFunction<typeof fetchTwitterUserProfile>;
 
 const app = express();
 app.use(express.json());
 app.use(requestIdMiddleware);
 app.use("/api/auth/x", xAuthRouter);
+app.use("/api/auth/twitter", twitterLoginRouter);
 
 const AUTH = { Authorization: "Bearer mock_token" };
 
@@ -93,8 +104,16 @@ beforeEach(() => {
     },
   });
 
+  mockExchangeLoginCodeForTokens.mockResolvedValue({
+    accessToken: "access-token",
+    refreshToken: "refresh-token",
+    expiresIn: 3600,
+  });
+
   (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(null);
   (mockPrisma.user.update as jest.Mock).mockResolvedValue({ id: "user-123" });
+  (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(null);
+  (mockPrisma.user.create as jest.Mock).mockResolvedValue({ id: "user-456" });
 });
 
 describe("POST /api/auth/x/authorize", () => {
@@ -309,5 +328,77 @@ describe("POST /api/auth/x/disconnect", () => {
         xHandle: null,
       },
     });
+  });
+});
+
+describe("GET callback — C-5 JWT leak regression", () => {
+  // Regression for C-5: JWT must not appear in redirect query string.
+  // HttpOnly cookies set via setAuthCookies() already carry the session;
+  // query-string tokens leak via Referer, browser history, and upstream logs.
+
+  it("GET /api/auth/x/callback does not leak JWT in redirect URL, sets auth cookies", async () => {
+    // Initiate login to seed a login-flow PKCE state via GET /login
+    const loginRes = await request(app).get("/api/auth/x/login");
+    expect(loginRes.status).toBe(302);
+    const location = loginRes.headers.location as string;
+    const url = new URL(location);
+    const state = url.searchParams.get("state");
+    expect(state).toBeTruthy();
+
+    // Drive the GET callback
+    const res = await request(app)
+      .get("/api/auth/x/callback")
+      .query({ code: "oauth-code", state });
+
+    expect(res.status).toBe(302);
+
+    const redirect = res.headers.location as string;
+    expect(redirect).toContain("provider=twitter");
+    expect(redirect).not.toContain("token=");
+    // Defense in depth: no raw JWT fragment should appear in the query
+    expect(redirect).not.toMatch(/[?&]token=/);
+
+    // HttpOnly auth cookies must be set so the portal has the session
+    const setCookie = res.headers["set-cookie"] as unknown as string[] | string;
+    const cookies = Array.isArray(setCookie) ? setCookie : [setCookie ?? ""];
+    expect(cookies.some((c) => c.includes("atlas_access_token="))).toBe(true);
+    expect(cookies.some((c) => c.includes("atlas_refresh_token="))).toBe(true);
+    expect(cookies.some((c) => /atlas_access_token=.+HttpOnly/i.test(c))).toBe(true);
+
+    // Confirm token exchange + profile fetch actually happened
+    expect(mockExchangeCodeForTokens).toHaveBeenCalledWith("oauth-code", "verifier-123");
+    expect(mockFetchTwitterUserProfile).toHaveBeenCalledWith("access-token");
+  });
+
+  it("GET /api/auth/twitter/callback does not leak JWT in redirect URL, sets auth cookies", async () => {
+    // Initiate twitter login to seed PKCE state via GET /api/auth/twitter
+    const loginRes = await request(app).get("/api/auth/twitter");
+    expect(loginRes.status).toBe(302);
+    const location = loginRes.headers.location as string;
+    const url = new URL(location);
+    const state = url.searchParams.get("state");
+    expect(state).toBeTruthy();
+
+    // Drive the callback
+    const res = await request(app)
+      .get("/api/auth/twitter/callback")
+      .query({ code: "oauth-code", state });
+
+    expect(res.status).toBe(302);
+
+    const redirect = res.headers.location as string;
+    expect(redirect).toContain("provider=twitter");
+    expect(redirect).not.toContain("token=");
+    expect(redirect).not.toMatch(/[?&]token=/);
+
+    const setCookie = res.headers["set-cookie"] as unknown as string[] | string;
+    const cookies = Array.isArray(setCookie) ? setCookie : [setCookie ?? ""];
+    expect(cookies.some((c) => c.includes("atlas_access_token="))).toBe(true);
+    expect(cookies.some((c) => c.includes("atlas_refresh_token="))).toBe(true);
+    expect(cookies.some((c) => /atlas_access_token=.+HttpOnly/i.test(c))).toBe(true);
+
+    // twitterLoginRouter uses the login-specific exchange
+    expect(mockExchangeLoginCodeForTokens).toHaveBeenCalledWith("oauth-code", "verifier-123");
+    expect(mockFetchTwitterUserProfile).toHaveBeenCalledWith("access-token");
   });
 });

--- a/services/api/src/routes/x-auth.ts
+++ b/services/api/src/routes/x-auth.ts
@@ -162,7 +162,10 @@ xAuthRouter.get("/callback", async (req, res) => {
 
     const token = signLoginToken(user.id);
     setAuthCookies(res, token, refreshToken);
-    res.redirect(`${frontendUrl}/auth/callback?token=${encodeURIComponent(token)}&provider=twitter`);
+    // SECURITY (C-5): do NOT put JWT in query string. HttpOnly cookies
+    // set via setAuthCookies() already carry the session; query-string
+    // tokens leak via Referer headers, browser history, and upstream logs.
+    res.redirect(`${frontendUrl}/auth/callback?provider=twitter`);
   } catch (err: any) {
     logger.error({ err: err.message, stack: err.stack }, "Twitter login callback failed");
     res.redirect(`${frontendUrl}/?error=callback_failed`);
@@ -408,8 +411,9 @@ twitterLoginRouter.get("/callback", async (req, res) => {
     const token = signLoginToken(user.id);
     setAuthCookies(res, token, refreshToken);
 
-    // Redirect to frontend with token in query (frontend stores it)
-    res.redirect(`${frontendUrl}/auth/callback?token=${encodeURIComponent(token)}&provider=twitter`);
+    // SECURITY (C-5): HttpOnly cookies carry the session — no token in query.
+    // Query-string JWTs leak via Referer, browser history, and upstream logs.
+    res.redirect(`${frontendUrl}/auth/callback?provider=twitter`);
   } catch (err: any) {
     logger.error({ err: err.message, stack: err.stack }, "Twitter login callback failed");
     res.redirect(`${frontendUrl}/?error=callback_failed`);


### PR DESCRIPTION
## Summary

Fixes **C-5** (critical): the X OAuth callback was leaking the issued JWT via the redirect URL query string.

Before:
```
302 Location: https://delphi-atlas.vercel.app/auth/callback?token=<JWT>&provider=twitter
```

After:
```
302 Location: https://delphi-atlas.vercel.app/auth/callback?provider=twitter
```

Why this is a vulnerability:
- `Referer` headers on the callback page leak the JWT to any third-party resource the portal loads
- Browser history persists the JWT indefinitely
- Upstream HTTP loggers / CDN access logs capture the full URL including the JWT

`setAuthCookies(res, token, refreshToken)` is already invoked immediately before each redirect, and it sets `atlas_access_token` and `atlas_refresh_token` as HttpOnly / `SameSite=None; Secure` cookies in production. The portal can read the session from cookies alone; during the transition it tolerates both shapes, so it is safe to ship the backend fix first.

## Sites fixed (both in `services/api/src/routes/x-auth.ts`)

- `xAuthRouter.get("/callback", ...)`        — `GET /api/auth/x/callback`        (line ~165)
- `twitterLoginRouter.get("/callback", ...)` — `GET /api/auth/twitter/callback`  (line ~412)

Grep confirms no other `?token=...` or `token=${...}` patterns remain in `services/api/src/routes/`.

## Regression coverage

Two new tests in `services/api/src/__tests__/routes/x-auth.test.ts` under
`describe("GET callback — C-5 JWT leak regression", ...)`:

- Drive `GET /api/auth/x/login` -> `GET /api/auth/x/callback` with a valid mock OAuth exchange
- Drive `GET /api/auth/twitter`  -> `GET /api/auth/twitter/callback` with a valid mock OAuth exchange
- Each asserts:
  - Response is a `302`
  - `Location` header contains `provider=twitter`
  - `Location` header does NOT contain `token=`  (defense in depth: also `not.toMatch(/[?&]token=/)`)
  - `Set-Cookie` includes `atlas_access_token=` and `atlas_refresh_token=` with `HttpOnly`
  - The relevant token-exchange mock (`exchangeCodeForTokens` / `exchangeLoginCodeForTokens`) was called

`npx jest x-auth` result: **12 passed / 0 failed** (10 existing + 2 new).

`npx tsc --noEmit -p tsconfig.test.json` passes cleanly.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, smoke test production login flow through `/api/auth/twitter` — confirm the portal still authenticates via cookies alone
- [ ] Grep production access logs post-deploy to confirm no more `token=` query-string JWTs showing up

## Notes for the orchestrator

- Do **not** admin-merge — let CI run and merge normally
- Portal (`atlas-portal`) tolerates both old and new redirect shapes right now, so backend can ship first without breaking users. Portal cleanup (removing the query-string token reader) is a separate follow-up.
- `setAuthCookies(res, token, refreshToken)` was already present on BOTH call sites before this PR; no cookie-setting bug was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)