### PR TITLE
feat(security): C-3 rotation backfill — encrypt existing XOAuth tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:backup": "./scripts/backup-db.sh",
     "db:backup:r2": "npx tsx scripts/backup-to-r2.ts",
     "smoke": "npx tsx services/api/src/scripts/smoke-test.ts",
+    "db:encrypt-xoauth": "npx tsx services/api/src/scripts/encrypt-xoauth-tokens.ts",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,12 @@ model User {
   xAccessToken      String?
   xRefreshToken     String?
   xTokenExpiresAt   DateTime?
+  // C-3: AES-256-GCM encrypted (format "v1:iv:tag:ct") token columns.
+  // Live alongside plaintext columns during the migration window — the
+  // read path prefers `*Enc` and falls back to plaintext, so either set
+  // of columns can be populated. See services/api/src/lib/crypto.ts.
+  xAccessTokenEnc   String?
+  xRefreshTokenEnc  String?
   xBio              String?
   xAvatarUrl        String?
   xFollowerCount    Int?

--- a/services/api/src/__tests__/lib/crypto.test.ts
+++ b/services/api/src/__tests__/lib/crypto.test.ts
@@ -1,0 +1,202 @@
+jest.mock("../../lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import crypto from "node:crypto";
+import {
+  __resetKeyCacheForTests,
+  buildTokenClear,
+  buildTokenWrite,
+  decryptToken,
+  encryptToken,
+  encryptionEnabled,
+  isEncrypted,
+  readAccessToken,
+  readRefreshToken,
+} from "../../lib/crypto";
+
+const ORIGINAL_KEY = process.env.TOKEN_ENCRYPTION_KEY;
+
+function setKey(key: string | undefined): void {
+  if (key === undefined) {
+    delete process.env.TOKEN_ENCRYPTION_KEY;
+  } else {
+    process.env.TOKEN_ENCRYPTION_KEY = key;
+  }
+  __resetKeyCacheForTests();
+}
+
+describe("crypto (XOAuth token encryption)", () => {
+  afterAll(() => {
+    setKey(ORIGINAL_KEY);
+  });
+
+  describe("with encryption disabled (no key)", () => {
+    beforeEach(() => setKey(undefined));
+
+    it("encryptionEnabled() returns false", () => {
+      expect(encryptionEnabled()).toBe(false);
+    });
+
+    it("encryptToken() passes plaintext through unchanged", () => {
+      expect(encryptToken("hello")).toBe("hello");
+    });
+
+    it("decryptToken() passes plaintext through unchanged", () => {
+      expect(decryptToken("hello")).toBe("hello");
+    });
+
+    it("buildTokenWrite() writes to plaintext columns only", () => {
+      const write = buildTokenWrite({
+        accessToken: "at",
+        refreshToken: "rt",
+        expiresAt: new Date("2026-01-01"),
+      });
+      expect(write.xAccessToken).toBe("at");
+      expect(write.xRefreshToken).toBe("rt");
+      expect(write.xAccessTokenEnc).toBeNull();
+      expect(write.xRefreshTokenEnc).toBeNull();
+      expect(write.xTokenExpiresAt).toEqual(new Date("2026-01-01"));
+    });
+
+    it("readAccessToken() prefers plaintext column when enc is absent", () => {
+      expect(readAccessToken({ xAccessToken: "plain", xAccessTokenEnc: null })).toBe(
+        "plain",
+      );
+    });
+  });
+
+  describe("with encryption enabled (hex key)", () => {
+    const hexKey = crypto.randomBytes(32).toString("hex");
+
+    beforeEach(() => setKey(hexKey));
+
+    it("encryptionEnabled() returns true", () => {
+      expect(encryptionEnabled()).toBe(true);
+    });
+
+    it("encrypt → decrypt roundtrips", () => {
+      const plaintext = "my-oauth-access-token-abc123";
+      const encrypted = encryptToken(plaintext);
+      expect(isEncrypted(encrypted)).toBe(true);
+      expect(encrypted.startsWith("v1:")).toBe(true);
+      expect(encrypted).not.toContain(plaintext);
+      expect(decryptToken(encrypted)).toBe(plaintext);
+    });
+
+    it("produces a fresh IV per encryption (ciphertexts differ)", () => {
+      const a = encryptToken("same-input");
+      const b = encryptToken("same-input");
+      expect(a).not.toBe(b);
+      expect(decryptToken(a)).toBe("same-input");
+      expect(decryptToken(b)).toBe("same-input");
+    });
+
+    it("decryptToken() throws on tampered ciphertext", () => {
+      const encrypted = encryptToken("secret");
+      const parts = encrypted.split(":");
+      // Flip a byte in the ciphertext segment
+      const tampered = Buffer.from(parts[3], "base64");
+      tampered[0] = tampered[0] ^ 0xff;
+      parts[3] = tampered.toString("base64");
+      expect(() => decryptToken(parts.join(":"))).toThrow();
+    });
+
+    it("decryptToken() passes plaintext through unchanged", () => {
+      expect(decryptToken("legacy-plaintext")).toBe("legacy-plaintext");
+    });
+
+    it("buildTokenWrite() writes to enc columns only, clearing plaintext", () => {
+      const write = buildTokenWrite({
+        accessToken: "at",
+        refreshToken: "rt",
+        expiresAt: new Date("2026-01-01"),
+      });
+      expect(write.xAccessToken).toBeNull();
+      expect(write.xRefreshToken).toBeNull();
+      expect(write.xAccessTokenEnc).not.toBeNull();
+      expect(write.xRefreshTokenEnc).not.toBeNull();
+      expect(isEncrypted(write.xAccessTokenEnc!)).toBe(true);
+      expect(isEncrypted(write.xRefreshTokenEnc!)).toBe(true);
+      expect(decryptToken(write.xAccessTokenEnc!)).toBe("at");
+      expect(decryptToken(write.xRefreshTokenEnc!)).toBe("rt");
+    });
+
+    it("buildTokenWrite() handles null refresh token gracefully", () => {
+      const write = buildTokenWrite({
+        accessToken: "at",
+        refreshToken: null,
+        expiresAt: null,
+      });
+      expect(write.xAccessTokenEnc).not.toBeNull();
+      expect(write.xRefreshTokenEnc).toBeNull();
+    });
+
+    it("readAccessToken() prefers the enc column and decrypts it", () => {
+      const enc = encryptToken("real-token");
+      expect(
+        readAccessToken({
+          xAccessToken: "stale-plaintext",
+          xAccessTokenEnc: enc,
+        }),
+      ).toBe("real-token");
+    });
+
+    it("readAccessToken() falls back to plaintext if enc is absent", () => {
+      expect(
+        readAccessToken({
+          xAccessToken: "legacy-plaintext",
+          xAccessTokenEnc: null,
+        }),
+      ).toBe("legacy-plaintext");
+    });
+
+    it("readRefreshToken() prefers the enc column and decrypts it", () => {
+      const enc = encryptToken("refresh-1");
+      expect(
+        readRefreshToken({
+          xRefreshToken: null,
+          xRefreshTokenEnc: enc,
+        }),
+      ).toBe("refresh-1");
+    });
+
+    it("buildTokenClear() returns all-null fragment", () => {
+      const clear = buildTokenClear();
+      expect(clear.xAccessToken).toBeNull();
+      expect(clear.xRefreshToken).toBeNull();
+      expect(clear.xAccessTokenEnc).toBeNull();
+      expect(clear.xRefreshTokenEnc).toBeNull();
+      expect(clear.xTokenExpiresAt).toBeNull();
+    });
+  });
+
+  describe("with encryption enabled (base64 key)", () => {
+    const b64Key = crypto.randomBytes(32).toString("base64");
+
+    beforeEach(() => setKey(b64Key));
+
+    it("accepts a base64-encoded key and roundtrips", () => {
+      expect(encryptionEnabled()).toBe(true);
+      const encrypted = encryptToken("hello");
+      expect(decryptToken(encrypted)).toBe("hello");
+    });
+  });
+
+  describe("with an invalid key", () => {
+    beforeEach(() => setKey("not-a-valid-32-byte-key"));
+
+    it("encryptionEnabled() returns false (graceful fallback)", () => {
+      expect(encryptionEnabled()).toBe(false);
+    });
+
+    it("encryptToken() falls through to plaintext", () => {
+      expect(encryptToken("hello")).toBe("hello");
+    });
+  });
+});

--- a/services/api/src/__tests__/scripts/encrypt-xoauth-tokens.test.ts
+++ b/services/api/src/__tests__/scripts/encrypt-xoauth-tokens.test.ts
@@ -1,0 +1,218 @@
+jest.mock("../../lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import crypto from "node:crypto";
+import {
+  __resetKeyCacheForTests,
+  decryptToken,
+  isEncrypted,
+} from "../../lib/crypto";
+import {
+  BackfillUserRow,
+  planRowMigration,
+  runBackfill,
+} from "../../scripts/encrypt-xoauth-tokens";
+
+const ORIGINAL_KEY = process.env.TOKEN_ENCRYPTION_KEY;
+
+function setKey(key: string | undefined): void {
+  if (key === undefined) {
+    delete process.env.TOKEN_ENCRYPTION_KEY;
+  } else {
+    process.env.TOKEN_ENCRYPTION_KEY = key;
+  }
+  __resetKeyCacheForTests();
+}
+
+describe("encrypt-xoauth-tokens backfill", () => {
+  beforeEach(() => {
+    setKey(crypto.randomBytes(32).toString("hex"));
+  });
+
+  afterAll(() => {
+    setKey(ORIGINAL_KEY);
+  });
+
+  describe("planRowMigration (pure decision matrix)", () => {
+    it("encrypts both columns when only plaintext is set", () => {
+      const row: BackfillUserRow = {
+        id: "u1",
+        xAccessToken: "access-plain",
+        xRefreshToken: "refresh-plain",
+        xAccessTokenEnc: null,
+        xRefreshTokenEnc: null,
+      };
+
+      const update = planRowMigration(row);
+
+      expect(update).not.toBeNull();
+      expect(update!.xAccessToken).toBeNull();
+      expect(update!.xRefreshToken).toBeNull();
+      expect(isEncrypted(update!.xAccessTokenEnc!)).toBe(true);
+      expect(isEncrypted(update!.xRefreshTokenEnc!)).toBe(true);
+      expect(decryptToken(update!.xAccessTokenEnc!)).toBe("access-plain");
+      expect(decryptToken(update!.xRefreshTokenEnc!)).toBe("refresh-plain");
+    });
+
+    it("only encrypts the plaintext half when the other side is already encrypted", () => {
+      const row: BackfillUserRow = {
+        id: "u2",
+        xAccessToken: "still-plain",
+        xRefreshToken: null,
+        xAccessTokenEnc: null,
+        xRefreshTokenEnc: "v1:already:encrypted:value",
+      };
+
+      const update = planRowMigration(row);
+
+      expect(update).not.toBeNull();
+      expect(update!.xAccessTokenEnc).toBeDefined();
+      expect(update!.xAccessToken).toBeNull();
+      // Refresh side untouched — both fields absent from the patch
+      expect(update).not.toHaveProperty("xRefreshTokenEnc");
+      expect(update).not.toHaveProperty("xRefreshToken");
+    });
+
+    it("returns null for rows that are already fully migrated", () => {
+      const row: BackfillUserRow = {
+        id: "u3",
+        xAccessToken: null,
+        xRefreshToken: null,
+        xAccessTokenEnc: "v1:done:done:done",
+        xRefreshTokenEnc: "v1:done:done:done",
+      };
+
+      expect(planRowMigration(row)).toBeNull();
+    });
+
+    it("returns null for rows that have no plaintext and no encrypted token at all", () => {
+      const row: BackfillUserRow = {
+        id: "u4",
+        xAccessToken: null,
+        xRefreshToken: null,
+        xAccessTokenEnc: null,
+        xRefreshTokenEnc: null,
+      };
+
+      expect(planRowMigration(row)).toBeNull();
+    });
+  });
+
+  describe("runBackfill (with mock Prisma)", () => {
+    function buildMockPrisma(rows: BackfillUserRow[]) {
+      const updates: { id: string; data: any }[] = [];
+      const prisma = {
+        user: {
+          findMany: jest.fn().mockResolvedValue(rows),
+          update: jest
+            .fn()
+            .mockImplementation(({ where, data }: { where: { id: string }; data: any }) => {
+              updates.push({ id: where.id, data });
+              return Promise.resolve();
+            }),
+        },
+      };
+      return { prisma, updates };
+    }
+
+    it("dry-run does not call prisma.user.update", async () => {
+      const { prisma, updates } = buildMockPrisma([
+        {
+          id: "a",
+          xAccessToken: "plain-a",
+          xRefreshToken: "plain-r",
+          xAccessTokenEnc: null,
+          xRefreshTokenEnc: null,
+        },
+      ]);
+
+      const stats = await runBackfill(prisma as any, { apply: false });
+
+      expect(updates).toHaveLength(0);
+      expect(stats.scanned).toBe(1);
+      expect(stats.migrated).toBe(1);
+      expect(stats.accessEncrypted).toBe(1);
+      expect(stats.refreshEncrypted).toBe(1);
+    });
+
+    it("apply mode writes encrypted columns and reports correct counts across mixed rows", async () => {
+      const rows: BackfillUserRow[] = [
+        // Row 1: full plaintext both sides → migrate both
+        {
+          id: "full-plain",
+          xAccessToken: "access-1",
+          xRefreshToken: "refresh-1",
+          xAccessTokenEnc: null,
+          xRefreshTokenEnc: null,
+        },
+        // Row 2: plaintext access only, refresh already encrypted → migrate access only
+        {
+          id: "half-migrated",
+          xAccessToken: "access-2",
+          xRefreshToken: null,
+          xAccessTokenEnc: null,
+          xRefreshTokenEnc: "v1:iv:tag:ct",
+        },
+        // Row 3: would never be returned by findMany in real life because the
+        // OR filter excludes it, but defend in depth — script must classify
+        // it as already migrated and skip.
+        {
+          id: "fully-migrated",
+          xAccessToken: null,
+          xRefreshToken: null,
+          xAccessTokenEnc: "v1:iv:tag:ct",
+          xRefreshTokenEnc: "v1:iv:tag:ct",
+        },
+      ];
+
+      const { prisma, updates } = buildMockPrisma(rows);
+      const stats = await runBackfill(prisma as any, { apply: true });
+
+      expect(stats.scanned).toBe(3);
+      expect(stats.migrated).toBe(2);
+      expect(stats.accessEncrypted).toBe(2);
+      expect(stats.refreshEncrypted).toBe(1);
+      expect(stats.skipped).toBe(1);
+
+      // Two writes — full-plain + half-migrated
+      expect(updates).toHaveLength(2);
+      const fullPlainUpdate = updates.find((u) => u.id === "full-plain")!;
+      expect(fullPlainUpdate.data.xAccessToken).toBeNull();
+      expect(fullPlainUpdate.data.xRefreshToken).toBeNull();
+      expect(isEncrypted(fullPlainUpdate.data.xAccessTokenEnc)).toBe(true);
+      expect(isEncrypted(fullPlainUpdate.data.xRefreshTokenEnc)).toBe(true);
+
+      const halfUpdate = updates.find((u) => u.id === "half-migrated")!;
+      expect(halfUpdate.data.xAccessToken).toBeNull();
+      expect(isEncrypted(halfUpdate.data.xAccessTokenEnc)).toBe(true);
+      // Refresh side must NOT be re-encrypted
+      expect(halfUpdate.data).not.toHaveProperty("xRefreshTokenEnc");
+      expect(halfUpdate.data).not.toHaveProperty("xRefreshToken");
+    });
+
+    it("is idempotent — re-running on already-migrated rows is a no-op", async () => {
+      const rows: BackfillUserRow[] = [
+        {
+          id: "done",
+          xAccessToken: null,
+          xRefreshToken: null,
+          xAccessTokenEnc: "v1:iv:tag:ct",
+          xRefreshTokenEnc: "v1:iv:tag:ct",
+        },
+      ];
+
+      const { prisma, updates } = buildMockPrisma(rows);
+      const stats = await runBackfill(prisma as any, { apply: true });
+
+      expect(updates).toHaveLength(0);
+      expect(stats.migrated).toBe(0);
+      expect(stats.skipped).toBe(1);
+    });
+  });
+});

--- a/services/api/src/lib/crypto.ts
+++ b/services/api/src/lib/crypto.ts
@@ -1,0 +1,228 @@
+import crypto from "node:crypto";
+import { logger } from "./logger";
+
+/**
+ * XOAuth token encryption at rest (C-3).
+ *
+ * Design:
+ * - AES-256-GCM with a 32-byte key read from `TOKEN_ENCRYPTION_KEY`
+ *   (accepts hex-encoded or base64-encoded).
+ * - Ciphertext format: `v1:<iv_b64>:<tag_b64>:<ct_b64>`
+ * - If the env var is missing/invalid, encryption is DISABLED and all
+ *   helpers fall through to the plaintext columns on User. This keeps
+ *   existing deployments working during the migration window and lets
+ *   us ship code ahead of the backfill.
+ * - Dual-column schema: `xAccessToken`/`xRefreshToken` (plaintext, legacy)
+ *   live alongside `xAccessTokenEnc`/`xRefreshTokenEnc` (ciphertext).
+ *   Reads prefer enc and fall back to plaintext; writes target whichever
+ *   column set is active based on whether encryption is enabled.
+ */
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_LENGTH = 32;
+const IV_LENGTH = 12;
+const VERSION = "v1";
+
+// `undefined` = not yet resolved, `null` = resolved but disabled, Buffer = enabled.
+let cachedKey: Buffer | null | undefined;
+
+function loadKey(): Buffer | null {
+  if (cachedKey !== undefined) return cachedKey;
+
+  const raw = process.env.TOKEN_ENCRYPTION_KEY;
+  if (!raw) {
+    cachedKey = null;
+    return null;
+  }
+
+  try {
+    let key: Buffer;
+    if (/^[0-9a-f]{64}$/i.test(raw)) {
+      key = Buffer.from(raw, "hex");
+    } else {
+      key = Buffer.from(raw, "base64");
+    }
+    if (key.length !== KEY_LENGTH) {
+      throw new Error(`Expected ${KEY_LENGTH}-byte key, got ${key.length}`);
+    }
+    cachedKey = key;
+    return cachedKey;
+  } catch (err: any) {
+    logger.error(
+      { err: err.message },
+      "TOKEN_ENCRYPTION_KEY is invalid — falling through to plaintext XOAuth token storage",
+    );
+    cachedKey = null;
+    return null;
+  }
+}
+
+/** True if a valid `TOKEN_ENCRYPTION_KEY` is present. */
+export function encryptionEnabled(): boolean {
+  return loadKey() !== null;
+}
+
+/** True if the value looks like a `v1:` encrypted token. */
+export function isEncrypted(value: string | null | undefined): boolean {
+  return typeof value === "string" && value.startsWith(`${VERSION}:`);
+}
+
+/** Encrypt a plaintext token. If encryption is disabled, returns the plaintext unchanged. */
+export function encryptToken(plaintext: string): string {
+  const key = loadKey();
+  if (!key) return plaintext;
+
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+
+  return [
+    VERSION,
+    iv.toString("base64"),
+    tag.toString("base64"),
+    ciphertext.toString("base64"),
+  ].join(":");
+}
+
+/**
+ * Decrypt a ciphertext produced by `encryptToken`.
+ * - Plaintext-looking values pass through unchanged (plaintext fallback).
+ * - Throws only if the value *looks* encrypted (`v1:` prefix) but cannot be decrypted.
+ */
+export function decryptToken(value: string): string {
+  if (!isEncrypted(value)) return value;
+
+  const key = loadKey();
+  if (!key) {
+    throw new Error(
+      "Cannot decrypt XOAuth token: TOKEN_ENCRYPTION_KEY is not set or invalid",
+    );
+  }
+
+  const parts = value.split(":");
+  if (parts.length !== 4) {
+    throw new Error("Malformed encrypted XOAuth token (expected 4 segments)");
+  }
+  const [, ivB64, tagB64, ctB64] = parts;
+  const iv = Buffer.from(ivB64, "base64");
+  const tag = Buffer.from(tagB64, "base64");
+  const ct = Buffer.from(ctB64, "base64");
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([decipher.update(ct), decipher.final()]);
+  return plaintext.toString("utf8");
+}
+
+// ─── Prisma write helpers ─────────────────────────────────────────────
+
+export interface TokenWriteFragment {
+  xAccessToken: string | null;
+  xRefreshToken: string | null;
+  xAccessTokenEnc: string | null;
+  xRefreshTokenEnc: string | null;
+  xTokenExpiresAt: Date | null;
+}
+
+/**
+ * Build the `data` fragment for a Prisma write that sets X tokens.
+ * When encryption is enabled, writes go to the `*Enc` columns and the
+ * plaintext columns are cleared to `null`. When disabled, the legacy
+ * plaintext columns are populated and the `*Enc` columns stay `null`.
+ */
+export function buildTokenWrite(args: {
+  accessToken: string | null;
+  refreshToken: string | null;
+  expiresAt: Date | null;
+}): TokenWriteFragment {
+  if (encryptionEnabled()) {
+    return {
+      xAccessToken: null,
+      xRefreshToken: null,
+      xAccessTokenEnc: args.accessToken ? encryptToken(args.accessToken) : null,
+      xRefreshTokenEnc: args.refreshToken ? encryptToken(args.refreshToken) : null,
+      xTokenExpiresAt: args.expiresAt,
+    };
+  }
+  return {
+    xAccessToken: args.accessToken,
+    xRefreshToken: args.refreshToken,
+    xAccessTokenEnc: null,
+    xRefreshTokenEnc: null,
+    xTokenExpiresAt: args.expiresAt,
+  };
+}
+
+/** Build the `data` fragment for clearing X tokens on disconnect. */
+export function buildTokenClear(): TokenWriteFragment {
+  return {
+    xAccessToken: null,
+    xRefreshToken: null,
+    xAccessTokenEnc: null,
+    xRefreshTokenEnc: null,
+    xTokenExpiresAt: null,
+  };
+}
+
+// ─── Prisma read helpers ──────────────────────────────────────────────
+
+/**
+ * Row shape used by read helpers. Use this in Prisma `select` clauses to
+ * pull both the enc and plaintext columns so reads can transparently
+ * fall back during the migration window.
+ */
+export interface UserTokenRow {
+  xAccessToken?: string | null;
+  xRefreshToken?: string | null;
+  xAccessTokenEnc?: string | null;
+  xRefreshTokenEnc?: string | null;
+}
+
+/** Prisma `select` fragment for reading both enc and plaintext token columns. */
+export const TOKEN_READ_SELECT = {
+  xAccessToken: true,
+  xRefreshToken: true,
+  xAccessTokenEnc: true,
+  xRefreshTokenEnc: true,
+} as const;
+
+/** Decrypt & return the access token, preferring enc column, falling back to plaintext. */
+export function readAccessToken(user: UserTokenRow | null | undefined): string | null {
+  if (!user) return null;
+  if (user.xAccessTokenEnc) {
+    try {
+      return decryptToken(user.xAccessTokenEnc);
+    } catch (err: any) {
+      logger.error(
+        { err: err.message },
+        "Failed to decrypt xAccessTokenEnc — falling back to plaintext column",
+      );
+    }
+  }
+  return user.xAccessToken ?? null;
+}
+
+/** Decrypt & return the refresh token, preferring enc column, falling back to plaintext. */
+export function readRefreshToken(user: UserTokenRow | null | undefined): string | null {
+  if (!user) return null;
+  if (user.xRefreshTokenEnc) {
+    try {
+      return decryptToken(user.xRefreshTokenEnc);
+    } catch (err: any) {
+      logger.error(
+        { err: err.message },
+        "Failed to decrypt xRefreshTokenEnc — falling back to plaintext column",
+      );
+    }
+  }
+  return user.xRefreshToken ?? null;
+}
+
+/** Reset the cached key. Test-only — not exported from index. */
+export function __resetKeyCacheForTests(): void {
+  cachedKey = undefined;
+}

--- a/services/api/src/scripts/encrypt-xoauth-tokens.ts
+++ b/services/api/src/scripts/encrypt-xoauth-tokens.ts
@@ -1,0 +1,215 @@
+/**
+ * C-3 rotation backfill — encrypt existing plaintext XOAuth tokens.
+ *
+ * Pairs with services/api/src/lib/crypto.ts. The crypto helper ships the
+ * dual-column read/write path so encrypted reads are live BEFORE this
+ * script runs; this is the one-shot rotation that moves any leftover
+ * plaintext rows over to the encrypted columns.
+ *
+ * Behaviour:
+ *   - Scans every User row that still has a non-null `xAccessToken` or
+ *     `xRefreshToken`.
+ *   - For each row: encrypts the plaintext (via encryptToken) and writes
+ *     the ciphertext to the matching `*Enc` column. Plaintext columns are
+ *     cleared once their encrypted twin is populated.
+ *   - Idempotent: rows where the `*Enc` column is already populated are
+ *     left alone — only the unmigrated half is touched. Re-running the
+ *     script after a partial pass is safe.
+ *   - Dry-run by default. Pass `--apply` to actually write.
+ *
+ * Required env:
+ *   - DATABASE_URL          (Prisma)
+ *   - TOKEN_ENCRYPTION_KEY  (32-byte hex or base64; same key the runtime uses)
+ *
+ * Run:
+ *   npx tsx services/api/src/scripts/encrypt-xoauth-tokens.ts          # dry-run
+ *   npx tsx services/api/src/scripts/encrypt-xoauth-tokens.ts --apply  # write
+ *
+ * Or via package script:
+ *   npm run db:encrypt-xoauth -- --apply
+ */
+
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import { PrismaClient } from "@prisma/client";
+import { encryptToken, encryptionEnabled } from "../lib/crypto";
+
+export interface BackfillUserRow {
+  id: string;
+  xAccessToken: string | null;
+  xRefreshToken: string | null;
+  xAccessTokenEnc: string | null;
+  xRefreshTokenEnc: string | null;
+}
+
+export interface BackfillStats {
+  scanned: number;
+  /** Rows where at least one column was actually encrypted (or would be in dry-run). */
+  migrated: number;
+  /** Plaintext access tokens encrypted into xAccessTokenEnc. */
+  accessEncrypted: number;
+  /** Plaintext refresh tokens encrypted into xRefreshTokenEnc. */
+  refreshEncrypted: number;
+  /** Rows the script chose not to touch because both halves were already migrated. */
+  skipped: number;
+  /** Rows the script chose not to touch because they had no plaintext to migrate. */
+  empty: number;
+}
+
+interface UserUpdate {
+  xAccessToken?: null;
+  xRefreshToken?: null;
+  xAccessTokenEnc?: string;
+  xRefreshTokenEnc?: string;
+}
+
+/**
+ * Pure planner — given a row, decide what should change.
+ * Extracted so the unit test can verify the decision matrix without
+ * spinning up a Prisma client.
+ */
+export function planRowMigration(row: BackfillUserRow): UserUpdate | null {
+  const update: UserUpdate = {};
+
+  // Access token: encrypt-if-plaintext-only.
+  if (row.xAccessToken && !row.xAccessTokenEnc) {
+    update.xAccessTokenEnc = encryptToken(row.xAccessToken);
+    update.xAccessToken = null;
+  }
+
+  // Refresh token: encrypt-if-plaintext-only.
+  if (row.xRefreshToken && !row.xRefreshTokenEnc) {
+    update.xRefreshTokenEnc = encryptToken(row.xRefreshToken);
+    update.xRefreshToken = null;
+  }
+
+  return Object.keys(update).length > 0 ? update : null;
+}
+
+/**
+ * Run the backfill against a Prisma client. Returns stats.
+ *
+ * Exported so the unit test can drive this with a mock client and the
+ * runtime entrypoint at the bottom of the file just wraps it.
+ */
+export async function runBackfill(
+  prisma: Pick<PrismaClient, "user">,
+  options: { apply: boolean; logger?: (msg: string) => void } = { apply: false },
+): Promise<BackfillStats> {
+  const log = options.logger ?? (() => {});
+
+  const stats: BackfillStats = {
+    scanned: 0,
+    migrated: 0,
+    accessEncrypted: 0,
+    refreshEncrypted: 0,
+    skipped: 0,
+    empty: 0,
+  };
+
+  // Pull only rows that still have plaintext on at least one side.
+  // Rows already fully migrated (both Enc populated, both plaintext null)
+  // never enter the candidate set.
+  const candidates = (await prisma.user.findMany({
+    where: {
+      OR: [
+        { xAccessToken: { not: null } },
+        { xRefreshToken: { not: null } },
+      ],
+    },
+    select: {
+      id: true,
+      xAccessToken: true,
+      xRefreshToken: true,
+      xAccessTokenEnc: true,
+      xRefreshTokenEnc: true,
+    },
+  })) as BackfillUserRow[];
+
+  stats.scanned = candidates.length;
+  log(`Scanned ${stats.scanned} candidate user(s) with plaintext XOAuth columns.`);
+
+  for (const row of candidates) {
+    const update = planRowMigration(row);
+
+    if (!update) {
+      // Row needs no patch. Two reasons we land here:
+      //   - Both halves are already encrypted (Enc populated, plaintext gone) → skipped
+      //   - Both halves are fully empty (no plaintext, no Enc) → empty (defensive;
+      //     the findMany filter normally excludes these, but a mock or a row
+      //     in inconsistent state might still be returned)
+      const hasAnyEnc = !!(row.xAccessTokenEnc || row.xRefreshTokenEnc);
+      if (hasAnyEnc) {
+        stats.skipped += 1;
+      } else {
+        stats.empty += 1;
+      }
+      continue;
+    }
+
+    if (update.xAccessTokenEnc !== undefined) stats.accessEncrypted += 1;
+    if (update.xRefreshTokenEnc !== undefined) stats.refreshEncrypted += 1;
+    stats.migrated += 1;
+
+    if (options.apply) {
+      await prisma.user.update({ where: { id: row.id }, data: update });
+    }
+  }
+
+  return stats;
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+
+  if (!encryptionEnabled()) {
+    console.error(
+      "❌ TOKEN_ENCRYPTION_KEY is not set or invalid. Refusing to run — there is no key to encrypt to.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `🔐 XOAuth token rotation backfill — ${apply ? "APPLY" : "DRY-RUN"} mode\n`,
+  );
+
+  const prisma = new PrismaClient();
+  try {
+    const stats = await runBackfill(prisma, {
+      apply,
+      logger: (msg) => console.log(`   ${msg}`),
+    });
+
+    console.log("");
+    console.log("─── Results ───────────────────────────────");
+    console.log(`Scanned candidates    : ${stats.scanned}`);
+    console.log(`Rows migrated         : ${stats.migrated}${apply ? "" : " (would migrate)"}`);
+    console.log(`  · access tokens     : ${stats.accessEncrypted}`);
+    console.log(`  · refresh tokens    : ${stats.refreshEncrypted}`);
+    console.log(`Already encrypted     : ${stats.skipped}`);
+    console.log(`Empty plaintext       : ${stats.empty}`);
+    console.log("───────────────────────────────────────────");
+
+    if (!apply && stats.migrated > 0) {
+      console.log(
+        "\nRe-run with `--apply` to write the changes. Make sure DATABASE_URL points at the right environment.",
+      );
+    } else if (apply) {
+      console.log("\n✅ Backfill complete.");
+    } else {
+      console.log("\nNothing to migrate. ✨");
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Only execute when run directly (allows the unit test to import without
+// triggering a real Prisma connection).
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("Backfill failed:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- New script `services/api/src/scripts/encrypt-xoauth-tokens.ts` — one-shot rotation that moves any leftover plaintext `xAccessToken` / `xRefreshToken` rows over to the new encrypted columns. Idempotent, dry-run by default, refuses to run without `TOKEN_ENCRYPTION_KEY`.
- New npm script: `npm run db:encrypt-xoauth -- --apply`
- 7 unit tests covering planner + runBackfill (mock Prisma): full plaintext, half-migrated rows, fully-migrated rows, dry-run, apply mode, idempotency.

## Why
Helper PR for cc-90569's C-3 work. Their commit message explicitly says "ship code ahead of the rotation backfill" — this is that backfill. The dual-column read/write path is already live in their crypto.ts helper, so encrypted reads work the moment the schema migration deploys; this script can run on its own schedule to clean up any plaintext that was written before the cutover.

## Stacks on cc-90569's C-3 commits
This PR includes the two C-3 commits (cherry-picked) so it tests cleanly:
- `8143e26` feat(security): add encrypted XOAuth token columns to User (C-3)
- `71b943d` feat(security): add crypto helper for XOAuth token encryption (C-3)

When cc-90569's primary C-3 PR lands first, this branch can rebase cleanly and the cherry-picked commits will drop out as duplicates. If this lands first, the helper file is already self-consistent.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest services/api/src/__tests__/lib/crypto.test.ts` — 19/19 (existing crypto tests still pass)
- [x] `npx jest services/api/src/__tests__/scripts/encrypt-xoauth-tokens.test.ts` — 7/7 new
- [ ] Manual: `npm run db:encrypt-xoauth` against staging (dry-run) → expected output: scanned count, would-migrate count, no writes
- [ ] Manual: `npm run db:encrypt-xoauth -- --apply` against staging → verify all rows have `xAccessTokenEnc` populated and `xAccessToken` cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)