### PR TITLE
feat(security): per-user AI rate limit on 5 cost-heavy routes (#88075)

### DIFF
--- a/services/api/src/__tests__/routes/ai-rate-limits.test.ts
+++ b/services/api/src/__tests__/routes/ai-rate-limits.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Integration test for the AI generation per-user rate limiter.
+ *
+ * #88075 — closes the demo-blocker gap where /api/research, /api/oracle,
+ * /api/campaigns/generate-from-pdf, /api/transcribe, and /api/images all
+ * called paid LLM/transcription APIs without a per-user cap. The general
+ * /api limiter is too loose for these (60-100/min); a single demo account
+ * could burn the project's monthly Anthropic / OpenAI / Gemini budget in
+ * minutes.
+ *
+ * The cap reuses `RATE_LIMIT_AI_GENERATION_MAX_REQUESTS` (already used by
+ * drafts.ts), so this test pins the wiring at the router level: third
+ * request from the same user must 429, fourth from a different user must
+ * still pass. Coverage on the limiter mechanics themselves lives in
+ * middleware/rateLimit.test.ts — this test only proves the middleware is
+ * present on the route.
+ */
+
+import request from "supertest";
+import express from "express";
+import { requestIdMiddleware } from "../../middleware/requestId";
+import { clearRateLimitStore } from "../../middleware/rateLimiter";
+import { expectSuccessResponse } from "../helpers/response";
+
+// Mock auth so the test can pin a deterministic userId per request via the
+// Authorization header. Mirrors the pattern in routes/paperclip.test.ts.
+jest.mock("../../middleware/auth", () => ({
+  authenticate: jest.fn((req: any, res: any, next: any) => {
+    const header = req.headers.authorization;
+    if (!header?.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Missing authorization token" });
+    }
+    req.userId = header.slice("Bearer ".length);
+    next();
+  }),
+  AuthRequest: {},
+}));
+
+// Tight cap so the test can prove the limiter trips without sending 20+
+// requests. The router reads config at import time, so this mock must
+// land before the route module is required.
+jest.mock("../../lib/config", () => ({
+  config: {
+    NODE_ENV: "test",
+    RATE_LIMIT_AI_GENERATION_MAX_REQUESTS: 2,
+    RATE_LIMIT_AI_GENERATION_WINDOW_MS: 60_000,
+  },
+}));
+
+// Stub the research backend so handler logic is hermetic — the limiter is
+// what we're exercising, not the Anthropic call path.
+jest.mock("../../lib/research", () => ({
+  conductResearch: jest.fn().mockResolvedValue({
+    summary: "stubbed",
+    keyFacts: [],
+    sentiment: "neutral",
+    relatedTopics: [],
+    sources: [],
+    confidence: 0.5,
+  }),
+}));
+
+jest.mock("../../lib/prisma", () => ({
+  prisma: {
+    researchResult: {
+      create: jest.fn().mockResolvedValue({ id: "research-1" }),
+      findMany: jest.fn().mockResolvedValue([]),
+      count: jest.fn().mockResolvedValue(0),
+    },
+    analyticsEvent: {
+      create: jest.fn().mockResolvedValue({ id: "event-1" }),
+    },
+  },
+}));
+
+import { researchRouter } from "../../routes/research";
+
+const app = express();
+app.set("trust proxy", 1);
+app.use(express.json());
+app.use(requestIdMiddleware);
+app.use("/api/research", researchRouter);
+
+const RESEARCH_BODY = { query: "what is the price of bitcoin" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Memory store is module-level — reset between tests so a previous
+  // test's burst doesn't leak into the next one.
+  clearRateLimitStore();
+});
+
+describe("POST /api/research — AI generation rate limit (#88075)", () => {
+  it("allows requests up to the configured limit and 429s the next one", async () => {
+    const headers = { Authorization: "Bearer user-alpha" };
+
+    const first = await request(app).post("/api/research").set(headers).send(RESEARCH_BODY);
+    const second = await request(app).post("/api/research").set(headers).send(RESEARCH_BODY);
+    const third = await request(app).post("/api/research").set(headers).send(RESEARCH_BODY);
+
+    expect(first.status).toBe(200);
+    expectSuccessResponse(first.body);
+    expect(first.headers["x-ratelimit-limit"]).toBe("2");
+    expect(first.headers["x-ratelimit-remaining"]).toBe("1");
+
+    expect(second.status).toBe(200);
+    expect(second.headers["x-ratelimit-remaining"]).toBe("0");
+
+    expect(third.status).toBe(429);
+    expect(third.body.error).toBe("Too many requests. Please try again later.");
+    expect(third.headers["retry-after"]).toEqual(expect.any(String));
+  });
+
+  it("buckets independently per authenticated user", async () => {
+    // Burn user-alpha's quota first.
+    await request(app)
+      .post("/api/research")
+      .set("Authorization", "Bearer user-alpha")
+      .send(RESEARCH_BODY);
+    await request(app)
+      .post("/api/research")
+      .set("Authorization", "Bearer user-alpha")
+      .send(RESEARCH_BODY);
+    const alphaBlocked = await request(app)
+      .post("/api/research")
+      .set("Authorization", "Bearer user-alpha")
+      .send(RESEARCH_BODY);
+    expect(alphaBlocked.status).toBe(429);
+
+    // user-beta starts with a fresh quota — proves the limiter buckets by
+    // userId, not a shared global counter that would punish unrelated users.
+    const betaFresh = await request(app)
+      .post("/api/research")
+      .set("Authorization", "Bearer user-beta")
+      .send(RESEARCH_BODY);
+    expect(betaFresh.status).toBe(200);
+    expect(betaFresh.headers["x-ratelimit-remaining"]).toBe("1");
+  });
+
+  it("does not consume quota for unauthenticated requests (auth runs first)", async () => {
+    // No Authorization header → auth middleware should reject with 401
+    // before the limiter sees the request, so we don't burn the IP bucket.
+    const res = await request(app).post("/api/research").send(RESEARCH_BODY);
+    expect(res.status).toBe(401);
+  });
+});

--- a/services/api/src/__tests__/routes/images.test.ts
+++ b/services/api/src/__tests__/routes/images.test.ts
@@ -42,13 +42,31 @@ jest.mock("../../lib/gemini", () => ({
   generateVisualConcept: jest.fn(),
 }));
 
-const mockConfig = {
-  GOOGLE_AI_API_KEY: "test-key",
-  GEMINI_MODEL: "gemini-2.5-flash",
-};
+// Mock factory must be self-contained — `jest.mock` is hoisted ABOVE any
+// `const`/`let` declarations in this file, so a closure-captured `mockConfig`
+// is undefined at the moment the route module is imported (which happens
+// before the test body runs). Routes/images.ts now triggers the rate-limit
+// middleware load on import, which reads `config.NODE_ENV` synchronously,
+// so the factory must hand back a fully populated object on the first read.
 jest.mock("../../lib/config", () => ({
-  get config() { return mockConfig; },
+  config: {
+    GOOGLE_AI_API_KEY: "test-key",
+    GEMINI_MODEL: "gemini-2.5-flash",
+    // NODE_ENV = "test" so the cleanup interval in middleware/rateLimiter.ts
+    // doesn't register and leak open handles into the Jest worker.
+    NODE_ENV: "test",
+    // RATE_LIMIT_AI_GENERATION_* are read by the per-user limiter wired
+    // onto POST /generate and POST /generate-for-draft (#88075). Pinned
+    // high so existing behavior tests don't accidentally trip the limit.
+    RATE_LIMIT_AI_GENERATION_MAX_REQUESTS: 1000,
+    RATE_LIMIT_AI_GENERATION_WINDOW_MS: 60_000,
+  },
 }));
+
+// Mutable reference to the same config object the route sees — tests below
+// flip GOOGLE_AI_API_KEY to exercise the "service not configured" branch.
+const mockConfig = (jest.requireMock("../../lib/config") as { config: any })
+  .config;
 
 import { prisma } from "../../lib/prisma";
 import { generateImage, generateVisualConcept } from "../../lib/gemini";

--- a/services/api/src/routes/campaigns-pdf.ts
+++ b/services/api/src/routes/campaigns-pdf.ts
@@ -2,6 +2,8 @@ import { Router } from "express";
 import multer from "multer";
 import { z } from "zod";
 import { authenticate, AuthRequest } from "../middleware/auth";
+import { rateLimitByUser } from "../middleware/rateLimit";
+import { config } from "../lib/config";
 import { logger } from "../lib/logger";
 import { success, error } from "../lib/response";
 import { extractInsights } from "../lib/content-extraction";
@@ -24,6 +26,15 @@ import {
  */
 export const campaignsPdfRouter = Router();
 campaignsPdfRouter.use(authenticate);
+
+// PDF→multi-tweet generation runs `extractInsights` (Anthropic) and then
+// `batchGenerateDrafts` (one Anthropic call per angle). A single request
+// can burn 5–10 LLM completions, so this needs the same per-user cap as
+// the other AI cost paths.
+const aiGenerationLimiter = rateLimitByUser(
+  config.RATE_LIMIT_AI_GENERATION_MAX_REQUESTS,
+  config.RATE_LIMIT_AI_GENERATION_WINDOW_MS,
+);
 
 // Multipart body coerces everything to strings, so validate accordingly and
 // coerce after. The file itself is handled by multer and isn't in req.body.
@@ -68,7 +79,9 @@ const pdfUpload = multer({
 //     pipeline for stored content
 // This route is the bridge so a client doesn't need to stage intermediate
 // content to call those two separately.
-campaignsPdfRouter.post("/generate-from-pdf", pdfUpload.single("file"), async (req: AuthRequest, res) => {
+// Rate-limit BEFORE multer so a flood of requests doesn't pay the
+// multipart parse cost just to be rejected.
+campaignsPdfRouter.post("/generate-from-pdf", aiGenerationLimiter, pdfUpload.single("file"), async (req: AuthRequest, res) => {
   try {
     if (!req.file) {
       return res.status(400).json(error("No file provided", 400));

--- a/services/api/src/routes/images.ts
+++ b/services/api/src/routes/images.ts
@@ -4,11 +4,20 @@ import { prisma } from "../lib/prisma";
 import { config } from "../lib/config";
 import { error, success } from "../lib/response";
 import { authenticate, AuthRequest } from "../middleware/auth";
+import { rateLimitByUser } from "../middleware/rateLimit";
 import { generateImage, generateVisualConcept, ImageStyle } from "../lib/gemini";
 import { logger } from "../lib/logger";
 
 export const imagesRouter = Router();
 imagesRouter.use(authenticate);
+
+// Image generation (Gemini) is metered per-image. The general API limiter
+// is too loose for this — apply the dedicated AI cost knob so demo users
+// can't accidentally run a 1000-image render loop.
+const aiGenerationLimiter = rateLimitByUser(
+  config.RATE_LIMIT_AI_GENERATION_MAX_REQUESTS,
+  config.RATE_LIMIT_AI_GENERATION_WINDOW_MS,
+);
 
 const generateSchema = z.object({
   prompt: z.string().min(1).max(5000),
@@ -104,7 +113,7 @@ async function createImageRecord(userId: string, prompt: string, style: ImageSty
 }
 
 // Standalone image concept generation
-imagesRouter.post("/generate", async (req: AuthRequest, res) => {
+imagesRouter.post("/generate", aiGenerationLimiter, async (req: AuthRequest, res) => {
   try {
     if (!config.GOOGLE_AI_API_KEY) {
       return res.status(503).json(error("Image generation is not configured — GOOGLE_AI_API_KEY missing", 503));
@@ -124,7 +133,7 @@ imagesRouter.post("/generate", async (req: AuthRequest, res) => {
 });
 
 // Generate companion visual for an existing draft
-imagesRouter.post("/generate-for-draft", async (req: AuthRequest, res) => {
+imagesRouter.post("/generate-for-draft", aiGenerationLimiter, async (req: AuthRequest, res) => {
   try {
     if (!config.GOOGLE_AI_API_KEY) {
       return res.status(503).json(error("Image generation is not configured — GOOGLE_AI_API_KEY missing", 503));

--- a/services/api/src/routes/oracle.ts
+++ b/services/api/src/routes/oracle.ts
@@ -2,6 +2,8 @@ import { Prisma } from "@prisma/client";
 import { Response, Router } from "express";
 import { z } from "zod";
 import { authenticate, AuthRequest } from "../middleware/auth";
+import { rateLimitByUser } from "../middleware/rateLimit";
+import { config } from "../lib/config";
 import { getAnthropicClient } from "../lib/anthropic";
 import {
   runOracleCompletion,
@@ -24,6 +26,16 @@ import type { ToolCall } from "../lib/providers/types";
 
 export const oracleRouter = Router();
 oracleRouter.use(authenticate);
+
+// Oracle endpoints all hit Anthropic (and sometimes burn multiple
+// turns per request via tool calling). They're the most expensive
+// surface in the API, so they get the same per-user AI cost cap as
+// drafts/research/transcribe/images/campaigns-pdf. Read endpoints
+// (`GET /session`, `DELETE /session`) stay on the general limiter.
+const aiGenerationLimiter = rateLimitByUser(
+  config.RATE_LIMIT_AI_GENERATION_MAX_REQUESTS,
+  config.RATE_LIMIT_AI_GENERATION_WINDOW_MS,
+);
 
 // ── Schema ───────────────────────────────────────────────────────
 
@@ -253,7 +265,7 @@ oracleRouter.delete("/session", async (req: AuthRequest, res) => {
   }
 });
 
-oracleRouter.post("/message", async (req: AuthRequest, res) => {
+oracleRouter.post("/message", aiGenerationLimiter, async (req: AuthRequest, res) => {
   try {
     if (
       typeof req.body === "object" &&
@@ -565,7 +577,7 @@ async function handleLegacyChat(req: AuthRequest, res: Response) {
   res.json(success({ text: response.content.trim() }));
 }
 
-oracleRouter.post("/chat", async (req: AuthRequest, res) => {
+oracleRouter.post("/chat", aiGenerationLimiter, async (req: AuthRequest, res) => {
   try {
     // Discriminate by body shape — the new OpenClaw route uses `message`
     // (singular string); the legacy widget path uses `messages` (array).
@@ -755,7 +767,7 @@ async function executeServerSide(
   }
 }
 
-oracleRouter.post("/agent", async (req: AuthRequest, res) => {
+oracleRouter.post("/agent", aiGenerationLimiter, async (req: AuthRequest, res) => {
   try {
     const body = agentSchema.parse(req.body);
 

--- a/services/api/src/routes/research.ts
+++ b/services/api/src/routes/research.ts
@@ -4,18 +4,30 @@ import { parsePagination } from "../lib/pagination";
 import { prisma } from "../lib/prisma";
 import { error, success } from "../lib/response";
 import { authenticate, AuthRequest } from "../middleware/auth";
+import { rateLimitByUser } from "../middleware/rateLimit";
+import { config } from "../lib/config";
 import { conductResearch } from "../lib/research";
 import { logger } from "../lib/logger";
 
 export const researchRouter = Router();
 researchRouter.use(authenticate);
 
+// Per-user rate limit for the Anthropic-backed research endpoint. Each
+// call burns through tokens — without a per-user cap a single account
+// can blow through the project's monthly LLM budget in minutes during
+// a customer demo. Mirrors drafts.ts/aiGenerationLimiter so we get one
+// knob in config (RATE_LIMIT_AI_GENERATION_*) for every AI cost path.
+const aiGenerationLimiter = rateLimitByUser(
+  config.RATE_LIMIT_AI_GENERATION_MAX_REQUESTS,
+  config.RATE_LIMIT_AI_GENERATION_WINDOW_MS,
+);
+
 const researchSchema = z.object({
   query: z.string().min(1).max(100000),
 });
 
 // Standalone research endpoint
-researchRouter.post("/", async (req: AuthRequest, res) => {
+researchRouter.post("/", aiGenerationLimiter, async (req: AuthRequest, res) => {
   try {
     const body = researchSchema.parse(req.body);
 

--- a/services/api/src/routes/transcribe.ts
+++ b/services/api/src/routes/transcribe.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import multer from "multer";
 import OpenAI from "openai";
 import { authenticate, AuthRequest } from "../middleware/auth";
+import { rateLimitByUser } from "../middleware/rateLimit";
 import { buildErrorResponse } from "../middleware/requestId";
 import { logger } from "../lib/logger";
 import { config } from "../lib/config";
@@ -10,12 +11,23 @@ import { success } from "../lib/response";
 export const transcribeRouter = Router();
 transcribeRouter.use(authenticate);
 
+// Whisper transcription is paid per-minute of audio and runs unbounded
+// until the file size limit kicks in. Cap it on the same per-user knob
+// as the other AI cost paths (drafts/research/oracle/images/campaigns-pdf)
+// so a single demo account can't burn through the OpenAI quota.
+const aiGenerationLimiter = rateLimitByUser(
+  config.RATE_LIMIT_AI_GENERATION_MAX_REQUESTS,
+  config.RATE_LIMIT_AI_GENERATION_WINDOW_MS,
+);
+
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 25 * 1024 * 1024 }, // 25 MB (Whisper limit)
 });
 
-transcribeRouter.post("/", upload.single("audio"), async (req: AuthRequest, res) => {
+// Rate-limit BEFORE multer so we don't waste the multipart parse on
+// requests we're going to reject anyway.
+transcribeRouter.post("/", aiGenerationLimiter, upload.single("audio"), async (req: AuthRequest, res) => {
   try {
     if (!req.file) {
       return res.status(400).json(buildErrorResponse(req, "No audio file provided"));


### PR DESCRIPTION
## Summary

- Wires `RATE_LIMIT_AI_GENERATION_*` (already used by `drafts.ts`) onto every remaining route that calls a paid LLM / transcription / image API. Closes the SL-113 demo-blocker thread carried forward from the Apr 10 burn session.
- Routes covered (8 endpoints across 5 files):
  - `POST /api/research/` (Anthropic)
  - `POST /api/oracle/{message,chat,agent}` (Anthropic, multi-turn)
  - `POST /api/campaigns/generate-from-pdf` (Anthropic, N angles per request)
  - `POST /api/transcribe/` (OpenAI Whisper)
  - `POST /api/images/{generate,generate-for-draft}` (Gemini image)
- Limiter is mounted **before** `multer` on transcribe + campaigns-pdf so a flood of requests doesn't pay the multipart parse cost just to be 429'd.

## Why

The burn session locked down auth (#158, #159) and the paperclip webhook (#182), but the AI cost paths above were still only behind the general `/api` limiter (60–100 req/min per user). A single demo account could spam `/api/oracle/chat` and burn the project's monthly Anthropic budget in minutes — exactly the kind of incident that would kill an Anil-style customer demo.

Default cap: **20 req/hour per user**, identical to the existing `drafts.ts` cap. One config knob (`RATE_LIMIT_AI_GENERATION_MAX_REQUESTS` / `_WINDOW_MS`) governs the entire AI cost surface.

## Test plan

- [x] New test: `services/api/src/__tests__/routes/ai-rate-limits.test.ts` — 3 scenarios (limit trip, per-user bucketing, auth-first order) using `/api/research` as the canonical wire-up proof. Limiter mechanics are already covered by `middleware/rateLimit.test.ts`.
- [x] Patches `images.test.ts` config mock — the new limiter import in `routes/images.ts` triggers a synchronous read of `config.NODE_ENV` at module load, which tripped Jest's hoisting rules with the previous getter→outer-`mockConfig` pattern. Factory now owns the config object and the test grabs a mutable reference via `jest.requireMock`.
- [x] Full backend suite: **71/71 passing, 662/662 tests** (+3 new).
- [x] Type-check clean (`npx tsc --noEmit`).

## Lane discipline

T3 lane: `services/api/src/routes/**` + tests only. CSP middleware untouched (T2 owns that). No changes to schema, scripts, or other lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)