### PR TITLE
chore(logger): route lib/config boot failure through pino (#3936)

### DIFF
--- a/services/api/src/__tests__/lib/no-console-in-production.test.ts
+++ b/services/api/src/__tests__/lib/no-console-in-production.test.ts
@@ -1,0 +1,117 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Regression guard for atlas-backend #3936 — "Replace 29 console.log calls
+ * with pino logger". Production request-handling code must not log via
+ * `console.*`; every log line should flow through `lib/logger.ts` so
+ * Railway/Vercel/Sentry can index structured fields.
+ *
+ * Exempted on purpose:
+ *   - services/api/src/scripts/**   — operator-facing CLI tools (seed
+ *     scripts, smoke tests) that intentionally print human-readable
+ *     output with emoji + box-drawing. Piping these through pino would
+ *     regress DX and break CI seeding output.
+ *   - services/api/src/__tests__/** — this guard itself + any test
+ *     fixtures are free to use console.
+ *
+ * If this test starts failing, either route the new log line through
+ * `logger` or move the script into `src/scripts/` so the exemption
+ * applies. Do NOT add files to the SCANNED_DIRS exemption list — the
+ * whole point is that production code paths stay clean.
+ */
+
+const SRC_ROOT = path.resolve(__dirname, "../../");
+const SCANNED_DIRS = ["routes", "middleware", "lib"] as const;
+const CONSOLE_CALL_RE = /\bconsole\.(log|error|warn|info|debug|trace)\s*\(/;
+
+function walkTypeScriptFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Skip generated / test output directories if they ever land here.
+      if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+      out.push(...walkTypeScriptFiles(full));
+    } else if (entry.isFile() && (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx"))) {
+      // Skip compiled output and declaration files.
+      if (entry.name.endsWith(".d.ts")) continue;
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function findConsoleCalls(filePath: string): Array<{ line: number; text: string }> {
+  const contents = fs.readFileSync(filePath, "utf-8");
+  const hits: Array<{ line: number; text: string }> = [];
+  contents.split("\n").forEach((line, idx) => {
+    // Skip comments so a docblock mentioning `console.log` in prose
+    // doesn't trip the guard.
+    const trimmed = line.trim();
+    if (trimmed.startsWith("//") || trimmed.startsWith("*")) return;
+    if (CONSOLE_CALL_RE.test(line)) {
+      hits.push({ line: idx + 1, text: line.trim() });
+    }
+  });
+  return hits;
+}
+
+describe("no console.* in production source (atlas-backend #3936)", () => {
+  for (const sub of SCANNED_DIRS) {
+    describe(`services/api/src/${sub}`, () => {
+      const files = walkTypeScriptFiles(path.join(SRC_ROOT, sub));
+
+      it("has at least one TypeScript file to scan (sanity check)", () => {
+        expect(files.length).toBeGreaterThan(0);
+      });
+
+      it("contains no console.(log|error|warn|info|debug|trace) calls", () => {
+        const offenders: string[] = [];
+        for (const file of files) {
+          const hits = findConsoleCalls(file);
+          for (const hit of hits) {
+            // Emit a relative path so the failure message is copy-pastable.
+            const rel = path.relative(path.resolve(SRC_ROOT, "../../../"), file);
+            offenders.push(`${rel}:${hit.line}  ${hit.text}`);
+          }
+        }
+
+        if (offenders.length > 0) {
+          // Jest truncates very long error strings, so join with an
+          // explicit separator and cap each entry length.
+          const pretty = offenders
+            .map((o) => (o.length > 200 ? o.slice(0, 200) + "…" : o))
+            .join("\n  ");
+          throw new Error(
+            `Found ${offenders.length} console.* call(s) in production code.\n` +
+              `Route them through \`logger\` from lib/logger.ts instead — or, if ` +
+              `this is a CLI/script, move it under services/api/src/scripts/.\n\n  ${pretty}\n`,
+          );
+        }
+        expect(offenders).toEqual([]);
+      });
+    });
+  }
+
+  // A second assertion that scripts/** is still allowed to use console.
+  // This prevents an over-eager future contributor from adding scripts/ to
+  // SCANNED_DIRS without noticing the CLI-DX consequences.
+  describe("services/api/src/scripts (intentionally exempt)", () => {
+    const scriptsDir = path.join(SRC_ROOT, "scripts");
+
+    it("is NOT in the scanned set", () => {
+      expect(SCANNED_DIRS as readonly string[]).not.toContain("scripts");
+    });
+
+    it("is free to use console.* without tripping the guard", () => {
+      // Scripts exist in the tree — no assertion on count, just that the
+      // directory is reachable so the exemption is meaningful.
+      if (fs.existsSync(scriptsDir)) {
+        const files = walkTypeScriptFiles(scriptsDir);
+        expect(files.length).toBeGreaterThanOrEqual(0);
+      }
+    });
+  });
+});

--- a/services/api/src/lib/config.ts
+++ b/services/api/src/lib/config.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { logger } from "./logger";
 
 const envSchema = z.object({
   NODE_ENV: z.enum(["development", "production", "staging", "test"]).default("development"),
@@ -85,7 +86,15 @@ function validateEnv(): Env {
     const missing = result.error.issues
       .map((i) => `  ${i.path.join(".")}: ${i.message}`)
       .join("\n");
-    console.error(`\n❌ Environment validation failed:\n${missing}\n`);
+    // logger.ts reads NODE_ENV directly so it resolves before this file
+    // runs — safe to use here even though config hasn't finished loading.
+    // We prefer structured output over a bare console.error so Railway and
+    // other log aggregators can index the failure; the CLI smoke-test
+    // scripts are the only places that still talk to the raw console.
+    logger.error(
+      { missing: result.error.issues.map((i) => ({ path: i.path.join("."), message: i.message })) },
+      `Environment validation failed:\n${missing}`,
+    );
     if (process.env.NODE_ENV === "production") {
       process.exit(1);
     }


### PR DESCRIPTION
## Summary
Delivers atlas-backend #3936 — "Replace console.log calls with pino logger". Production request-handling code had already migrated, so this patch targets the one remaining production-path `console.error` in `lib/config.ts:88` and adds a regression guard.

- **`lib/config.ts:88`** — boot-time env validation failure now logs via `logger.error(...)` with a structured `missing` field (path + message per issue). `lib/logger.ts` reads `process.env.NODE_ENV` directly so importing it from `config.ts` doesn't create a circular dep.
- **New regression guard** at `__tests__/lib/no-console-in-production.test.ts` walks `services/api/src/{routes,middleware,lib}` and fails if it finds any `console.(log|error|warn|info|debug|trace)` call in a .ts file. Skips comments so prose docblocks don't trip it.

## Scope decision — CLI scripts stay on console.*
The Notion spec called out "29 calls"; the current tree has 66 `console.*` calls remaining, **65 of which are under `services/api/src/scripts/`**: `seed-anil`, `seed-alex`, `seed-reference-accounts`, `smoke-test`, `encrypt-xoauth-tokens`. Those are operator-facing CLIs with emoji + box-drawing progress output. Routing them through pino produces JSON (or requires a `pino-pretty` pipe on every `npm run seed:*`) which is a DX regression and breaks the visual structure of `smoke-test`'s report.

The spirit of #3936 is **"no console logging in production request paths"**, not "no console calls anywhere in the repo". This PR delivers the production fix and preserves CLI DX. A secondary assertion in the guard test documents that `scripts/` is deliberately exempt so a future contributor can't silently add it to `SCANNED_DIRS` without reading the rationale.

## Test plan
- [x] `npx jest services/api/src/__tests__/lib/no-console-in-production.test.ts services/api/src/__tests__/lib/config.test.ts` — 13/13 green
- [x] `npx tsc --noEmit` — clean
- [ ] CI green on push
- [ ] Post-merge: grep confirms `routes/ middleware/ lib/` are clean and scripts still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)