### PR TITLE
test(alerts): pin Alert.deliveredAt stamping + route serialization

### DIFF
--- a/prisma/migrations/20260411210000_alert_delivered_at/migration.sql
+++ b/prisma/migrations/20260411210000_alert_delivered_at/migration.sql
@@ -1,0 +1,14 @@
+-- Add `deliveredAt` to the `alerts` table for Telegram delivery tracking.
+--
+-- Background: this column was originally added via `prisma db push` (the
+-- repo's de-facto schema sync mechanism — see CLAUDE.md "Prisma db push
+-- runs on startup to sync schema") in commit 2b2ba62. Production already
+-- has the column, so this migration is the catch-up record so any future
+-- environment that bootstraps via `prisma migrate deploy` (rather than
+-- `db push`) ends up in the same state.
+--
+-- `IF NOT EXISTS` keeps it idempotent against environments where db push
+-- already created the column, so applying the full migration history
+-- against a "warm" database is a no-op for this row.
+
+ALTER TABLE "alerts" ADD COLUMN IF NOT EXISTS "deliveredAt" TIMESTAMP(3);

--- a/services/api/src/__tests__/lib/alertDelivery.test.ts
+++ b/services/api/src/__tests__/lib/alertDelivery.test.ts
@@ -9,6 +9,14 @@ jest.mock("../../lib/prisma", () => ({
     alertSubscription: {
       findMany: jest.fn(),
     },
+    alert: {
+      // Stamping path: dispatchAlert calls prisma.alert.update with
+      // { deliveredAt } when deliverAlertToUser resolves to true. The
+      // mock has to exist on the module-level prisma reference so the
+      // .then() callback in alertDelivery.ts can call .catch() on the
+      // returned chain without throwing.
+      update: jest.fn().mockReturnValue({ catch: jest.fn() }),
+    },
   },
 }));
 
@@ -113,5 +121,56 @@ describe("dispatchAlert", () => {
     expect(errorSpy).toHaveBeenCalledWith({ err: error }, "[alertDelivery] Dispatch failed for alert alert-1");
 
     errorSpy.mockRestore();
+  });
+
+  // ── deliveredAt stamping (Alert.deliveredAt + Telegram delivery tracking) ──
+  //
+  // dispatchAlert fires deliverAlertToUser without awaiting it, then attaches
+  // a `.then((ok) => { if (ok) prisma.alert.update(...) })` callback. The two
+  // tests below pin both branches of that callback so the field gets stamped
+  // exactly when delivery actually succeeded — and never on failure.
+
+  it("stamps deliveredAt on the Alert row when Telegram delivery succeeds", async () => {
+    (mockPrisma.alertSubscription.findMany as jest.Mock).mockResolvedValueOnce([
+      { id: "sub-1", delivery: ["TELEGRAM"] },
+    ]);
+    // Telegram delivery returns truthy → stamping branch fires.
+    mockDeliverAlertToUser.mockResolvedValueOnce(true);
+    // Reset the chained-mock so we can assert against this single call.
+    (mockPrisma.alert.update as jest.Mock).mockClear();
+    (mockPrisma.alert.update as jest.Mock).mockReturnValueOnce({ catch: jest.fn() });
+
+    await dispatchAlert(baseAlert);
+    // The .then() handler runs on the next microtask after the awaited
+    // deliverAlertToUser promise resolves; flushing twice covers both the
+    // deliver promise and the chained .then.
+    await flushPromises();
+    await flushPromises();
+
+    expect(mockPrisma.alert.update).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.alert.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "alert-1" },
+        data: expect.objectContaining({ deliveredAt: expect.any(Date) }),
+      }),
+    );
+  });
+
+  it("leaves deliveredAt unset when Telegram delivery fails", async () => {
+    (mockPrisma.alertSubscription.findMany as jest.Mock).mockResolvedValueOnce([
+      { id: "sub-1", delivery: ["TELEGRAM"] },
+    ]);
+    // Telegram delivery returns falsy → stamping branch must NOT fire.
+    // (Falsy here means the bot couldn't reach the user — not an exception.
+    // Exception path is covered by the existing "logs Telegram delivery
+    // failures" test above.)
+    mockDeliverAlertToUser.mockResolvedValueOnce(false);
+    (mockPrisma.alert.update as jest.Mock).mockClear();
+
+    await dispatchAlert(baseAlert);
+    await flushPromises();
+    await flushPromises();
+
+    expect(mockPrisma.alert.update).not.toHaveBeenCalled();
   });
 });

--- a/services/api/src/__tests__/routes/alerts.test.ts
+++ b/services/api/src/__tests__/routes/alerts.test.ts
@@ -238,6 +238,49 @@ describe("GET /api/alerts/feed", () => {
       expect.objectContaining({ where: { userId: "user-123" } })
     );
   });
+
+  // Pin the contract that the feed serializes Alert.deliveredAt back to the
+  // client. The route relies on Prisma's default-select behavior (no `select`
+  // clause → all columns) to surface this — if a future change adds a `select`
+  // and forgets to include deliveredAt, Telegram delivery tracking goes dark
+  // in the portal feed and this test catches it.
+  it("returns deliveredAt on each alert (Telegram delivery tracking)", async () => {
+    const deliveredAt = new Date("2026-04-11T20:00:00.000Z");
+    const alerts = [
+      {
+        id: "a-delivered",
+        title: "Telegram delivered",
+        createdAt: new Date("2026-04-11T19:55:00.000Z"),
+        deliveredAt,
+      },
+      {
+        id: "a-undelivered",
+        title: "Not yet delivered",
+        createdAt: new Date("2026-04-11T19:50:00.000Z"),
+        deliveredAt: null,
+      },
+    ];
+    (mockPrisma.alert.findMany as jest.Mock).mockResolvedValueOnce(alerts);
+    // Defense-in-depth: assert the route does NOT add a `select` clause —
+    // adding one without `deliveredAt: true` would silently drop the field
+    // from the response. Tests caught the ai-rate-limit drift the same way
+    // (asserting on call shape, not just response).
+    const res = await request(app).get("/api/alerts/feed").set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.alerts).toHaveLength(2);
+    expect(res.body.data.alerts[0]).toMatchObject({
+      id: "a-delivered",
+      deliveredAt: deliveredAt.toISOString(),
+    });
+    expect(res.body.data.alerts[1]).toMatchObject({
+      id: "a-undelivered",
+      deliveredAt: null,
+    });
+    // Confirm the Prisma call did not narrow the column set.
+    const findManyCall = (mockPrisma.alert.findMany as jest.Mock).mock.calls[0][0];
+    expect(findManyCall.select).toBeUndefined();
+  });
 });
 
 describe("GET /api/alerts/:id", () => {


### PR DESCRIPTION
## Summary

The \`Alert.deliveredAt\` field and the \`dispatchAlert()\` Telegram-stamping logic both shipped earlier in commit \`2b2ba62\` (\"feat: add deliveredAt to Alert model + stamp on Telegram delivery\"), but neither path had a regression test. This PR closes that gap with the three explicit tests requested by the demo-blocker brief plus a catch-up Prisma migration.

## What ships

**Tests (3 new, +3 total in suite):**

1. \`__tests__/lib/alertDelivery.test.ts\` — *\"stamps deliveredAt on the Alert row when Telegram delivery succeeds\"* — pins the \`.then((ok) => prisma.alert.update(...))\` branch and asserts the \`{ where: { id }, data: { deliveredAt: <Date> } }\` payload.

2. \`__tests__/lib/alertDelivery.test.ts\` — *\"leaves deliveredAt unset when Telegram delivery fails\"* — pins the negative branch (delivery returns \`false\`) so a future refactor can't accidentally stamp on a falsy return.

3. \`__tests__/routes/alerts.test.ts\` — *\"returns deliveredAt on each alert (Telegram delivery tracking)\"* — exercises \`GET /api/alerts/feed\` with two mocked alerts (one stamped, one \`null\`) and verifies both surface in the JSON response. Also asserts the route does **NOT** add a \`select\` clause — adding one without \`deliveredAt: true\` would silently drop the field.

**Migration (catch-up):**

\`prisma/migrations/20260411210000_alert_delivered_at/migration.sql\` — single \`ALTER TABLE \"alerts\" ADD COLUMN IF NOT EXISTS \"deliveredAt\" TIMESTAMP(3);\`. The column was originally added via \`prisma db push\` (the repo's de-facto schema sync per \`CLAUDE.md\`), so production already has it; the \`IF NOT EXISTS\` makes applying the full migration history against a warm database a no-op for this row, while any future bootstrap via \`prisma migrate deploy\` ends up in the same schema state.

## Why now

The demo flow needs a way to show \"this alert reached the user via Telegram at HH:MM\" — the data was already being stamped, but no test pinned the contract, and no migration recorded the schema change for cold environments. Both gaps would have bitten us during the customer demo.

## Lane discipline

- **No production code touched.** The route + library logic was already correct in commit \`2b2ba62\`.
- **No conflict with cc-55084's in-flight #3937 Zod validation work** in \`routes/alerts.ts\` — the route test only imports the router and mocks Prisma; whatever Zod-validation lines they add to the PATCH handler don't affect the GET /feed contract this test exercises.
- **Worktree-isolated:** all work happened in \`~/projects/atlas-backend-alert-tests\` so the main checkout stays untouched while their dirty WIP sits there.

## Test plan

- [x] \`npx jest alertDelivery alerts.test\` — both new + existing pass (42/42)
- [x] Full backend suite — **71 suites / 665 tests passing** (was 662, +3 new)
- [x] \`npx tsc --noEmit\` — clean
- [x] Migration SQL is idempotent (\`IF NOT EXISTS\`) and safe to apply against environments where \`db push\` already added the column

🤖 Generated with [Claude Code](https://claude.com/claude-code)