### PR TITLE
security(alerts): add requireUserId guard to every handler (#3947)

### DIFF
--- a/services/api/src/__tests__/routes/alerts.test.ts
+++ b/services/api/src/__tests__/routes/alerts.test.ts
@@ -9,10 +9,21 @@ import express from "express";
 import { alertsRouter } from "../../routes/alerts";
 import { requestIdMiddleware } from "../../middleware/requestId";
 
+// The `X-Test-Skip-UserId: 1` request header instructs the mock authenticate
+// middleware to bypass its normal `req.userId = "user-123"` assignment and
+// call next() with an unauthenticated request. This lets the defense-in-depth
+// guard tests exercise the `requireUserId` path in each handler without
+// rewiring jest.mock mid-suite.
 jest.mock("../../middleware/auth", () => ({
   authenticate: jest.fn((req: any, res: any, next: any) => {
     const header = req.headers.authorization;
     if (!header?.startsWith("Bearer ")) return res.status(401).json({ error: "Missing authorization token" });
+    if (req.headers["x-test-skip-userid"] === "1") {
+      // Simulate a middleware bypass: authentication "succeeded" but the
+      // userId never got populated. The handler's requireUserId guard is
+      // the only thing standing between the request and the Prisma query.
+      return next();
+    }
     req.userId = "user-123";
     next();
   }),
@@ -280,5 +291,164 @@ describe("DELETE /api/alerts/:id", () => {
     const res = await request(app).delete("/api/alerts/a-1").set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.data.success).toBe(true);
+  });
+});
+
+// Defense-in-depth guard tests — atlas-backend #3947. Each request carries
+// `X-Test-Skip-UserId: 1` which causes the mocked authenticate middleware to
+// call next() WITHOUT setting `req.userId`. The only thing preventing a
+// cross-user leak in that state is the `requireUserId` guard at the top of
+// each handler; these tests prove it fires and that no Prisma query runs.
+describe("defense-in-depth: requireUserId guard", () => {
+  const NO_USER = { Authorization: "Bearer mock_token", "X-Test-Skip-UserId": "1" };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GET /subscriptions returns 401 and does not query Prisma", async () => {
+    const res = await request(app).get("/api/alerts/subscriptions").set(NO_USER);
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Unauthorized");
+    expect(mockPrisma.alertSubscription.findMany).not.toHaveBeenCalled();
+  });
+
+  it("POST /subscriptions returns 401 and does not upsert", async () => {
+    const res = await request(app)
+      .post("/api/alerts/subscriptions")
+      .set(NO_USER)
+      .send({ type: "CATEGORY", value: "DeFi" });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Unauthorized");
+    expect(mockPrisma.alertSubscription.upsert).not.toHaveBeenCalled();
+  });
+
+  it("PATCH /subscriptions/:id returns 401 and does not update", async () => {
+    const res = await request(app)
+      .patch("/api/alerts/subscriptions/sub-1")
+      .set(NO_USER)
+      .send({ isActive: false });
+    expect(res.status).toBe(401);
+    expect(mockPrisma.alertSubscription.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.alertSubscription.update).not.toHaveBeenCalled();
+  });
+
+  it("DELETE /subscriptions/:id returns 401 and does not delete", async () => {
+    const res = await request(app).delete("/api/alerts/subscriptions/sub-1").set(NO_USER);
+    expect(res.status).toBe(401);
+    expect(mockPrisma.alertSubscription.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.alertSubscription.delete).not.toHaveBeenCalled();
+  });
+
+  it("GET /feed returns 401 and does not query alerts", async () => {
+    const res = await request(app).get("/api/alerts/feed").set(NO_USER);
+    expect(res.status).toBe(401);
+    expect(mockPrisma.alert.findMany).not.toHaveBeenCalled();
+  });
+
+  it("GET /:id returns 401 and does not query the alert", async () => {
+    const res = await request(app).get("/api/alerts/a-1").set(NO_USER);
+    expect(res.status).toBe(401);
+    expect(mockPrisma.alert.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("PATCH /:id returns 401 and does not update the alert", async () => {
+    const res = await request(app).patch("/api/alerts/a-1").set(NO_USER).send({});
+    expect(res.status).toBe(401);
+    expect(mockPrisma.alert.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.alert.update).not.toHaveBeenCalled();
+  });
+
+  it("DELETE /:id returns 401 and does not delete the alert", async () => {
+    const res = await request(app).delete("/api/alerts/a-1").set(NO_USER);
+    expect(res.status).toBe(401);
+    expect(mockPrisma.alert.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.alert.delete).not.toHaveBeenCalled();
+  });
+});
+
+// Verify that the authenticated userId flows through to every Prisma query
+// unchanged. These assertions catch the specific regression atlas-backend
+// #3947 is defending against: a query that omits `userId` from its where
+// clause would silently match every row in the table.
+describe("userId scoping on every query", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("POST /subscriptions upserts with userId in the compound key AND the create body", async () => {
+    (mockPrisma.alertSubscription.upsert as jest.Mock).mockResolvedValueOnce(mockSub);
+    await request(app)
+      .post("/api/alerts/subscriptions")
+      .set(AUTH)
+      .send({ type: "CATEGORY", value: "DeFi" });
+
+    expect(mockPrisma.alertSubscription.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId_type_value: { userId: "user-123", type: "CATEGORY", value: "DeFi" },
+        },
+        create: expect.objectContaining({ userId: "user-123" }),
+      }),
+    );
+  });
+
+  it("PATCH /subscriptions/:id scopes the ownership findFirst to userId", async () => {
+    (mockPrisma.alertSubscription.findFirst as jest.Mock).mockResolvedValueOnce(mockSub);
+    (mockPrisma.alertSubscription.update as jest.Mock).mockResolvedValueOnce(mockSub);
+
+    await request(app)
+      .patch("/api/alerts/subscriptions/sub-1")
+      .set(AUTH)
+      .send({ isActive: false });
+
+    expect(mockPrisma.alertSubscription.findFirst).toHaveBeenCalledWith({
+      where: { id: "sub-1", userId: "user-123" },
+    });
+  });
+
+  it("DELETE /subscriptions/:id scopes the ownership findFirst to userId", async () => {
+    (mockPrisma.alertSubscription.findFirst as jest.Mock).mockResolvedValueOnce(mockSub);
+    (mockPrisma.alertSubscription.delete as jest.Mock).mockResolvedValueOnce(mockSub);
+
+    await request(app).delete("/api/alerts/subscriptions/sub-1").set(AUTH);
+
+    expect(mockPrisma.alertSubscription.findFirst).toHaveBeenCalledWith({
+      where: { id: "sub-1", userId: "user-123" },
+    });
+  });
+
+  it("GET /feed passes userId (and any category filter) to findMany", async () => {
+    (mockPrisma.alert.findMany as jest.Mock).mockResolvedValueOnce([]);
+    await request(app).get("/api/alerts/feed?category=DeFi").set(AUTH);
+    expect(mockPrisma.alert.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user-123", category: "DeFi" },
+      }),
+    );
+  });
+
+  it("PATCH /:id scopes the ownership findFirst to userId", async () => {
+    const alert = { id: "a-1", userId: "user-123", title: "My Alert" };
+    (mockPrisma.alert.findFirst as jest.Mock).mockResolvedValueOnce(alert);
+    (mockPrisma.alert.update as jest.Mock).mockResolvedValueOnce({ ...alert, expiresAt: new Date() });
+
+    await request(app).patch("/api/alerts/a-1").set(AUTH).send({});
+
+    expect(mockPrisma.alert.findFirst).toHaveBeenCalledWith({
+      where: { id: "a-1", userId: "user-123" },
+    });
+  });
+
+  it("DELETE /:id scopes the ownership findFirst to userId", async () => {
+    const alert = { id: "a-1", userId: "user-123", title: "My Alert" };
+    (mockPrisma.alert.findFirst as jest.Mock).mockResolvedValueOnce(alert);
+    (mockPrisma.alert.delete as jest.Mock).mockResolvedValueOnce(alert);
+
+    await request(app).delete("/api/alerts/a-1").set(AUTH);
+
+    expect(mockPrisma.alert.findFirst).toHaveBeenCalledWith({
+      where: { id: "a-1", userId: "user-123" },
+    });
   });
 });

--- a/services/api/src/routes/alerts.ts
+++ b/services/api/src/routes/alerts.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import { Router, Response } from "express";
 import { z } from "zod";
 import { parsePagination } from "../lib/pagination";
 import { prisma } from "../lib/prisma";
@@ -24,13 +24,47 @@ const updateSubscriptionSchema = z.object({
   delivery: deliverySchema,
 });
 
+/**
+ * Defense-in-depth userId guard.
+ *
+ * `authenticate` already rejects unauthenticated requests with 401, so in
+ * normal operation `req.userId` is guaranteed to be set before any handler
+ * here runs. This helper exists for two reasons:
+ *
+ *   1. TypeScript narrowing. `AuthRequest.userId` is declared as
+ *      `string | undefined`, so every query used to carry a `req.userId!`
+ *      non-null assertion. A silent middleware-ordering regression could
+ *      then compile cleanly and leak every user's alert data to anonymous
+ *      callers. Narrowing to `string` at the top of each handler makes
+ *      the compiler refuse any query that forgets to scope.
+ *
+ *   2. Layered defense. If a future refactor ever moves `alertsRouter.use(
+ *      authenticate)` or introduces a pre-middleware that bypasses it, the
+ *      handler's own 401 response stops the request before it reaches a
+ *      Prisma query. This is the "alert security — add userId filter" fix
+ *      tracked as atlas-backend #3947.
+ *
+ * Returns the userId string on success, or `null` after having written a
+ * 401 response to `res`. Callers must early-return on `null`.
+ */
+function requireUserId(req: AuthRequest, res: Response): string | null {
+  if (!req.userId) {
+    res.status(401).json(buildErrorResponse(req, "Unauthorized"));
+    return null;
+  }
+  return req.userId;
+}
+
 // Get user's alert subscriptions
 alertsRouter.get("/subscriptions", async (req: AuthRequest, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+
   try {
     const { take, skip } = parsePagination(req.query, { limit: 20, offset: 0 });
 
     const subscriptions = await prisma.alertSubscription.findMany({
-      where: { userId: req.userId },
+      where: { userId },
       take,
       skip,
     });
@@ -45,16 +79,19 @@ alertsRouter.get("/subscriptions", async (req: AuthRequest, res) => {
 
 // Add subscription
 alertsRouter.post("/subscriptions", async (req: AuthRequest, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+
   try {
     const body = subscriptionSchema.parse(req.body);
 
     const subscription = await prisma.alertSubscription.upsert({
       where: {
-        userId_type_value: { userId: req.userId!, type: body.type, value: body.value },
+        userId_type_value: { userId, type: body.type, value: body.value },
       },
       update: { isActive: true, delivery: body.delivery || ["PORTAL"] },
       create: {
-        userId: req.userId!,
+        userId,
         type: body.type,
         value: body.value,
         delivery: body.delivery || ["PORTAL"],
@@ -79,11 +116,18 @@ alertsRouter.post("/subscriptions", async (req: AuthRequest, res) => {
 
 // Toggle subscription
 alertsRouter.patch("/subscriptions/:id", async (req: AuthRequest, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+
   try {
     const body = updateSubscriptionSchema.parse(req.body);
 
+    // Ownership check — scoped to this user. If another user owns the row
+    // (or no row exists), findFirst returns null and we 404 before the
+    // update ever runs. The subsequent update is keyed by primary id only,
+    // but it's protected by the prior check.
     const sub = await prisma.alertSubscription.findFirst({
-      where: { id: req.params.id as string, userId: req.userId },
+      where: { id: req.params.id as string, userId },
     });
     if (!sub) return res.status(404).json(buildErrorResponse(req, "Subscription not found"));
 
@@ -110,9 +154,14 @@ alertsRouter.patch("/subscriptions/:id", async (req: AuthRequest, res) => {
 
 // Delete subscription
 alertsRouter.delete("/subscriptions/:id", async (req: AuthRequest, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+
   try {
+    // Ownership check — see PATCH handler for why we scope findFirst by
+    // userId and only then delete by primary id.
     const sub = await prisma.alertSubscription.findFirst({
-      where: { id: req.params.id as string, userId: req.userId },
+      where: { id: req.params.id as string, userId },
     });
     if (!sub) return res.status(404).json(buildErrorResponse(req, "Subscription not found"));
 
@@ -127,11 +176,14 @@ alertsRouter.delete("/subscriptions/:id", async (req: AuthRequest, res) => {
 
 // Get recent alerts (feed) — must be before /:id to avoid matching "feed" as an ID
 alertsRouter.get("/feed", async (req: AuthRequest, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+
   try {
     const { take, skip } = parsePagination(req.query, { limit: 20, offset: 0 });
 
     const category = req.query.category as string | undefined;
-    const where: any = { userId: req.userId };
+    const where: any = { userId };
     if (category) {
       where.category = category;
     }
@@ -157,10 +209,13 @@ alertsRouter.get("/feed", async (req: AuthRequest, res) => {
 
 // Get single alert (ownership verified)
 alertsRouter.get("/:id", async (req: AuthRequest, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+
   try {
     const alertId = req.params.id as string;
     const alert = await prisma.alert.findFirst({
-      where: { id: alertId, userId: req.userId },
+      where: { id: alertId, userId },
     });
     if (!alert) return res.status(404).json(buildErrorResponse(req, "Alert not found"));
     res.json(success({ alert }));
@@ -171,10 +226,14 @@ alertsRouter.get("/:id", async (req: AuthRequest, res) => {
 
 // Dismiss/acknowledge alert (set expiresAt to now, ownership verified)
 alertsRouter.patch("/:id", async (req: AuthRequest, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+
   try {
     const alertId = req.params.id as string;
+    // Ownership check — scoped to this user before the update.
     const alert = await prisma.alert.findFirst({
-      where: { id: alertId, userId: req.userId },
+      where: { id: alertId, userId },
     });
     if (!alert) return res.status(404).json(buildErrorResponse(req, "Alert not found"));
 
@@ -190,10 +249,14 @@ alertsRouter.patch("/:id", async (req: AuthRequest, res) => {
 
 // Delete alert (ownership verified)
 alertsRouter.delete("/:id", async (req: AuthRequest, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+
   try {
     const alertId = req.params.id as string;
+    // Ownership check — scoped to this user before the delete.
     const alert = await prisma.alert.findFirst({
-      where: { id: alertId, userId: req.userId },
+      where: { id: alertId, userId },
     });
     if (!alert) return res.status(404).json(buildErrorResponse(req, "Alert not found"));
 


### PR DESCRIPTION
## Summary
Hardens `services/api/src/routes/alerts.ts` by adding an explicit `requireUserId` guard to every handler. Implements atlas-backend #3947 ("Fix alert security — add userId filter").

Every query in the file was already scoped by `userId`, but relied on a `req.userId!` non-null assertion + middleware-ordering guarantee. Any refactor that moves `authenticate` or adds a bypass would compile cleanly and leak all users' alert subscriptions + alert feeds to anonymous callers.

## Changes
- **New helper `requireUserId(req, res)`** — checks `req.userId`, writes 401 if missing, narrows return type to `string` on success. Called as the first line of every handler.
- **Every `req.userId!` non-null assertion removed** — handlers use the narrowed local `userId` binding. TypeScript would now reject a query that forgot to scope.
- **No response-shape or status-code changes** for valid requests.

## Test plan
- [x] `npx jest services/api/src/__tests__/routes/alerts.test.ts` — 34/34 green
  - 20 existing tests (unchanged, all pass)
  - **8 new defense-in-depth tests** — each handler returns 401 and never calls Prisma when the mocked authenticate bypasses the userId assignment
  - **6 new userId-scoping assertions** — each handler verifies `userId: "user-123"` flows through to its Prisma call
- [x] `npx tsc --noEmit` — clean
- [ ] CI green on push
- [ ] Post-merge: manual smoke — `/api/alerts/feed` with a valid token returns only the caller's rows; with no token returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)