### PR TITLE
chore(seed): wire scripts/seed-anil.ts as npm run seed:anil (#3948)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "rm -rf dist && npx prisma generate && npx tsc",
     "start": "npx prisma db push --accept-data-loss && node dist/services/api/src/index.js",
     "seed:demo": "npx ts-node scripts/seed-demo.ts",
+    "seed:anil": "npx tsx scripts/seed-anil.ts",
     "db:generate": "npx prisma generate",
     "db:push": "npx prisma db push",
     "db:migrate": "npx prisma migrate dev",

--- a/services/api/src/__tests__/scripts/seed-anil-wired.test.ts
+++ b/services/api/src/__tests__/scripts/seed-anil-wired.test.ts
@@ -1,0 +1,64 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Regression guard for atlas-backend #3948 — "Seed Anil account + voice
+ * profile + demo data". The canonical seed script lives at
+ * `scripts/seed-anil.ts` (not `services/api/src/scripts/seed-anil.ts`,
+ * which is an older duplicate that is not imported anywhere). It must
+ * be wired into `package.json` as `npm run seed:anil` so ops can
+ * repopulate the Wednesday Apr 14 Anil demo in one command rather than
+ * remembering the full `npx tsx` path.
+ *
+ * This test fails loud if the entry is deleted or retargeted to the
+ * wrong file. Deliberately light — it doesn't execute the script
+ * (that would hit a real database) and doesn't duplicate the type
+ * checks that live in prisma + tsconfig.
+ */
+
+// __dirname = services/api/src/__tests__/scripts
+// repo root  = ../../../../../  (5 levels up)
+const REPO_ROOT = path.resolve(__dirname, "../../../../../");
+const PACKAGE_JSON = path.join(REPO_ROOT, "package.json");
+const SEED_ANIL_SCRIPT = path.join(REPO_ROOT, "scripts/seed-anil.ts");
+
+describe("seed:anil — npm script wiring (atlas-backend #3948)", () => {
+  it("repo root resolves to a directory that contains package.json", () => {
+    // Sanity-check the path arithmetic above. If this fails, the other
+    // assertions would produce confusing "file not found" errors.
+    expect(fs.existsSync(PACKAGE_JSON)).toBe(true);
+  });
+
+  it("defines a `seed:anil` entry in package.json scripts", () => {
+    const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, "utf-8"));
+    expect(pkg.scripts).toBeDefined();
+    expect(pkg.scripts["seed:anil"]).toBeDefined();
+  });
+
+  it("the `seed:anil` entry points at scripts/seed-anil.ts (not the old duplicate)", () => {
+    const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, "utf-8"));
+    const cmd: string = pkg.scripts["seed:anil"];
+    // Must target the canonical root-level script. The old duplicate at
+    // services/api/src/scripts/seed-anil.ts is dead code and we don't
+    // want ops pointing at it from package.json.
+    expect(cmd).toMatch(/scripts\/seed-anil\.ts/);
+    expect(cmd).not.toMatch(/services\/api\/src\/scripts\/seed-anil\.ts/);
+    // tsx is the expected runtime — ts-node is slow and has a different
+    // resolver. Keep this assertion strict so a well-meaning swap back
+    // to ts-node doesn't slip through.
+    expect(cmd).toMatch(/npx\s+tsx/);
+  });
+
+  it("the target file exists and looks like the demo-ready script", () => {
+    expect(fs.existsSync(SEED_ANIL_SCRIPT)).toBe(true);
+    const contents = fs.readFileSync(SEED_ANIL_SCRIPT, "utf-8");
+    // Header sentinel from scripts/seed-anil.ts — if someone rewrites
+    // the file from scratch this assertion will force them to update
+    // the expected shape intentionally.
+    expect(contents).toMatch(/Seed \/ Repair Anil Demo Account/);
+    // Contract with the dispatch workflow — the script must be
+    // idempotent. Every version of this file so far has started with a
+    // "safe to run multiple times" promise; keep that invariant.
+    expect(contents.toLowerCase()).toMatch(/idempotent|safe to run multiple times/);
+  });
+});


### PR DESCRIPTION
## Summary
Delivers atlas-backend #3948 — "Seed Anil account + voice profile + demo data". The canonical demo-ready seed script has existed at `scripts/seed-anil.ts` for a while (476 LOC, idempotent, populates X OAuth primary login + voice profile + reference voices + saved blends + drafts + analytics + alerts + learning log), but it was only callable via the full `npx tsx scripts/seed-anil.ts` path. This PR adds the spec-mandated `npm run seed:anil` entry so the Wednesday Apr 14 Anil demo repopulate is a one-liner.

## Changes
- **`package.json`** — new `"seed:anil": "npx tsx scripts/seed-anil.ts"` entry next to `seed:demo`. Uses `tsx` for consistency with the other recent script runners and to avoid the slower ts-node resolver.

## Note on the duplicate
An older `services/api/src/scripts/seed-anil.ts` (316 LOC) exists but is not imported anywhere (grep-verified — only self-references). Intentionally **not** deleted in this PR to keep the blast radius minimal. The regression test below hard-wires `seed:anil` to the canonical root-level file, so the duplicate cannot be accidentally promoted.

## Test plan
- [x] `npx jest services/api/src/__tests__/scripts/seed-anil-wired.test.ts` — 4/4 green
  - package.json has a `seed:anil` script entry
  - entry points at `scripts/seed-anil.ts` (NOT the old duplicate)
  - entry uses `npx tsx` (not ts-node)
  - target file exists with the "demo-ready" header + idempotency promise
- [x] `npx tsc --noEmit` — clean
- [x] `node -e "require('./package.json').scripts['seed:anil']"` — parses
- [ ] CI green on push
- [ ] Post-merge smoke: `DATABASE_URL=... npm run seed:anil` against a throwaway DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)