### PR TITLE
fix: remove duplicate adminBackupRouter mount

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,8 @@ model User {
   voiceDimensionInsight VoiceDimensionInsight?
   blendedVoiceProfile   BlendedVoiceProfile?
 
+  @@index([supabaseId])
+  @@index([xHandle])
   @@map("users")
 }
 
@@ -78,6 +80,7 @@ model Session {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  @@index([userId])
   @@map("sessions")
 }
 
@@ -90,6 +93,7 @@ model OracleSession {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@index([userId, updatedAt])
   @@map("oracle_sessions")
 }
 
@@ -184,6 +188,7 @@ model SavedBlend {
   user   User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   voices BlendVoice[]
 
+  @@index([userId])
   @@map("saved_blends")
 }
 
@@ -230,6 +235,8 @@ model TweetDraft {
   @@index([status, scheduledAt])
   @@index([campaignId])
   @@index([userId, sortOrder])
+  @@index([userId, status])
+  @@index([userId, createdAt])
   @@map("tweet_drafts")
 }
 

--- a/services/api/src/__tests__/routes/admin.test.ts
+++ b/services/api/src/__tests__/routes/admin.test.ts
@@ -1,0 +1,567 @@
+/**
+ * Admin routes test suite
+ * Tests GET /overview, /roster, /pipeline, /adoption, /activity-daily
+ * Mocks: Prisma, auth middleware
+ */
+
+import request from "supertest";
+import express from "express";
+import { adminRouter } from "../../routes/admin";
+import { requestIdMiddleware } from "../../middleware/requestId";
+import { expectErrorResponse, expectSuccessResponse } from "../helpers/response";
+
+/* ── Auth mock ────────────────────────────────────────────────── */
+jest.mock("../../middleware/auth", () => ({
+  authenticate: jest.fn((req: any, res: any, next: any) => {
+    const header = req.headers.authorization;
+    if (!header?.startsWith("Bearer "))
+      return res.status(401).json({ error: "Missing authorization token" });
+    req.userId = "user-admin";
+    next();
+  }),
+  AuthRequest: {},
+}));
+
+jest.mock("../../lib/supabase", () => ({ supabaseAdmin: null }));
+jest.mock("../../lib/logger", () => ({ logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() } }));
+
+/* ── Prisma mock ──────────────────────────────────────────────── */
+jest.mock("../../lib/prisma", () => ({
+  prisma: {
+    user: {
+      count: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+    },
+    analyticsEvent: {
+      count: jest.fn(),
+      groupBy: jest.fn(),
+      findMany: jest.fn(),
+    },
+    tweetDraft: {
+      aggregate: jest.fn(),
+      groupBy: jest.fn(),
+    },
+    voiceProfile: {
+      count: jest.fn(),
+    },
+    alertSubscription: {
+      groupBy: jest.fn(),
+    },
+    briefing: {
+      groupBy: jest.fn(),
+    },
+    campaign: {
+      groupBy: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from "../../lib/prisma";
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+/* ── App setup ────────────────────────────────────────────────── */
+const app = express();
+app.use(express.json());
+app.use(requestIdMiddleware);
+app.use("/api/admin", adminRouter);
+
+const AUTH = { Authorization: "Bearer mock_token" };
+
+beforeAll(() => {
+  process.env.JWT_SECRET = "test-secret";
+});
+
+afterAll(() => {
+  delete process.env.JWT_SECRET;
+});
+
+/* ── Helper: make findUnique return an ADMIN user ─────────────── */
+function mockAdmin() {
+  (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+    id: "user-admin",
+    role: "ADMIN",
+  });
+}
+
+function mockNonAdmin() {
+  (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+    id: "user-admin",
+    role: "ANALYST",
+  });
+}
+
+function mockUserNotFound() {
+  (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce(null);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GET /api/admin/overview
+// ═══════════════════════════════════════════════════════════════
+
+describe("GET /api/admin/overview", () => {
+  it("returns 401 without token", async () => {
+    const res = await request(app).get("/api/admin/overview");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin user", async () => {
+    mockNonAdmin();
+    const res = await request(app).get("/api/admin/overview").set(AUTH);
+    expect(res.status).toBe(403);
+    expectErrorResponse(res.body, "Admin access required");
+  });
+
+  it("returns 403 when user not found", async () => {
+    mockUserNotFound();
+    const res = await request(app).get("/api/admin/overview").set(AUTH);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns platform-wide KPIs", async () => {
+    mockAdmin();
+
+    (mockPrisma.user.count as jest.Mock).mockResolvedValueOnce(42);
+    (mockPrisma.analyticsEvent.groupBy as jest.Mock).mockResolvedValueOnce(
+      // activeUsers7d — 3 distinct users
+      [{ userId: "u1" }, { userId: "u2" }, { userId: "u3" }],
+    );
+    (mockPrisma.analyticsEvent.count as jest.Mock)
+      .mockResolvedValueOnce(100) // draftsCreated30d
+      .mockResolvedValueOnce(25) // draftsPosted30d
+      .mockResolvedValueOnce(8); // imagesGenerated30d
+    (mockPrisma.tweetDraft.aggregate as jest.Mock).mockResolvedValueOnce({
+      _avg: { actualEngagement: 4.5, predictedEngagement: 3.2 },
+    });
+
+    const res = await request(app).get("/api/admin/overview").set(AUTH);
+    expect(res.status).toBe(200);
+
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.totalUsers).toBe(42);
+    expect(data.activeUsers7d).toBe(3);
+    expect(data.draftsCreated30d).toBe(100);
+    expect(data.draftsPosted30d).toBe(25);
+    expect(data.imagesGenerated30d).toBe(8);
+    expect(data.avgActualEngagement30d).toBe(4.5);
+    expect(data.avgPredictedEngagement30d).toBe(3.2);
+  });
+
+  it("returns null engagement when no posted drafts", async () => {
+    mockAdmin();
+
+    (mockPrisma.user.count as jest.Mock).mockResolvedValueOnce(1);
+    (mockPrisma.analyticsEvent.groupBy as jest.Mock).mockResolvedValueOnce([]);
+    (mockPrisma.analyticsEvent.count as jest.Mock)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0);
+    (mockPrisma.tweetDraft.aggregate as jest.Mock).mockResolvedValueOnce({
+      _avg: { actualEngagement: null, predictedEngagement: null },
+    });
+
+    const res = await request(app).get("/api/admin/overview").set(AUTH);
+    expect(res.status).toBe(200);
+
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.avgActualEngagement30d).toBeNull();
+    expect(data.avgPredictedEngagement30d).toBeNull();
+  });
+
+  it("returns 500 on prisma error", async () => {
+    mockAdmin();
+    (mockPrisma.user.count as jest.Mock).mockRejectedValueOnce(new Error("DB down"));
+
+    const res = await request(app).get("/api/admin/overview").set(AUTH);
+    expect(res.status).toBe(500);
+    expectErrorResponse(res.body, "Failed to load admin overview");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// GET /api/admin/roster
+// ═══════════════════════════════════════════════════════════════
+
+describe("GET /api/admin/roster", () => {
+  it("returns 401 without token", async () => {
+    const res = await request(app).get("/api/admin/roster");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin user", async () => {
+    mockNonAdmin();
+    const res = await request(app).get("/api/admin/roster").set(AUTH);
+    expect(res.status).toBe(403);
+    expectErrorResponse(res.body, "Admin access required");
+  });
+
+  it("returns user roster with usage stats", async () => {
+    mockAdmin();
+
+    const now = new Date();
+    (mockPrisma.user.findMany as jest.Mock).mockResolvedValueOnce([
+      {
+        id: "u1",
+        handle: "alice",
+        displayName: "Alice",
+        role: "ANALYST",
+        onboardingTrack: "CRYPTO",
+        tourCompleted: true,
+        createdAt: now,
+        xHandle: "alice_x",
+        passwordHash: "should-be-stripped",
+        voiceProfile: { maturity: "ADVANCED", tweetsAnalyzed: 50 },
+        _count: { tweetDrafts: 20 },
+      },
+      {
+        id: "u2",
+        handle: "bob",
+        displayName: "Bob",
+        role: "MANAGER",
+        onboardingTrack: null,
+        tourCompleted: false,
+        createdAt: now,
+        xHandle: null,
+        passwordHash: "also-stripped",
+        voiceProfile: null,
+        _count: { tweetDrafts: 0 },
+      },
+    ]);
+    (mockPrisma.tweetDraft.groupBy as jest.Mock).mockResolvedValueOnce([
+      { userId: "u1", _count: { _all: 10 } },
+    ]);
+    (mockPrisma.analyticsEvent.groupBy as jest.Mock).mockResolvedValueOnce([
+      { userId: "u1", _count: { _all: 35 }, _max: { createdAt: now } },
+    ]);
+
+    const res = await request(app).get("/api/admin/roster").set(AUTH);
+    expect(res.status).toBe(200);
+
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.users).toHaveLength(2);
+
+    const alice = data.users[0];
+    expect(alice.id).toBe("u1");
+    expect(alice.handle).toBe("alice");
+    expect(alice.voiceMaturity).toBe("ADVANCED");
+    expect(alice.tweetsAnalyzed).toBe(50);
+    expect(alice.totalDrafts).toBe(20);
+    expect(alice.totalPosts).toBe(10);
+    expect(alice.events30d).toBe(35);
+    expect(alice.lastSeen).toBe(now.toISOString());
+    // passwordHash must not be in the response
+    expect(alice.passwordHash).toBeUndefined();
+
+    const bob = data.users[1];
+    expect(bob.voiceMaturity).toBeNull();
+    expect(bob.tweetsAnalyzed).toBe(0);
+    expect(bob.totalPosts).toBe(0);
+    expect(bob.events30d).toBe(0);
+    expect(bob.lastSeen).toBeNull();
+  });
+
+  it("returns empty roster when no users", async () => {
+    mockAdmin();
+
+    (mockPrisma.user.findMany as jest.Mock).mockResolvedValueOnce([]);
+    (mockPrisma.tweetDraft.groupBy as jest.Mock).mockResolvedValueOnce([]);
+    (mockPrisma.analyticsEvent.groupBy as jest.Mock).mockResolvedValueOnce([]);
+
+    const res = await request(app).get("/api/admin/roster").set(AUTH);
+    expect(res.status).toBe(200);
+    expect(expectSuccessResponse<any>(res.body).users).toEqual([]);
+  });
+
+  it("returns 500 on prisma error", async () => {
+    mockAdmin();
+    (mockPrisma.user.findMany as jest.Mock).mockRejectedValueOnce(new Error("DB down"));
+
+    const res = await request(app).get("/api/admin/roster").set(AUTH);
+    expect(res.status).toBe(500);
+    expectErrorResponse(res.body, "Failed to load admin roster");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// GET /api/admin/pipeline
+// ═══════════════════════════════════════════════════════════════
+
+describe("GET /api/admin/pipeline", () => {
+  it("returns 401 without token", async () => {
+    const res = await request(app).get("/api/admin/pipeline");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin user", async () => {
+    mockNonAdmin();
+    const res = await request(app).get("/api/admin/pipeline").set(AUTH);
+    expect(res.status).toBe(403);
+    expectErrorResponse(res.body, "Admin access required");
+  });
+
+  it("returns funnel and sourceTypes with data", async () => {
+    mockAdmin();
+
+    (mockPrisma.tweetDraft.groupBy as jest.Mock)
+      .mockResolvedValueOnce([
+        // status groups
+        { status: "DRAFT", _count: { _all: 15 } },
+        { status: "POSTED", _count: { _all: 8 } },
+        { status: "APPROVED", _count: { _all: 3 } },
+      ])
+      .mockResolvedValueOnce([
+        // source groups
+        { sourceType: "REPORT", _count: { _all: 10 } },
+        { sourceType: "TWEET", _count: { _all: 5 } },
+        { sourceType: null, _count: { _all: 2 } },
+      ]);
+
+    const res = await request(app).get("/api/admin/pipeline").set(AUTH);
+    expect(res.status).toBe(200);
+
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.funnel).toEqual({
+      DRAFT: 15,
+      APPROVED: 3,
+      SCHEDULED: 0,
+      POSTED: 8,
+      ARCHIVED: 0,
+    });
+    expect(data.sourceTypes.REPORT).toBe(10);
+    expect(data.sourceTypes.TWEET).toBe(5);
+    // null sourceType entries are skipped
+    expect(data.sourceTypes.MANUAL).toBe(0);
+  });
+
+  it("returns zeroed funnel when no drafts exist", async () => {
+    mockAdmin();
+
+    (mockPrisma.tweetDraft.groupBy as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const res = await request(app).get("/api/admin/pipeline").set(AUTH);
+    expect(res.status).toBe(200);
+
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.funnel).toEqual({
+      DRAFT: 0,
+      APPROVED: 0,
+      SCHEDULED: 0,
+      POSTED: 0,
+      ARCHIVED: 0,
+    });
+    expect(data.sourceTypes).toEqual({
+      REPORT: 0,
+      ARTICLE: 0,
+      TWEET: 0,
+      TRENDING_TOPIC: 0,
+      VOICE_NOTE: 0,
+      MANUAL: 0,
+    });
+  });
+
+  it("returns 500 on prisma error", async () => {
+    mockAdmin();
+    (mockPrisma.tweetDraft.groupBy as jest.Mock).mockRejectedValueOnce(
+      new Error("DB down"),
+    );
+
+    const res = await request(app).get("/api/admin/pipeline").set(AUTH);
+    expect(res.status).toBe(500);
+    expectErrorResponse(res.body, "Failed to load admin pipeline");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// GET /api/admin/adoption
+// ═══════════════════════════════════════════════════════════════
+
+describe("GET /api/admin/adoption", () => {
+  it("returns 401 without token", async () => {
+    const res = await request(app).get("/api/admin/adoption");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin user", async () => {
+    mockNonAdmin();
+    const res = await request(app).get("/api/admin/adoption").set(AUTH);
+    expect(res.status).toBe(403);
+    expectErrorResponse(res.body, "Admin access required");
+  });
+
+  it("returns feature adoption counts", async () => {
+    mockAdmin();
+
+    (mockPrisma.user.count as jest.Mock).mockResolvedValueOnce(50);
+    (mockPrisma.voiceProfile.count as jest.Mock).mockResolvedValueOnce(30);
+    (mockPrisma.analyticsEvent.groupBy as jest.Mock)
+      .mockResolvedValueOnce([{ userId: "u1" }, { userId: "u2" }]) // researchUsed
+      .mockResolvedValueOnce([{ userId: "u1" }, { userId: "u3" }, { userId: "u4" }]); // imagesGenerated
+    (mockPrisma.alertSubscription.groupBy as jest.Mock).mockResolvedValueOnce([
+      { userId: "u1" },
+    ]);
+    (mockPrisma.briefing.groupBy as jest.Mock).mockResolvedValueOnce([
+      { userId: "u1" },
+      { userId: "u2" },
+      { userId: "u3" },
+    ]);
+    (mockPrisma.campaign.groupBy as jest.Mock).mockResolvedValueOnce([
+      { userId: "u1" },
+      { userId: "u2" },
+    ]);
+
+    const res = await request(app).get("/api/admin/adoption").set(AUTH);
+    expect(res.status).toBe(200);
+
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.totalUsers).toBe(50);
+    expect(data.voiceCalibrated).toBe(30);
+    expect(data.researchUsed30d).toBe(2);
+    expect(data.alertsConfigured).toBe(1);
+    expect(data.briefingsGenerated30d).toBe(3);
+    expect(data.campaignsCreated).toBe(2);
+    expect(data.imagesGenerated30d).toBe(3);
+  });
+
+  it("returns zeros when no adoption data", async () => {
+    mockAdmin();
+
+    (mockPrisma.user.count as jest.Mock).mockResolvedValueOnce(0);
+    (mockPrisma.voiceProfile.count as jest.Mock).mockResolvedValueOnce(0);
+    (mockPrisma.analyticsEvent.groupBy as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    (mockPrisma.alertSubscription.groupBy as jest.Mock).mockResolvedValueOnce([]);
+    (mockPrisma.briefing.groupBy as jest.Mock).mockResolvedValueOnce([]);
+    (mockPrisma.campaign.groupBy as jest.Mock).mockResolvedValueOnce([]);
+
+    const res = await request(app).get("/api/admin/adoption").set(AUTH);
+    expect(res.status).toBe(200);
+
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.totalUsers).toBe(0);
+    expect(data.voiceCalibrated).toBe(0);
+    expect(data.researchUsed30d).toBe(0);
+    expect(data.alertsConfigured).toBe(0);
+    expect(data.briefingsGenerated30d).toBe(0);
+    expect(data.campaignsCreated).toBe(0);
+    expect(data.imagesGenerated30d).toBe(0);
+  });
+
+  it("returns 500 on prisma error", async () => {
+    mockAdmin();
+    (mockPrisma.user.count as jest.Mock).mockRejectedValueOnce(new Error("DB down"));
+
+    const res = await request(app).get("/api/admin/adoption").set(AUTH);
+    expect(res.status).toBe(500);
+    expectErrorResponse(res.body, "Failed to load admin adoption");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// GET /api/admin/activity-daily
+// ═══════════════════════════════════════════════════════════════
+
+describe("GET /api/admin/activity-daily", () => {
+  it("returns 401 without token", async () => {
+    const res = await request(app).get("/api/admin/activity-daily");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin user", async () => {
+    mockNonAdmin();
+    const res = await request(app).get("/api/admin/activity-daily").set(AUTH);
+    expect(res.status).toBe(403);
+    expectErrorResponse(res.body, "Admin access required");
+  });
+
+  it("returns 30 days of activity data with events bucketed", async () => {
+    mockAdmin();
+
+    const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    (mockPrisma.analyticsEvent.findMany as jest.Mock).mockResolvedValueOnce([
+      { type: "DRAFT_CREATED", createdAt: today },
+      { type: "DRAFT_CREATED", createdAt: today },
+      { type: "DRAFT_POSTED", createdAt: today },
+      { type: "DRAFT_CREATED", createdAt: yesterday },
+      { type: "DRAFT_POSTED", createdAt: yesterday },
+      { type: "DRAFT_POSTED", createdAt: yesterday },
+    ]);
+
+    const res = await request(app).get("/api/admin/activity-daily").set(AUTH);
+    expect(res.status).toBe(200);
+
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.days).toHaveLength(30);
+
+    // Each day has date, created, posted
+    for (const day of data.days) {
+      expect(day).toHaveProperty("date");
+      expect(day).toHaveProperty("created");
+      expect(day).toHaveProperty("posted");
+      expect(typeof day.date).toBe("string");
+      expect(typeof day.created).toBe("number");
+      expect(typeof day.posted).toBe("number");
+    }
+
+    // Today's bucket
+    const todayKey = today.toISOString().slice(0, 10);
+    const todayBucket = data.days.find((d: any) => d.date === todayKey);
+    if (todayBucket) {
+      expect(todayBucket.created).toBe(2);
+      expect(todayBucket.posted).toBe(1);
+    }
+
+    // Yesterday's bucket
+    const yesterdayKey = yesterday.toISOString().slice(0, 10);
+    const yesterdayBucket = data.days.find((d: any) => d.date === yesterdayKey);
+    if (yesterdayBucket) {
+      expect(yesterdayBucket.created).toBe(1);
+      expect(yesterdayBucket.posted).toBe(2);
+    }
+  });
+
+  it("returns 30 zeroed days when no events exist", async () => {
+    mockAdmin();
+    (mockPrisma.analyticsEvent.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+    const res = await request(app).get("/api/admin/activity-daily").set(AUTH);
+    expect(res.status).toBe(200);
+
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.days).toHaveLength(30);
+
+    for (const day of data.days) {
+      expect(day.created).toBe(0);
+      expect(day.posted).toBe(0);
+    }
+  });
+
+  it("days are sorted chronologically", async () => {
+    mockAdmin();
+    (mockPrisma.analyticsEvent.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+    const res = await request(app).get("/api/admin/activity-daily").set(AUTH);
+    expect(res.status).toBe(200);
+
+    const data = expectSuccessResponse<any>(res.body);
+    const dates = data.days.map((d: any) => d.date);
+    const sorted = [...dates].sort();
+    expect(dates).toEqual(sorted);
+  });
+
+  it("returns 500 on prisma error", async () => {
+    mockAdmin();
+    (mockPrisma.analyticsEvent.findMany as jest.Mock).mockRejectedValueOnce(
+      new Error("DB down"),
+    );
+
+    const res = await request(app).get("/api/admin/activity-daily").set(AUTH);
+    expect(res.status).toBe(500);
+    expectErrorResponse(res.body, "Failed to load admin activity daily");
+  });
+});

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -152,7 +152,6 @@ app.use("/api/qa", qaRouter);
 app.use("/api/admin/feature-flags", adminFlagsRouter);
 app.use("/api/admin/backup", adminBackupRouter);
 app.use("/api/admin", adminRouter);
-app.use("/api/admin/backup", adminBackupRouter);
 app.use("/api/twitter", twitterRouter);
 app.use("/api/queue", queueRouter);
 


### PR DESCRIPTION
## Summary
- Removes the duplicate `app.use("/api/admin/backup", adminBackupRouter)` mount on line 155 of `services/api/src/index.ts`
- The router was already correctly mounted at line 153, before `adminRouter`

## Test plan
- [ ] Confirm `/api/admin/backup` routes still respond correctly in staging