### PR TITLE
security(paperclip): rate-limit the public webhook (#90230)

### DIFF
--- a/services/api/src/__tests__/routes/paperclip.test.ts
+++ b/services/api/src/__tests__/routes/paperclip.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import express from "express";
 import { requestIdMiddleware } from "../../middleware/requestId";
+import { clearRateLimitStore } from "../../middleware/rateLimiter";
 import { expectErrorResponse, expectSuccessResponse } from "../helpers/response";
 
 jest.mock("../../middleware/auth", () => ({
@@ -85,6 +86,12 @@ const WEBHOOK_HEADERS = { "x-paperclip-secret": "paperclip-webhook-secret" };
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // The webhook route is rate-limited (30 req/min per IP, namespaced
+  // "paperclip-webhook"). Tests share a module-level memory store, so
+  // reset it between tests to avoid leaking counters from one test's
+  // burst into the next test's assertions — that would cause spurious
+  // 429s in unrelated tests as soon as the rate-limit suite lands.
+  clearRateLimitStore();
 });
 
 describe("POST /api/paperclip/webhook", () => {
@@ -275,5 +282,99 @@ describe("POST /api/paperclip/trigger", () => {
     expect(res.status).toBe(502);
     const body = expectErrorResponse(res.body, "Paperclip unavailable");
     expect(body.details).toEqual({ error: "down" });
+  });
+});
+
+// Rate-limit suite for atlas-backend #90230. The Paperclip webhook is
+// "public" (no Authorization header, guarded only by a shared secret),
+// and every accepted hit creates a briefing row + fires a Telegram
+// alert. A tighter per-IP limiter than the general 100/min /api limiter
+// keeps that blast radius bounded. The limiter lives inside the router
+// module (so production and tests see the same configuration).
+describe("POST /api/paperclip/webhook — rate limiting (#90230)", () => {
+  const WEBHOOK_BODY = { type: "task.completed", data: { taskId: "rate-test" } };
+
+  it("allows the first 30 requests through with 200", async () => {
+    for (let i = 0; i < 30; i++) {
+      const res = await request(app)
+        .post("/api/paperclip/webhook")
+        .set(WEBHOOK_HEADERS)
+        .send(WEBHOOK_BODY);
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("returns 429 with Retry-After on the 31st request in the same window", async () => {
+    for (let i = 0; i < 30; i++) {
+      await request(app)
+        .post("/api/paperclip/webhook")
+        .set(WEBHOOK_HEADERS)
+        .send(WEBHOOK_BODY);
+    }
+
+    const res = await request(app)
+      .post("/api/paperclip/webhook")
+      .set(WEBHOOK_HEADERS)
+      .send(WEBHOOK_BODY);
+
+    expect(res.status).toBe(429);
+    // The rate limiter uses `buildErrorResponse` (shape: { error, message })
+    // rather than the `error()` helper from lib/response (shape:
+    // { ok: false, error, timestamp }). Assert against the actual shape.
+    expect(res.body.error).toBe("Too many requests. Please try again later.");
+    // Retry-After is set in seconds and must be positive.
+    expect(res.headers["retry-after"]).toBeDefined();
+    expect(Number(res.headers["retry-after"])).toBeGreaterThan(0);
+  });
+
+  it("sets X-RateLimit-* headers on every response", async () => {
+    const res = await request(app)
+      .post("/api/paperclip/webhook")
+      .set(WEBHOOK_HEADERS)
+      .send(WEBHOOK_BODY);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-ratelimit-limit"]).toBe("30");
+    // First call in a clean window → remaining should be 29.
+    expect(res.headers["x-ratelimit-remaining"]).toBe("29");
+    // Reset timestamp is a unix seconds value in the future.
+    const reset = Number(res.headers["x-ratelimit-reset"]);
+    expect(reset).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it("fires even when the secret is wrong — secret check happens AFTER the limiter", async () => {
+    // This is the key property: a burst of bad-secret requests from an
+    // attacker cannot be used to enumerate past the limiter, because the
+    // limiter is the first middleware on the route. 30 bad-secret hits
+    // count against the same bucket as 30 good-secret hits.
+    for (let i = 0; i < 30; i++) {
+      await request(app)
+        .post("/api/paperclip/webhook")
+        .set("x-paperclip-secret", "wrong")
+        .send(WEBHOOK_BODY);
+    }
+
+    const res = await request(app)
+      .post("/api/paperclip/webhook")
+      .set(WEBHOOK_HEADERS)
+      .send(WEBHOOK_BODY);
+
+    expect(res.status).toBe(429);
+  });
+
+  it("does NOT rate-limit /api/paperclip/trigger (authenticated route)", async () => {
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({ role: "ADMIN" });
+    mockTriggerPaperclipTask.mockResolvedValue({ taskId: "task-X" } as any);
+
+    // 31 authenticated /trigger calls — should not trip the webhook
+    // limiter because /trigger has no route-level limiter. (The general
+    // /api limiter is not wired into this test app.)
+    for (let i = 0; i < 31; i++) {
+      const res = await request(app)
+        .post("/api/paperclip/trigger")
+        .set(AUTH)
+        .send({ agentId: "a", taskType: "t", payload: {} });
+      expect(res.status).not.toBe(429);
+    }
   });
 });

--- a/services/api/src/routes/paperclip.ts
+++ b/services/api/src/routes/paperclip.ts
@@ -12,8 +12,31 @@ import { prisma } from "../lib/prisma";
 import { error, success } from "../lib/response";
 import { deliverAlertToUser } from "../lib/telegram";
 import { authenticate, AuthRequest } from "../middleware/auth";
+import { rateLimit } from "../middleware/rateLimit";
 
 export const paperclipRouter = Router();
+
+/**
+ * IP-based rate limiter for the public Paperclip webhook endpoint.
+ *
+ * The webhook is "public" in that it carries no `Authorization` header —
+ * it's protected by a shared `x-paperclip-secret`, which stops external
+ * attackers but does nothing about an upstream Paperclip bug looping on
+ * digest.ready events, nor about a leaked secret being blasted at the
+ * endpoint. Each successful hit creates a `briefing` row and fans out a
+ * Telegram alert, so the blast radius of "too many valid hits" is real.
+ *
+ * 30 req/min per IP is tighter than the general `/api` limiter
+ * (100/min) and leaves enough headroom for normal Paperclip traffic,
+ * which in practice sends a handful of digests per user per day. The
+ * `"paperclip-webhook"` namespace prevents counter collision with any
+ * other route-level limiter that might stack on the same path.
+ *
+ * This limiter is ONLY wired into the `/webhook` route (see below) —
+ * `/trigger` is authenticated + admin-gated and already benefits from
+ * the per-user general limiter.
+ */
+const paperclipWebhookRateLimiter = rateLimit(30, 60 * 1000, "paperclip-webhook");
 
 const supportedEventTypes = [
   "task.completed",
@@ -121,7 +144,7 @@ function normalizeDigestPayload(input: unknown) {
   };
 }
 
-paperclipRouter.post("/webhook", async (req, res) => {
+paperclipRouter.post("/webhook", paperclipWebhookRateLimiter, async (req, res) => {
   try {
     const expectedSecret = config.PAPERCLIP_WEBHOOK_SECRET?.trim();
     if (!expectedSecret) {


### PR DESCRIPTION
## Summary
Delivers atlas-backend #90230 — "Backend: add rate limiting to public API endpoints". Audit found **one** public endpoint missing an explicit route-level limiter: `POST /api/paperclip/webhook`. Every other public/unauthenticated route is already covered (`auth.ts` per-endpoint, `x-auth.ts` router-level, `docs.ts` via index.ts, everything else authenticated + general `/api` limiter).

## Threat
The Paperclip webhook is guarded by a shared `x-paperclip-secret` header — that stops external attackers but does nothing about an upstream Paperclip bug looping on `digest.ready` or a leaked secret being blasted at the endpoint. **Each accepted hit creates a `briefing` row AND fires a Telegram alert.** "Too many valid hits" has a real blast radius.

## Fix
- **`paperclipWebhookRateLimiter = rateLimit(30, 60_000, "paperclip-webhook")`** — 30 req/min per IP, namespaced.
- Wired as the **first** middleware on the `/webhook` route only.
- **Runs before the shared-secret check**, so a burst of bad-secret hits still counts against the bucket — attackers can't enumerate past the limiter by rotating secrets.
- `/trigger` stays un-route-limited (already authenticated + admin-gated, covered by the general per-user limiter).

## Audit notes (scope decision)
| Route | Status | Notes |
|---|---|---|
| `auth.ts` | ✅ covered | Per-endpoint `authRateLimiter`/`registerRateLimiter`/`loginRateLimiter` |
| `x-auth.ts` | ✅ covered | `xAuthRouter.use(rateLimit(20, 60_000))` router-level |
| `docs.ts` | ✅ covered | `docsRateLimiter` wired in index.ts:122 |
| `paperclip.ts /webhook` | **this PR** | Was unauthenticated + unlimited (except the general 100/min fallback) |
| `paperclip.ts /trigger` | ✅ covered | Authenticated + admin-gated |
| All other routes | ✅ covered | `authenticate` + general per-user `/api` limiter |

## Test plan
- [x] `npx jest services/api/src/__tests__/routes/paperclip.test.ts` — **14/14 green** (9 existing + 5 new)
  - 30 requests succeed
  - 31st returns 429 with `Retry-After`
  - `X-RateLimit-Limit/Remaining/Reset` headers set
  - 429 fires even with wrong secret (limiter is first)
  - `/trigger` is NOT rate-limited by the new middleware
- [x] Existing tests now `clearRateLimitStore()` in beforeEach to prevent counter leakage
- [x] `npx tsc --noEmit` — clean
- [ ] CI green on push
- [ ] Post-merge: hit `/api/paperclip/webhook` 31× from a curl loop and verify 429 on the 31st

🤖 Generated with [Claude Code](https://claude.com/claude-code)