### PR TITLE
perf: add missing Prisma indexes for common queries

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,8 @@ model User {
   voiceDimensionInsight VoiceDimensionInsight?
   blendedVoiceProfile   BlendedVoiceProfile?
 
+  @@index([supabaseId])
+  @@index([xHandle])
   @@map("users")
 }
 
@@ -78,6 +80,7 @@ model Session {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  @@index([userId])
   @@map("sessions")
 }
 
@@ -90,6 +93,7 @@ model OracleSession {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@index([userId, updatedAt])
   @@map("oracle_sessions")
 }
 
@@ -184,6 +188,7 @@ model SavedBlend {
   user   User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   voices BlendVoice[]
 
+  @@index([userId])
   @@map("saved_blends")
 }
 
@@ -230,6 +235,8 @@ model TweetDraft {
   @@index([status, scheduledAt])
   @@index([campaignId])
   @@index([userId, sortOrder])
+  @@index([userId, status])
+  @@index([userId, createdAt])
   @@map("tweet_drafts")
 }
 


### PR DESCRIPTION
## Summary
- Adds 7 database indexes to `prisma/schema.prisma` for query patterns that were missing coverage:
  - `User(supabaseId)` — auth lookups by Supabase ID
  - `User(xHandle)` — X handle lookups
  - `TweetDraft(userId, status)` — draft listing filtered by status
  - `TweetDraft(userId, createdAt)` — draft listing sorted by date
  - `OracleSession(userId, updatedAt)` — recent Oracle session lookup
  - `Session(userId)` — session lookups by user
  - `SavedBlend(userId)` — blend listing by user

## Test plan
- [ ] `npx prisma validate` passes
- [ ] Deploy to staging and confirm `prisma db push` applies cleanly
- [ ] No breaking changes — additive index-only migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)