### PR TITLE
feat(security): XOAuth token encryption at rest (C-3)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,12 @@ model User {
   xAccessToken      String?
   xRefreshToken     String?
   xTokenExpiresAt   DateTime?
+  // C-3: AES-256-GCM encrypted (format "v1:iv:tag:ct") token columns.
+  // Live alongside plaintext columns during the migration window — the
+  // read path prefers `*Enc` and falls back to plaintext, so either set
+  // of columns can be populated. See services/api/src/lib/crypto.ts.
+  xAccessTokenEnc   String?
+  xRefreshTokenEnc  String?
   xBio              String?
   xAvatarUrl        String?
   xFollowerCount    Int?

--- a/services/api/src/__tests__/lib/crypto.test.ts
+++ b/services/api/src/__tests__/lib/crypto.test.ts
@@ -1,0 +1,202 @@
+jest.mock("../../lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import crypto from "node:crypto";
+import {
+  __resetKeyCacheForTests,
+  buildTokenClear,
+  buildTokenWrite,
+  decryptToken,
+  encryptToken,
+  encryptionEnabled,
+  isEncrypted,
+  readAccessToken,
+  readRefreshToken,
+} from "../../lib/crypto";
+
+const ORIGINAL_KEY = process.env.TOKEN_ENCRYPTION_KEY;
+
+function setKey(key: string | undefined): void {
+  if (key === undefined) {
+    delete process.env.TOKEN_ENCRYPTION_KEY;
+  } else {
+    process.env.TOKEN_ENCRYPTION_KEY = key;
+  }
+  __resetKeyCacheForTests();
+}
+
+describe("crypto (XOAuth token encryption)", () => {
+  afterAll(() => {
+    setKey(ORIGINAL_KEY);
+  });
+
+  describe("with encryption disabled (no key)", () => {
+    beforeEach(() => setKey(undefined));
+
+    it("encryptionEnabled() returns false", () => {
+      expect(encryptionEnabled()).toBe(false);
+    });
+
+    it("encryptToken() passes plaintext through unchanged", () => {
+      expect(encryptToken("hello")).toBe("hello");
+    });
+
+    it("decryptToken() passes plaintext through unchanged", () => {
+      expect(decryptToken("hello")).toBe("hello");
+    });
+
+    it("buildTokenWrite() writes to plaintext columns only", () => {
+      const write = buildTokenWrite({
+        accessToken: "at",
+        refreshToken: "rt",
+        expiresAt: new Date("2026-01-01"),
+      });
+      expect(write.xAccessToken).toBe("at");
+      expect(write.xRefreshToken).toBe("rt");
+      expect(write.xAccessTokenEnc).toBeNull();
+      expect(write.xRefreshTokenEnc).toBeNull();
+      expect(write.xTokenExpiresAt).toEqual(new Date("2026-01-01"));
+    });
+
+    it("readAccessToken() prefers plaintext column when enc is absent", () => {
+      expect(readAccessToken({ xAccessToken: "plain", xAccessTokenEnc: null })).toBe(
+        "plain",
+      );
+    });
+  });
+
+  describe("with encryption enabled (hex key)", () => {
+    const hexKey = crypto.randomBytes(32).toString("hex");
+
+    beforeEach(() => setKey(hexKey));
+
+    it("encryptionEnabled() returns true", () => {
+      expect(encryptionEnabled()).toBe(true);
+    });
+
+    it("encrypt → decrypt roundtrips", () => {
+      const plaintext = "my-oauth-access-token-abc123";
+      const encrypted = encryptToken(plaintext);
+      expect(isEncrypted(encrypted)).toBe(true);
+      expect(encrypted.startsWith("v1:")).toBe(true);
+      expect(encrypted).not.toContain(plaintext);
+      expect(decryptToken(encrypted)).toBe(plaintext);
+    });
+
+    it("produces a fresh IV per encryption (ciphertexts differ)", () => {
+      const a = encryptToken("same-input");
+      const b = encryptToken("same-input");
+      expect(a).not.toBe(b);
+      expect(decryptToken(a)).toBe("same-input");
+      expect(decryptToken(b)).toBe("same-input");
+    });
+
+    it("decryptToken() throws on tampered ciphertext", () => {
+      const encrypted = encryptToken("secret");
+      const parts = encrypted.split(":");
+      // Flip a byte in the ciphertext segment
+      const tampered = Buffer.from(parts[3], "base64");
+      tampered[0] = tampered[0] ^ 0xff;
+      parts[3] = tampered.toString("base64");
+      expect(() => decryptToken(parts.join(":"))).toThrow();
+    });
+
+    it("decryptToken() passes plaintext through unchanged", () => {
+      expect(decryptToken("legacy-plaintext")).toBe("legacy-plaintext");
+    });
+
+    it("buildTokenWrite() writes to enc columns only, clearing plaintext", () => {
+      const write = buildTokenWrite({
+        accessToken: "at",
+        refreshToken: "rt",
+        expiresAt: new Date("2026-01-01"),
+      });
+      expect(write.xAccessToken).toBeNull();
+      expect(write.xRefreshToken).toBeNull();
+      expect(write.xAccessTokenEnc).not.toBeNull();
+      expect(write.xRefreshTokenEnc).not.toBeNull();
+      expect(isEncrypted(write.xAccessTokenEnc!)).toBe(true);
+      expect(isEncrypted(write.xRefreshTokenEnc!)).toBe(true);
+      expect(decryptToken(write.xAccessTokenEnc!)).toBe("at");
+      expect(decryptToken(write.xRefreshTokenEnc!)).toBe("rt");
+    });
+
+    it("buildTokenWrite() handles null refresh token gracefully", () => {
+      const write = buildTokenWrite({
+        accessToken: "at",
+        refreshToken: null,
+        expiresAt: null,
+      });
+      expect(write.xAccessTokenEnc).not.toBeNull();
+      expect(write.xRefreshTokenEnc).toBeNull();
+    });
+
+    it("readAccessToken() prefers the enc column and decrypts it", () => {
+      const enc = encryptToken("real-token");
+      expect(
+        readAccessToken({
+          xAccessToken: "stale-plaintext",
+          xAccessTokenEnc: enc,
+        }),
+      ).toBe("real-token");
+    });
+
+    it("readAccessToken() falls back to plaintext if enc is absent", () => {
+      expect(
+        readAccessToken({
+          xAccessToken: "legacy-plaintext",
+          xAccessTokenEnc: null,
+        }),
+      ).toBe("legacy-plaintext");
+    });
+
+    it("readRefreshToken() prefers the enc column and decrypts it", () => {
+      const enc = encryptToken("refresh-1");
+      expect(
+        readRefreshToken({
+          xRefreshToken: null,
+          xRefreshTokenEnc: enc,
+        }),
+      ).toBe("refresh-1");
+    });
+
+    it("buildTokenClear() returns all-null fragment", () => {
+      const clear = buildTokenClear();
+      expect(clear.xAccessToken).toBeNull();
+      expect(clear.xRefreshToken).toBeNull();
+      expect(clear.xAccessTokenEnc).toBeNull();
+      expect(clear.xRefreshTokenEnc).toBeNull();
+      expect(clear.xTokenExpiresAt).toBeNull();
+    });
+  });
+
+  describe("with encryption enabled (base64 key)", () => {
+    const b64Key = crypto.randomBytes(32).toString("base64");
+
+    beforeEach(() => setKey(b64Key));
+
+    it("accepts a base64-encoded key and roundtrips", () => {
+      expect(encryptionEnabled()).toBe(true);
+      const encrypted = encryptToken("hello");
+      expect(decryptToken(encrypted)).toBe("hello");
+    });
+  });
+
+  describe("with an invalid key", () => {
+    beforeEach(() => setKey("not-a-valid-32-byte-key"));
+
+    it("encryptionEnabled() returns false (graceful fallback)", () => {
+      expect(encryptionEnabled()).toBe(false);
+    });
+
+    it("encryptToken() falls through to plaintext", () => {
+      expect(encryptToken("hello")).toBe("hello");
+    });
+  });
+});

--- a/services/api/src/__tests__/routes/queue.test.ts
+++ b/services/api/src/__tests__/routes/queue.test.ts
@@ -75,6 +75,8 @@ beforeEach(() => {
   (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
     xAccessToken: "access-token",
     xRefreshToken: "refresh-token",
+    xAccessTokenEnc: null,
+    xRefreshTokenEnc: null,
     xTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
   });
   (mockPrisma.user.update as jest.Mock).mockResolvedValue({});
@@ -294,6 +296,8 @@ describe("POST /api/queue/:id/publish", () => {
     (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
       xAccessToken: null,
       xRefreshToken: null,
+      xAccessTokenEnc: null,
+      xRefreshTokenEnc: null,
       xTokenExpiresAt: null,
     });
 

--- a/services/api/src/__tests__/routes/x-auth.test.ts
+++ b/services/api/src/__tests__/routes/x-auth.test.ts
@@ -218,6 +218,8 @@ describe("POST /api/auth/x/callback", () => {
       data: {
         xAccessToken: "access-token",
         xRefreshToken: "refresh-token",
+        xAccessTokenEnc: null,
+        xRefreshTokenEnc: null,
         xTokenExpiresAt: expect.any(Date),
         xHandle: "atlas_handle",
         xBio: "Crypto analyst",
@@ -233,6 +235,9 @@ describe("GET /api/auth/x/status", () => {
     (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
       xHandle: null,
       xAccessToken: null,
+      xRefreshToken: null,
+      xAccessTokenEnc: null,
+      xRefreshTokenEnc: null,
       xTokenExpiresAt: null,
     });
 
@@ -254,7 +259,14 @@ describe("GET /api/auth/x/status", () => {
     });
     expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
       where: { id: "user-123" },
-      select: { xHandle: true, xAccessToken: true, xTokenExpiresAt: true },
+      select: {
+        xHandle: true,
+        xTokenExpiresAt: true,
+        xAccessToken: true,
+        xRefreshToken: true,
+        xAccessTokenEnc: true,
+        xRefreshTokenEnc: true,
+      },
     });
   });
 
@@ -262,6 +274,9 @@ describe("GET /api/auth/x/status", () => {
     (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
       xHandle: "atlas_handle",
       xAccessToken: "access-token",
+      xRefreshToken: "refresh-token",
+      xAccessTokenEnc: null,
+      xRefreshTokenEnc: null,
       xTokenExpiresAt: new Date(Date.now() + 60_000),
     });
 
@@ -287,6 +302,9 @@ describe("GET /api/auth/x/status", () => {
     (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
       xHandle: "atlas_handle",
       xAccessToken: "access-token",
+      xRefreshToken: "refresh-token",
+      xAccessTokenEnc: null,
+      xRefreshTokenEnc: null,
       xTokenExpiresAt: new Date(Date.now() - 60_000),
     });
 
@@ -324,6 +342,8 @@ describe("POST /api/auth/x/disconnect", () => {
       data: {
         xAccessToken: null,
         xRefreshToken: null,
+        xAccessTokenEnc: null,
+        xRefreshTokenEnc: null,
         xTokenExpiresAt: null,
         xHandle: null,
       },

--- a/services/api/src/lib/crypto.ts
+++ b/services/api/src/lib/crypto.ts
@@ -1,0 +1,228 @@
+import crypto from "node:crypto";
+import { logger } from "./logger";
+
+/**
+ * XOAuth token encryption at rest (C-3).
+ *
+ * Design:
+ * - AES-256-GCM with a 32-byte key read from `TOKEN_ENCRYPTION_KEY`
+ *   (accepts hex-encoded or base64-encoded).
+ * - Ciphertext format: `v1:<iv_b64>:<tag_b64>:<ct_b64>`
+ * - If the env var is missing/invalid, encryption is DISABLED and all
+ *   helpers fall through to the plaintext columns on User. This keeps
+ *   existing deployments working during the migration window and lets
+ *   us ship code ahead of the backfill.
+ * - Dual-column schema: `xAccessToken`/`xRefreshToken` (plaintext, legacy)
+ *   live alongside `xAccessTokenEnc`/`xRefreshTokenEnc` (ciphertext).
+ *   Reads prefer enc and fall back to plaintext; writes target whichever
+ *   column set is active based on whether encryption is enabled.
+ */
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_LENGTH = 32;
+const IV_LENGTH = 12;
+const VERSION = "v1";
+
+// `undefined` = not yet resolved, `null` = resolved but disabled, Buffer = enabled.
+let cachedKey: Buffer | null | undefined;
+
+function loadKey(): Buffer | null {
+  if (cachedKey !== undefined) return cachedKey;
+
+  const raw = process.env.TOKEN_ENCRYPTION_KEY;
+  if (!raw) {
+    cachedKey = null;
+    return null;
+  }
+
+  try {
+    let key: Buffer;
+    if (/^[0-9a-f]{64}$/i.test(raw)) {
+      key = Buffer.from(raw, "hex");
+    } else {
+      key = Buffer.from(raw, "base64");
+    }
+    if (key.length !== KEY_LENGTH) {
+      throw new Error(`Expected ${KEY_LENGTH}-byte key, got ${key.length}`);
+    }
+    cachedKey = key;
+    return cachedKey;
+  } catch (err: any) {
+    logger.error(
+      { err: err.message },
+      "TOKEN_ENCRYPTION_KEY is invalid — falling through to plaintext XOAuth token storage",
+    );
+    cachedKey = null;
+    return null;
+  }
+}
+
+/** True if a valid `TOKEN_ENCRYPTION_KEY` is present. */
+export function encryptionEnabled(): boolean {
+  return loadKey() !== null;
+}
+
+/** True if the value looks like a `v1:` encrypted token. */
+export function isEncrypted(value: string | null | undefined): boolean {
+  return typeof value === "string" && value.startsWith(`${VERSION}:`);
+}
+
+/** Encrypt a plaintext token. If encryption is disabled, returns the plaintext unchanged. */
+export function encryptToken(plaintext: string): string {
+  const key = loadKey();
+  if (!key) return plaintext;
+
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+
+  return [
+    VERSION,
+    iv.toString("base64"),
+    tag.toString("base64"),
+    ciphertext.toString("base64"),
+  ].join(":");
+}
+
+/**
+ * Decrypt a ciphertext produced by `encryptToken`.
+ * - Plaintext-looking values pass through unchanged (plaintext fallback).
+ * - Throws only if the value *looks* encrypted (`v1:` prefix) but cannot be decrypted.
+ */
+export function decryptToken(value: string): string {
+  if (!isEncrypted(value)) return value;
+
+  const key = loadKey();
+  if (!key) {
+    throw new Error(
+      "Cannot decrypt XOAuth token: TOKEN_ENCRYPTION_KEY is not set or invalid",
+    );
+  }
+
+  const parts = value.split(":");
+  if (parts.length !== 4) {
+    throw new Error("Malformed encrypted XOAuth token (expected 4 segments)");
+  }
+  const [, ivB64, tagB64, ctB64] = parts;
+  const iv = Buffer.from(ivB64, "base64");
+  const tag = Buffer.from(tagB64, "base64");
+  const ct = Buffer.from(ctB64, "base64");
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([decipher.update(ct), decipher.final()]);
+  return plaintext.toString("utf8");
+}
+
+// ─── Prisma write helpers ─────────────────────────────────────────────
+
+export interface TokenWriteFragment {
+  xAccessToken: string | null;
+  xRefreshToken: string | null;
+  xAccessTokenEnc: string | null;
+  xRefreshTokenEnc: string | null;
+  xTokenExpiresAt: Date | null;
+}
+
+/**
+ * Build the `data` fragment for a Prisma write that sets X tokens.
+ * When encryption is enabled, writes go to the `*Enc` columns and the
+ * plaintext columns are cleared to `null`. When disabled, the legacy
+ * plaintext columns are populated and the `*Enc` columns stay `null`.
+ */
+export function buildTokenWrite(args: {
+  accessToken: string | null;
+  refreshToken: string | null;
+  expiresAt: Date | null;
+}): TokenWriteFragment {
+  if (encryptionEnabled()) {
+    return {
+      xAccessToken: null,
+      xRefreshToken: null,
+      xAccessTokenEnc: args.accessToken ? encryptToken(args.accessToken) : null,
+      xRefreshTokenEnc: args.refreshToken ? encryptToken(args.refreshToken) : null,
+      xTokenExpiresAt: args.expiresAt,
+    };
+  }
+  return {
+    xAccessToken: args.accessToken,
+    xRefreshToken: args.refreshToken,
+    xAccessTokenEnc: null,
+    xRefreshTokenEnc: null,
+    xTokenExpiresAt: args.expiresAt,
+  };
+}
+
+/** Build the `data` fragment for clearing X tokens on disconnect. */
+export function buildTokenClear(): TokenWriteFragment {
+  return {
+    xAccessToken: null,
+    xRefreshToken: null,
+    xAccessTokenEnc: null,
+    xRefreshTokenEnc: null,
+    xTokenExpiresAt: null,
+  };
+}
+
+// ─── Prisma read helpers ──────────────────────────────────────────────
+
+/**
+ * Row shape used by read helpers. Use this in Prisma `select` clauses to
+ * pull both the enc and plaintext columns so reads can transparently
+ * fall back during the migration window.
+ */
+export interface UserTokenRow {
+  xAccessToken?: string | null;
+  xRefreshToken?: string | null;
+  xAccessTokenEnc?: string | null;
+  xRefreshTokenEnc?: string | null;
+}
+
+/** Prisma `select` fragment for reading both enc and plaintext token columns. */
+export const TOKEN_READ_SELECT = {
+  xAccessToken: true,
+  xRefreshToken: true,
+  xAccessTokenEnc: true,
+  xRefreshTokenEnc: true,
+} as const;
+
+/** Decrypt & return the access token, preferring enc column, falling back to plaintext. */
+export function readAccessToken(user: UserTokenRow | null | undefined): string | null {
+  if (!user) return null;
+  if (user.xAccessTokenEnc) {
+    try {
+      return decryptToken(user.xAccessTokenEnc);
+    } catch (err: any) {
+      logger.error(
+        { err: err.message },
+        "Failed to decrypt xAccessTokenEnc — falling back to plaintext column",
+      );
+    }
+  }
+  return user.xAccessToken ?? null;
+}
+
+/** Decrypt & return the refresh token, preferring enc column, falling back to plaintext. */
+export function readRefreshToken(user: UserTokenRow | null | undefined): string | null {
+  if (!user) return null;
+  if (user.xRefreshTokenEnc) {
+    try {
+      return decryptToken(user.xRefreshTokenEnc);
+    } catch (err: any) {
+      logger.error(
+        { err: err.message },
+        "Failed to decrypt xRefreshTokenEnc — falling back to plaintext column",
+      );
+    }
+  }
+  return user.xRefreshToken ?? null;
+}
+
+/** Reset the cached key. Test-only — not exported from index. */
+export function __resetKeyCacheForTests(): void {
+  cachedKey = undefined;
+}

--- a/services/api/src/lib/scheduler.ts
+++ b/services/api/src/lib/scheduler.ts
@@ -6,6 +6,12 @@
 import { prisma } from "./prisma";
 import { logger } from "./logger";
 import { runScheduledBackupIfDue } from "./backup";
+import {
+  buildTokenWrite,
+  readAccessToken,
+  readRefreshToken,
+  TOKEN_READ_SELECT,
+} from "./crypto";
 
 const POLL_INTERVAL_MS = 60_000; // Check every minute
 
@@ -18,9 +24,8 @@ async function processScheduledDrafts(): Promise<{ posted: number; failed: numbe
       user: {
         select: {
           id: true,
-          xAccessToken: true,
-          xRefreshToken: true,
           xTokenExpiresAt: true,
+          ...TOKEN_READ_SELECT,
         },
       },
     },
@@ -35,7 +40,8 @@ async function processScheduledDrafts(): Promise<{ posted: number; failed: numbe
 
   for (const draft of dueDrafts) {
     try {
-      if (!draft.user.xAccessToken) {
+      let accessToken = readAccessToken(draft.user);
+      if (!accessToken) {
         // No X token — move back to APPROVED so user can post manually
         await prisma.tweetDraft.update({
           where: { id: draft.id },
@@ -47,17 +53,17 @@ async function processScheduledDrafts(): Promise<{ posted: number; failed: numbe
       }
 
       // Refresh token if expired
-      let accessToken = draft.user.xAccessToken;
-      if (draft.user.xTokenExpiresAt && draft.user.xTokenExpiresAt < now && draft.user.xRefreshToken) {
-        const refreshed = await refreshAccessToken(draft.user.xRefreshToken);
+      const draftRefreshToken = readRefreshToken(draft.user);
+      if (draft.user.xTokenExpiresAt && draft.user.xTokenExpiresAt < now && draftRefreshToken) {
+        const refreshed = await refreshAccessToken(draftRefreshToken);
         accessToken = refreshed.accessToken;
         await prisma.user.update({
           where: { id: draft.userId },
-          data: {
-            xAccessToken: refreshed.accessToken,
-            xRefreshToken: refreshed.refreshToken,
-            xTokenExpiresAt: new Date(Date.now() + refreshed.expiresIn * 1000),
-          },
+          data: buildTokenWrite({
+            accessToken: refreshed.accessToken,
+            refreshToken: refreshed.refreshToken,
+            expiresAt: new Date(Date.now() + refreshed.expiresIn * 1000),
+          }),
         });
       }
 

--- a/services/api/src/routes/drafts.ts
+++ b/services/api/src/routes/drafts.ts
@@ -12,6 +12,12 @@ import { extractInsights } from "../lib/content-extraction";
 import { batchGenerateDrafts } from "../lib/batch-generate";
 import { config } from "../lib/config";
 import { rateLimitByUser } from "../middleware/rateLimit";
+import {
+  buildTokenWrite,
+  readAccessToken,
+  readRefreshToken,
+  TOKEN_READ_SELECT,
+} from "../lib/crypto";
 
 export const draftsRouter = Router();
 draftsRouter.use(authenticate);
@@ -725,25 +731,26 @@ draftsRouter.post("/:id/post", authenticate, async (req: AuthRequest, res) => {
 
     const user = await prisma.user.findUnique({
       where: { id: req.userId! },
-      select: { xAccessToken: true, xRefreshToken: true, xTokenExpiresAt: true },
+      select: { ...TOKEN_READ_SELECT, xTokenExpiresAt: true },
     });
 
-    if (!user?.xAccessToken) {
+    let accessToken = readAccessToken(user);
+    if (!accessToken) {
       return res.status(400).json(buildErrorResponse(req, "X account not linked. Connect your X account first."));
     }
 
     // Refresh token if expired
-    let accessToken = user.xAccessToken;
-    if (user.xTokenExpiresAt && user.xTokenExpiresAt < new Date() && user.xRefreshToken) {
-      const refreshed = await refreshAccessToken(user.xRefreshToken);
+    const currentRefreshToken = readRefreshToken(user);
+    if (user?.xTokenExpiresAt && user.xTokenExpiresAt < new Date() && currentRefreshToken) {
+      const refreshed = await refreshAccessToken(currentRefreshToken);
       accessToken = refreshed.accessToken;
       await prisma.user.update({
         where: { id: req.userId! },
-        data: {
-          xAccessToken: refreshed.accessToken,
-          xRefreshToken: refreshed.refreshToken,
-          xTokenExpiresAt: new Date(Date.now() + refreshed.expiresIn * 1000),
-        },
+        data: buildTokenWrite({
+          accessToken: refreshed.accessToken,
+          refreshToken: refreshed.refreshToken,
+          expiresAt: new Date(Date.now() + refreshed.expiresIn * 1000),
+        }),
       });
     }
 
@@ -837,7 +844,7 @@ draftsRouter.post("/process-scheduled", authenticate, async (req: AuthRequest, r
     const now = new Date();
     const dueDrafts = await prisma.tweetDraft.findMany({
       where: { status: "SCHEDULED", scheduledAt: { lte: now } },
-      include: { user: { select: { id: true, xAccessToken: true, xRefreshToken: true, xTokenExpiresAt: true } } },
+      include: { user: { select: { id: true, xTokenExpiresAt: true, ...TOKEN_READ_SELECT } } },
     });
 
     if (dueDrafts.length === 0) {
@@ -850,23 +857,24 @@ draftsRouter.post("/process-scheduled", authenticate, async (req: AuthRequest, r
 
     for (const draft of dueDrafts) {
       try {
-        if (!draft.user.xAccessToken) {
+        let accessToken = readAccessToken(draft.user);
+        if (!accessToken) {
           logger.warn({ draftId: draft.id, userId: draft.userId }, "Scheduled draft skipped — no X token");
           failed++;
           continue;
         }
 
-        let accessToken = draft.user.xAccessToken;
-        if (draft.user.xTokenExpiresAt && draft.user.xTokenExpiresAt < now && draft.user.xRefreshToken) {
-          const refreshed = await refreshAccessToken(draft.user.xRefreshToken);
+        const draftRefreshToken = readRefreshToken(draft.user);
+        if (draft.user.xTokenExpiresAt && draft.user.xTokenExpiresAt < now && draftRefreshToken) {
+          const refreshed = await refreshAccessToken(draftRefreshToken);
           accessToken = refreshed.accessToken;
           await prisma.user.update({
             where: { id: draft.userId },
-            data: {
-              xAccessToken: refreshed.accessToken,
-              xRefreshToken: refreshed.refreshToken,
-              xTokenExpiresAt: new Date(Date.now() + refreshed.expiresIn * 1000),
-            },
+            data: buildTokenWrite({
+              accessToken: refreshed.accessToken,
+              refreshToken: refreshed.refreshToken,
+              expiresAt: new Date(Date.now() + refreshed.expiresIn * 1000),
+            }),
           });
         }
 

--- a/services/api/src/routes/queue.ts
+++ b/services/api/src/routes/queue.ts
@@ -7,6 +7,12 @@ import { buildErrorResponse } from "../middleware/requestId";
 import { success } from "../lib/response";
 import { logger } from "../lib/logger";
 import { postTweet, refreshAccessToken } from "../lib/twitter";
+import {
+  buildTokenWrite,
+  readAccessToken,
+  readRefreshToken,
+  TOKEN_READ_SELECT,
+} from "../lib/crypto";
 
 export const queueRouter = Router();
 queueRouter.use(authenticate);
@@ -38,25 +44,27 @@ function getQueueStatus(scheduledAt: Date | null): "queued" | "scheduled" {
 async function getPublishAccessToken(userId: string): Promise<string> {
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { xAccessToken: true, xRefreshToken: true, xTokenExpiresAt: true },
+    select: { ...TOKEN_READ_SELECT, xTokenExpiresAt: true },
   });
 
-  if (!user?.xAccessToken) {
+  const accessToken = readAccessToken(user);
+  if (!accessToken) {
     throw new Error("X account not linked. Connect your X account first.");
   }
 
-  if (!user.xTokenExpiresAt || user.xTokenExpiresAt >= new Date() || !user.xRefreshToken) {
-    return user.xAccessToken;
+  const refreshToken = readRefreshToken(user);
+  if (!user?.xTokenExpiresAt || user.xTokenExpiresAt >= new Date() || !refreshToken) {
+    return accessToken;
   }
 
-  const refreshed = await refreshAccessToken(user.xRefreshToken);
+  const refreshed = await refreshAccessToken(refreshToken);
   await prisma.user.update({
     where: { id: userId },
-    data: {
-      xAccessToken: refreshed.accessToken,
-      xRefreshToken: refreshed.refreshToken,
-      xTokenExpiresAt: new Date(Date.now() + refreshed.expiresIn * 1000),
-    },
+    data: buildTokenWrite({
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      expiresAt: new Date(Date.now() + refreshed.expiresIn * 1000),
+    }),
   });
 
   return refreshed.accessToken;

--- a/services/api/src/routes/twitter.ts
+++ b/services/api/src/routes/twitter.ts
@@ -6,6 +6,12 @@ import { logger } from "../lib/logger";
 import { success, error } from "../lib/response";
 import { buildErrorResponse } from "../middleware/requestId";
 import { getCached, setCache } from "../lib/redis";
+import {
+  buildTokenWrite,
+  readAccessToken,
+  readRefreshToken,
+  TOKEN_READ_SELECT,
+} from "../lib/crypto";
 
 export const twitterRouter = Router();
 
@@ -47,45 +53,43 @@ async function writeToCache<T>(key: string, data: T): Promise<void> {
 
 // ── Token helpers ────────────────────────────────────────────────────
 
-interface UserXTokens {
-  xAccessToken: string;
-  xRefreshToken: string | null;
-  xTokenExpiresAt: Date | null;
-}
-
 /**
  * Retrieve the user's X access token, refreshing if expired.
  * Returns null if user has no linked X account.
+ *
+ * Transparently handles the C-3 encrypted token columns — reads prefer
+ * the encrypted column, fall back to plaintext, and refreshed tokens
+ * are persisted via buildTokenWrite so they honor the active mode.
  */
 async function getValidAccessToken(userId: string): Promise<string | null> {
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { xAccessToken: true, xRefreshToken: true, xTokenExpiresAt: true },
+    select: { ...TOKEN_READ_SELECT, xTokenExpiresAt: true },
   });
 
-  if (!user?.xAccessToken) return null;
-
-  const tokens = user as UserXTokens;
+  const accessToken = readAccessToken(user);
+  if (!accessToken) return null;
 
   // Check if token is expired (with 60s buffer)
-  const isExpired = tokens.xTokenExpiresAt
-    ? tokens.xTokenExpiresAt.getTime() < Date.now() + 60_000
+  const isExpired = user?.xTokenExpiresAt
+    ? user.xTokenExpiresAt.getTime() < Date.now() + 60_000
     : false;
 
-  if (!isExpired) return tokens.xAccessToken;
+  if (!isExpired) return accessToken;
 
   // Attempt refresh
-  if (!tokens.xRefreshToken) return null;
+  const currentRefreshToken = readRefreshToken(user);
+  if (!currentRefreshToken) return null;
 
   try {
-    const refreshed = await refreshAccessToken(tokens.xRefreshToken);
+    const refreshed = await refreshAccessToken(currentRefreshToken);
     await prisma.user.update({
       where: { id: userId },
-      data: {
-        xAccessToken: refreshed.accessToken,
-        xRefreshToken: refreshed.refreshToken,
-        xTokenExpiresAt: new Date(Date.now() + refreshed.expiresIn * 1000),
-      },
+      data: buildTokenWrite({
+        accessToken: refreshed.accessToken,
+        refreshToken: refreshed.refreshToken,
+        expiresAt: new Date(Date.now() + refreshed.expiresIn * 1000),
+      }),
     });
     return refreshed.accessToken;
   } catch (err: any) {

--- a/services/api/src/routes/x-auth.ts
+++ b/services/api/src/routes/x-auth.ts
@@ -4,6 +4,12 @@ import { OnboardingTrack } from "@prisma/client";
 import { prisma } from "../lib/prisma";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { generateOAuthUrl, generateLoginOAuthUrl, exchangeCodeForTokens, exchangeLoginCodeForTokens, lookupUser, fetchTwitterUserProfile } from "../lib/twitter";
+import {
+  buildTokenClear,
+  buildTokenWrite,
+  readAccessToken,
+  TOKEN_READ_SELECT,
+} from "../lib/crypto";
 import { config } from "../lib/config";
 import { logger } from "../lib/logger";
 import { error } from "../lib/response";
@@ -129,9 +135,11 @@ xAuthRouter.get("/callback", async (req, res) => {
         where: { id: user.id },
         data: {
           xHandle,
-          xAccessToken: accessToken,
-          xRefreshToken: refreshToken,
-          xTokenExpiresAt: new Date(Date.now() + expiresIn * 1000),
+          ...buildTokenWrite({
+            accessToken,
+            refreshToken,
+            expiresAt: new Date(Date.now() + expiresIn * 1000),
+          }),
           displayName: displayName || user.displayName,
           avatarUrl: avatarUrl || user.avatarUrl,
           xBio: xBio ?? user.xBio,
@@ -147,9 +155,11 @@ xAuthRouter.get("/callback", async (req, res) => {
           displayName,
           avatarUrl,
           xHandle,
-          xAccessToken: accessToken,
-          xRefreshToken: refreshToken,
-          xTokenExpiresAt: new Date(Date.now() + expiresIn * 1000),
+          ...buildTokenWrite({
+            accessToken,
+            refreshToken,
+            expiresAt: new Date(Date.now() + expiresIn * 1000),
+          }),
           xBio,
           xAvatarUrl,
           xFollowerCount,
@@ -205,9 +215,11 @@ xAuthRouter.post("/callback", authenticate, async (req: AuthRequest, res) => {
     await prisma.user.update({
       where: { id: req.userId! },
       data: {
-        xAccessToken: accessToken,
-        xRefreshToken: refreshToken,
-        xTokenExpiresAt: new Date(Date.now() + expiresIn * 1000),
+        ...buildTokenWrite({
+          accessToken,
+          refreshToken,
+          expiresAt: new Date(Date.now() + expiresIn * 1000),
+        }),
         xHandle,
         xBio,
         xAvatarUrl,
@@ -231,11 +243,11 @@ xAuthRouter.get("/status", authenticate, async (req: AuthRequest, res) => {
   try {
     const user = await prisma.user.findUnique({
       where: { id: req.userId! },
-      select: { xHandle: true, xAccessToken: true, xTokenExpiresAt: true },
+      select: { xHandle: true, xTokenExpiresAt: true, ...TOKEN_READ_SELECT },
     });
 
     res.json(success({
-      linked: !!user?.xAccessToken,
+      linked: !!readAccessToken(user),
       xHandle: user?.xHandle || null,
       tokenExpired: user?.xTokenExpiresAt ? user.xTokenExpiresAt < new Date() : true,
     }));
@@ -253,7 +265,7 @@ xAuthRouter.post("/disconnect", authenticate, async (req: AuthRequest, res) => {
   try {
     await prisma.user.update({
       where: { id: req.userId! },
-      data: { xAccessToken: null, xRefreshToken: null, xTokenExpiresAt: null, xHandle: null },
+      data: { ...buildTokenClear(), xHandle: null },
     });
     res.json(success({ linked: false }));
   } catch (err: any) {
@@ -375,9 +387,11 @@ twitterLoginRouter.get("/callback", async (req, res) => {
         where: { id: user.id },
         data: {
           xHandle,
-          xAccessToken: accessToken,
-          xRefreshToken: refreshToken,
-          xTokenExpiresAt: new Date(Date.now() + expiresIn * 1000),
+          ...buildTokenWrite({
+            accessToken,
+            refreshToken,
+            expiresAt: new Date(Date.now() + expiresIn * 1000),
+          }),
           displayName: displayName || user.displayName,
           avatarUrl: avatarUrl || user.avatarUrl,
           xBio: xBio ?? user.xBio,
@@ -394,9 +408,11 @@ twitterLoginRouter.get("/callback", async (req, res) => {
           displayName,
           avatarUrl,
           xHandle,
-          xAccessToken: accessToken,
-          xRefreshToken: refreshToken,
-          xTokenExpiresAt: new Date(Date.now() + expiresIn * 1000),
+          ...buildTokenWrite({
+            accessToken,
+            refreshToken,
+            expiresAt: new Date(Date.now() + expiresIn * 1000),
+          }),
           xBio,
           xAvatarUrl,
           xFollowerCount,

--- a/services/api/src/scripts/rotate-x-tokens.ts
+++ b/services/api/src/scripts/rotate-x-tokens.ts
@@ -1,0 +1,288 @@
+/**
+ * rotate-x-tokens — backfill script for C-3 XOAuth token encryption.
+ *
+ * Advisor directive: "If backfill runs dirty in prod before demo, every
+ *  linked X account breaks mid-demo. SHIP CODE, NOT DATA."
+ *
+ * This script is GATED. By default it does a dry-run (counts rows that
+ * would be affected, then exits 0). It refuses to perform any writes
+ * unless BOTH of the following are true:
+ *
+ *   1. TOKEN_ENCRYPTION_KEY is set and valid (encryptionEnabled() === true)
+ *   2. RUN_ROTATE_X_TOKENS=1 is in the environment
+ *
+ * If either gate fails, no writes happen. The script can also be run in
+ * `--verify` mode, which iterates rows that already have encrypted
+ * columns populated and attempts to decrypt each — useful for
+ * post-rotation smoke testing without any DB mutation.
+ *
+ * Usage:
+ *   # dry-run (safe, counts rows only)
+ *   npx ts-node services/api/src/scripts/rotate-x-tokens.ts
+ *
+ *   # actual rotation (after TOKEN_ENCRYPTION_KEY is live in Railway)
+ *   RUN_ROTATE_X_TOKENS=1 npx ts-node services/api/src/scripts/rotate-x-tokens.ts
+ *
+ *   # post-rotation verification (read-only)
+ *   npx ts-node services/api/src/scripts/rotate-x-tokens.ts --verify
+ */
+
+import { prisma } from "../lib/prisma";
+import { logger } from "../lib/logger";
+import {
+  decryptToken,
+  encryptToken,
+  encryptionEnabled,
+  isEncrypted,
+} from "../lib/crypto";
+
+const BATCH_SIZE = 100;
+
+interface RotationStats {
+  processed: number;
+  encrypted: number;
+  skipped: number;
+  failed: number;
+}
+
+async function countCandidates(): Promise<number> {
+  return prisma.user.count({
+    where: {
+      OR: [
+        { AND: [{ xAccessToken: { not: null } }, { xAccessTokenEnc: null }] },
+        { AND: [{ xRefreshToken: { not: null } }, { xRefreshTokenEnc: null }] },
+      ],
+    },
+  });
+}
+
+async function rotateBatch(
+  afterId: string | null,
+): Promise<{ stats: RotationStats; lastId: string | null }> {
+  const stats: RotationStats = { processed: 0, encrypted: 0, skipped: 0, failed: 0 };
+
+  const users = await prisma.user.findMany({
+    where: {
+      OR: [
+        { AND: [{ xAccessToken: { not: null } }, { xAccessTokenEnc: null }] },
+        { AND: [{ xRefreshToken: { not: null } }, { xRefreshTokenEnc: null }] },
+      ],
+    },
+    select: {
+      id: true,
+      xAccessToken: true,
+      xRefreshToken: true,
+      xAccessTokenEnc: true,
+      xRefreshTokenEnc: true,
+    },
+    orderBy: { id: "asc" },
+    ...(afterId ? { cursor: { id: afterId }, skip: 1 } : {}),
+    take: BATCH_SIZE,
+  });
+
+  let lastId: string | null = null;
+
+  for (const user of users) {
+    stats.processed++;
+    lastId = user.id;
+
+    // Idempotent: if both plaintext fields are already null OR both enc
+    // fields are populated, skip.
+    const needsAccess = !!user.xAccessToken && !user.xAccessTokenEnc;
+    const needsRefresh = !!user.xRefreshToken && !user.xRefreshTokenEnc;
+    if (!needsAccess && !needsRefresh) {
+      stats.skipped++;
+      continue;
+    }
+
+    try {
+      const data: {
+        xAccessToken?: null;
+        xRefreshToken?: null;
+        xAccessTokenEnc?: string;
+        xRefreshTokenEnc?: string;
+      } = {};
+
+      if (needsAccess && user.xAccessToken) {
+        data.xAccessTokenEnc = encryptToken(user.xAccessToken);
+        data.xAccessToken = null;
+      }
+      if (needsRefresh && user.xRefreshToken) {
+        data.xRefreshTokenEnc = encryptToken(user.xRefreshToken);
+        data.xRefreshToken = null;
+      }
+
+      await prisma.user.update({ where: { id: user.id }, data });
+      stats.encrypted++;
+    } catch (err: any) {
+      logger.error(
+        { err: err.message, userId: user.id },
+        "rotate-x-tokens: failed to rotate user",
+      );
+      stats.failed++;
+    }
+  }
+
+  return { stats, lastId };
+}
+
+async function runRotation(): Promise<void> {
+  logger.info("rotate-x-tokens: starting rotation pass");
+
+  const total: RotationStats = { processed: 0, encrypted: 0, skipped: 0, failed: 0 };
+  let afterId: string | null = null;
+  let batchIndex = 0;
+
+  while (true) {
+    const { stats, lastId } = await rotateBatch(afterId);
+    if (stats.processed === 0) break;
+
+    total.processed += stats.processed;
+    total.encrypted += stats.encrypted;
+    total.skipped += stats.skipped;
+    total.failed += stats.failed;
+    batchIndex++;
+
+    logger.info(
+      {
+        batch: batchIndex,
+        batchStats: stats,
+        totals: { ...total },
+      },
+      "rotate-x-tokens: batch complete",
+    );
+
+    if (stats.processed < BATCH_SIZE) break;
+    afterId = lastId;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log("rotate-x-tokens: rotation complete", total);
+  logger.info({ totals: total }, "rotate-x-tokens: rotation complete");
+}
+
+async function runVerify(): Promise<number> {
+  logger.info("rotate-x-tokens: --verify mode, read-only");
+
+  let checked = 0;
+  let failed = 0;
+  let afterId: string | null = null;
+
+  while (true) {
+    const batch: Array<{
+      id: string;
+      xAccessTokenEnc: string | null;
+      xRefreshTokenEnc: string | null;
+    }> = await prisma.user.findMany({
+      where: {
+        OR: [
+          { xAccessTokenEnc: { not: null } },
+          { xRefreshTokenEnc: { not: null } },
+        ],
+      },
+      select: {
+        id: true,
+        xAccessTokenEnc: true,
+        xRefreshTokenEnc: true,
+      },
+      orderBy: { id: "asc" },
+      ...(afterId ? { cursor: { id: afterId }, skip: 1 } : {}),
+      take: BATCH_SIZE,
+    });
+
+    if (batch.length === 0) break;
+
+    for (const row of batch) {
+      checked++;
+      if (row.xAccessTokenEnc && isEncrypted(row.xAccessTokenEnc)) {
+        try {
+          decryptToken(row.xAccessTokenEnc);
+        } catch (err: any) {
+          failed++;
+          logger.error(
+            { err: err.message, userId: row.id, column: "xAccessTokenEnc" },
+            "rotate-x-tokens: verify decrypt failed",
+          );
+        }
+      }
+      if (row.xRefreshTokenEnc && isEncrypted(row.xRefreshTokenEnc)) {
+        try {
+          decryptToken(row.xRefreshTokenEnc);
+        } catch (err: any) {
+          failed++;
+          logger.error(
+            { err: err.message, userId: row.id, column: "xRefreshTokenEnc" },
+            "rotate-x-tokens: verify decrypt failed",
+          );
+        }
+      }
+    }
+
+    afterId = batch[batch.length - 1]!.id;
+    if (batch.length < BATCH_SIZE) break;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log("rotate-x-tokens: verify complete", { checked, failed });
+  logger.info({ checked, failed }, "rotate-x-tokens: verify complete");
+  return failed;
+}
+
+async function main(): Promise<number> {
+  const verify = process.argv.includes("--verify");
+
+  if (verify) {
+    const failed = await runVerify();
+    return failed > 0 ? 2 : 0;
+  }
+
+  // Dry-run gate: show what would happen without writing.
+  const gateEnabled = process.env.RUN_ROTATE_X_TOKENS === "1";
+  if (!gateEnabled) {
+    const candidates = await countCandidates();
+    // eslint-disable-next-line no-console
+    console.log(
+      "rotate-x-tokens: DRY RUN (RUN_ROTATE_X_TOKENS!=1) —",
+      candidates,
+      "row(s) would be rotated",
+    );
+    // eslint-disable-next-line no-console
+    console.log(
+      "rotate-x-tokens: to actually rotate, run with RUN_ROTATE_X_TOKENS=1 and TOKEN_ENCRYPTION_KEY set",
+    );
+    logger.info({ candidates }, "rotate-x-tokens: dry run — no writes");
+    return 0;
+  }
+
+  // Write gate: key must be live. No point rotating without it.
+  if (!encryptionEnabled()) {
+    logger.error(
+      "rotate-x-tokens: TOKEN_ENCRYPTION_KEY is not set or invalid — aborting",
+    );
+    // eslint-disable-next-line no-console
+    console.error(
+      "rotate-x-tokens: ABORT — TOKEN_ENCRYPTION_KEY must be a valid 32-byte key (hex or base64) before rotation",
+    );
+    return 1;
+  }
+
+  await runRotation();
+  return 0;
+}
+
+if (require.main === module) {
+  main()
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((err) => {
+      logger.error(
+        { err: err.message, stack: err.stack },
+        "rotate-x-tokens: uncaught failure",
+      );
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}


### PR DESCRIPTION
## Summary

- Encrypt X OAuth access / refresh tokens at rest via **AES-256-GCM**, keyed off a new `TOKEN_ENCRYPTION_KEY` env var.
- Dual-column schema: `xAccessTokenEnc` / `xRefreshTokenEnc` live alongside the legacy plaintext columns during the migration window. Reads prefer the encrypted column and fall back to plaintext, so deployments keep working with or without the key set.
- Ship **code now, backfill later** — the `rotate-x-tokens` script is gated behind two explicit env flags so it cannot accidentally run and nuke linked X accounts mid-demo.

## Why now

C-3 is a Wednesday demo blocker flagged by security audit. We lose the ability to argue "tokens are encrypted at rest" the moment anyone grep's the production DB and finds raw X OAuth tokens.

## What's in this PR

### New files
- `services/api/src/lib/crypto.ts` — AES-256-GCM helper with a stable `v1:iv:tag:ct` format, plaintext-fallback semantics, and 19 unit tests covering enabled + disabled + invalid-key paths.
- `services/api/src/__tests__/lib/crypto.test.ts` — 19 unit tests (all green).
- `services/api/src/scripts/rotate-x-tokens.ts` — gated backfill + `--verify` script. **Not wired into CI or package.json; shipped but dormant.**

### Schema
- `prisma/schema.prisma` — adds `xAccessTokenEnc` / `xRefreshTokenEnc` as nullable `String?` columns on `User`, alongside the existing plaintext columns.

### Route / lib wire-ups
- `services/api/src/routes/x-auth.ts` — all **5 token write sites** wrapped in `buildTokenWrite`; status endpoint reads via `readAccessToken` + `TOKEN_READ_SELECT`; disconnect uses `buildTokenClear`.
- `services/api/src/routes/queue.ts` — `getPublishAccessToken` reads through the helpers and writes refreshed tokens via `buildTokenWrite`.
- `services/api/src/routes/drafts.ts` — synchronous `POST /:id/post` and `/process-scheduled` cron loop both decoded & refreshed via helpers.
- `services/api/src/routes/twitter.ts` — `getValidAccessToken` (behind `/api/twitter/follows` + `/api/twitter/likes`) decrypts on read, persists refresh through `buildTokenWrite`. Removes unused `UserXTokens` interface.
- `services/api/src/lib/scheduler.ts` — background `processScheduledDrafts` loop matches the pattern.

### Tests
- `services/api/src/__tests__/routes/x-auth.test.ts` — updated mock fixtures + `toHaveBeenCalledWith` assertions to include the enc columns. 12/12 passing.
- `services/api/src/__tests__/routes/queue.test.ts` — same treatment. 9/9 passing.

## Safety design

- **Zero-key fallback:** if `TOKEN_ENCRYPTION_KEY` is unset, `buildTokenWrite` populates the plaintext columns and leaves enc null — identical to today's behavior. No routes regress when the key isn't deployed yet.
- **Backfill gate:** `rotate-x-tokens.ts` refuses to write unless BOTH `RUN_ROTATE_X_TOKENS=1` AND `encryptionEnabled() === true`. Default behavior is a dry-run that counts candidate rows.
- **Idempotent rotation:** rows already migrated (enc populated, plaintext null) are skipped. Per-row try/catch so one bad row can't halt the pass.
- **`--verify` mode:** post-rotation smoke test that iterates every row with enc columns and attempts to decrypt. Exits non-zero on any failure. Read-only.

## Rollout plan

1. Merge this PR — code goes live with `TOKEN_ENCRYPTION_KEY` unset. All existing flows unchanged.
2. Provision `TOKEN_ENCRYPTION_KEY` in Railway (prod + staging).
3. Deploy — fresh logins start landing in encrypted columns. Existing plaintext rows keep working via the read fallback.
4. After the Wednesday demo window, run `RUN_ROTATE_X_TOKENS=1 node dist/scripts/rotate-x-tokens.js` once.
5. Run `node dist/scripts/rotate-x-tokens.js --verify` to confirm every row decrypts cleanly.
6. In a follow-up PR: drop the plaintext `xAccessToken` / `xRefreshToken` columns from schema (after one cycle of observation).

## Test plan

- [x] `crypto.ts` unit tests — 19/19 passing (encrypted + plaintext paths, hex + base64 keys, tamper detection).
- [x] `x-auth.test.ts` — 12/12 passing with new assertion shapes.
- [x] `queue.test.ts` — 9/9 passing.
- [x] **Full suite:** `npx jest` — 67 suites, 628 tests, all green.
- [x] `npx tsc --noEmit -p tsconfig.test.json` — zero errors.
- [ ] Manual smoke test against staging after `TOKEN_ENCRYPTION_KEY` is provisioned.

## Out of scope

- Dropping plaintext columns (deliberate — migration window).
- Running the backfill (deliberate — gated, ships dormant).
- Key rotation tooling (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)