### PR TITLE
feat(api): draft history endpoint

### DIFF
--- a/services/api/src/__tests__/routes/drafts-history.test.ts
+++ b/services/api/src/__tests__/routes/drafts-history.test.ts
@@ -1,0 +1,257 @@
+import request from "supertest";
+import express from "express";
+import { draftsRouter } from "../../routes/drafts";
+import { requestIdMiddleware } from "../../middleware/requestId";
+
+jest.mock("../../middleware/auth", () => ({
+  authenticate: jest.fn((req: any, res: any, next: any) => {
+    const header = req.headers.authorization;
+    if (!header?.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Missing authorization token" });
+    }
+
+    req.userId = "user-123";
+    next();
+  }),
+  AuthRequest: {},
+}));
+
+jest.mock("../../lib/supabase", () => ({ supabaseAdmin: null }));
+
+jest.mock("../../lib/prisma", () => ({
+  prisma: {
+    tweetDraft: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    voiceProfile: {
+      findUnique: jest.fn(),
+    },
+    savedBlend: {
+      findFirst: jest.fn(),
+    },
+    analyticsEvent: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../lib/pipeline", () => ({
+  runGenerationPipeline: jest.fn(),
+}));
+
+jest.mock("../../lib/content-extraction", () => ({
+  extractInsights: jest.fn(),
+}));
+
+jest.mock("../../lib/batch-generate", () => ({
+  batchGenerateDrafts: jest.fn(),
+}));
+
+import { prisma } from "../../lib/prisma";
+
+const app = express();
+app.use(express.json());
+app.use(requestIdMiddleware);
+app.use("/api/drafts", draftsRouter);
+
+const AUTH = "Bearer mock_token";
+const mockFindMany = prisma.tweetDraft.findMany as jest.Mock;
+const mockCount = prisma.tweetDraft.count as jest.Mock;
+
+function makeDraft(index: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id: `draft-${index}`,
+    userId: "user-123",
+    content: `Draft ${index}`,
+    version: 1,
+    status: "DRAFT",
+    confidence: 0.8,
+    predictedEngagement: 100 + index,
+    actualEngagement: null,
+    engagementMetrics: null,
+    xTweetId: null,
+    metricsLastFetchedAt: null,
+    sourceType: "MANUAL",
+    sourceContent: null,
+    blendId: null,
+    feedback: null,
+    scheduledAt: null,
+    campaignId: null,
+    sortOrder: null,
+    voiceDimensionsSnapshot: null,
+    createdAt: new Date(`2026-04-${String((index % 28) + 1).padStart(2, "0")}T12:00:00.000Z`),
+    updatedAt: new Date(`2026-04-${String((index % 28) + 1).padStart(2, "0")}T12:05:00.000Z`),
+    ...overrides,
+  };
+}
+
+function encodeCursor(id: string, createdAt: string): string {
+  return Buffer.from(JSON.stringify({ id, createdAt }), "utf8").toString("base64");
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFindMany.mockResolvedValue([]);
+  mockCount.mockResolvedValue(0);
+});
+
+describe("GET /api/drafts/history", () => {
+  it("returns the first 50 drafts sorted newest-first by default", async () => {
+    const drafts = Array.from({ length: 50 }, (_, index) => makeDraft(index + 1));
+    mockFindMany.mockResolvedValueOnce(drafts);
+    mockCount.mockResolvedValueOnce(50);
+
+    const res = await request(app)
+      .get("/api/drafts/history")
+      .set("Authorization", AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.drafts).toHaveLength(50);
+    expect(res.body.data.hasMore).toBe(false);
+    expect(res.body.data.nextCursor).toBeNull();
+    expect(res.body.data.total).toBe(50);
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { userId: "user-123" },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: 51,
+    });
+    expect(mockCount).toHaveBeenCalledWith({
+      where: { userId: "user-123" },
+    });
+  });
+
+  it("applies a multi-status filter", async () => {
+    mockFindMany.mockResolvedValueOnce([makeDraft(1, { status: "POSTED" })]);
+    mockCount.mockResolvedValueOnce(1);
+
+    const res = await request(app)
+      .get("/api/drafts/history?status=POSTED,SCHEDULED")
+      .set("Authorization", AUTH);
+
+    expect(res.status).toBe(200);
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId: "user-123",
+          status: { in: ["POSTED", "SCHEDULED"] },
+        },
+      }),
+    );
+  });
+
+  it("applies an inclusive createdAt date range", async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    mockCount.mockResolvedValueOnce(0);
+
+    const from = "2026-04-01T00:00:00.000Z";
+    const to = "2026-04-10T23:59:59.999Z";
+
+    const res = await request(app)
+      .get(`/api/drafts/history?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`)
+      .set("Authorization", AUTH);
+
+    expect(res.status).toBe(200);
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId: "user-123",
+          createdAt: {
+            gte: new Date(from),
+            lte: new Date(to),
+          },
+        },
+      }),
+    );
+  });
+
+  it("continues from the cursor for newest sort with a stable tiebreaker", async () => {
+    const cursorCreatedAt = "2026-04-10T12:00:00.000Z";
+    const nextPage = [
+      makeDraft(3, { id: "draft-3", createdAt: new Date("2026-04-09T12:00:00.000Z") }),
+      makeDraft(2, { id: "draft-2", createdAt: new Date("2026-04-09T10:00:00.000Z") }),
+      makeDraft(1, { id: "draft-1", createdAt: new Date("2026-04-08T12:00:00.000Z") }),
+    ];
+    mockFindMany.mockResolvedValueOnce(nextPage);
+    mockCount.mockResolvedValueOnce(25);
+
+    const cursor = encodeCursor("draft-9", cursorCreatedAt);
+    const res = await request(app)
+      .get(`/api/drafts/history?limit=2&cursor=${encodeURIComponent(cursor)}&sort=newest`)
+      .set("Authorization", AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.drafts).toHaveLength(2);
+    expect(res.body.data.hasMore).toBe(true);
+    expect(res.body.data.nextCursor).toBe(
+      encodeCursor("draft-2", "2026-04-09T10:00:00.000Z"),
+    );
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: {
+        AND: [
+          { userId: "user-123" },
+          {
+            OR: [
+              { createdAt: { lt: new Date(cursorCreatedAt) } },
+              { createdAt: new Date(cursorCreatedAt), id: { lt: "draft-9" } },
+            ],
+          },
+        ],
+      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: 3,
+    });
+  });
+
+  it("clamps limit to 200", async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    mockCount.mockResolvedValueOnce(0);
+
+    const res = await request(app)
+      .get("/api/drafts/history?limit=999")
+      .set("Authorization", AUTH);
+
+    expect(res.status).toBe(200);
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 201,
+      }),
+    );
+  });
+
+  it("returns 400 for an invalid status filter", async () => {
+    const res = await request(app)
+      .get("/api/drafts/history?status=FAILED")
+      .set("Authorization", AUTH);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+    expect(mockFindMany).not.toHaveBeenCalled();
+    expect(mockCount).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty page with a null cursor when no drafts match", async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    mockCount.mockResolvedValueOnce(0);
+
+    const res = await request(app)
+      .get("/api/drafts/history?status=POSTED")
+      .set("Authorization", AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      drafts: [],
+      nextCursor: null,
+      hasMore: false,
+      total: 0,
+    });
+  });
+});

--- a/services/api/src/routes/drafts.ts
+++ b/services/api/src/routes/drafts.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import type { DraftStatus, Prisma, TweetDraft } from "@prisma/client";
 import { z } from "zod";
 import { prisma } from "../lib/prisma";
 import { authenticate, AuthRequest } from "../middleware/auth";
@@ -67,6 +68,184 @@ const updateDraftSchema = z.object({
   status: z.enum(["DRAFT", "APPROVED", "POSTED", "ARCHIVED"]).optional(),
   feedback: z.string().optional(),
 });
+
+const draftHistoryStatusValues = ["DRAFT", "APPROVED", "SCHEDULED", "POSTED", "ARCHIVED"] as const;
+const draftHistoryStatusSet = new Set<string>(draftHistoryStatusValues);
+
+type DraftHistoryCursorPayload = {
+  id: string;
+  createdAt: string;
+};
+
+type DraftHistoryCursor = {
+  id: string;
+  createdAt: Date;
+};
+
+export type DraftHistorySort = "newest" | "oldest";
+
+export type DraftHistoryQuery = {
+  status?: DraftStatus[];
+  from?: Date;
+  to?: Date;
+  limit: number;
+  cursor?: DraftHistoryCursor;
+  sort: DraftHistorySort;
+};
+
+export type DraftHistoryResponse = {
+  drafts: TweetDraft[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  total: number | null;
+};
+
+const emptyStringToUndefined = (value: unknown) => value === "" ? undefined : value;
+
+const draftHistoryCursorSchema = z.object({
+  id: z.string().min(1),
+  createdAt: z.string().datetime({ offset: true }),
+});
+
+function encodeDraftHistoryCursor(draft: Pick<TweetDraft, "id" | "createdAt">): string {
+  const payload: DraftHistoryCursorPayload = {
+    id: draft.id,
+    createdAt: draft.createdAt.toISOString(),
+  };
+
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
+}
+
+function decodeDraftHistoryCursor(cursor: string): DraftHistoryCursor {
+  let decoded: unknown;
+
+  try {
+    decoded = JSON.parse(Buffer.from(cursor, "base64").toString("utf8"));
+  } catch {
+    throw new Error("Invalid cursor");
+  }
+
+  const parsed = draftHistoryCursorSchema.safeParse(decoded);
+  if (!parsed.success) {
+    throw new Error("Invalid cursor");
+  }
+
+  return {
+    id: parsed.data.id,
+    createdAt: new Date(parsed.data.createdAt),
+  };
+}
+
+const draftHistoryQuerySchema = z
+  .object({
+    status: z.preprocess(emptyStringToUndefined, z.string().optional()),
+    from: z.preprocess(emptyStringToUndefined, z.string().datetime({ offset: true }).optional()),
+    to: z.preprocess(emptyStringToUndefined, z.string().datetime({ offset: true }).optional()),
+    limit: z
+      .preprocess(emptyStringToUndefined, z.coerce.number().int().positive().default(50))
+      .transform((value) => Math.min(value, 200)),
+    cursor: z.preprocess(emptyStringToUndefined, z.string().optional()),
+    sort: z.preprocess(emptyStringToUndefined, z.enum(["newest", "oldest"]).default("newest")),
+  })
+  .superRefine((value, ctx) => {
+    const statuses = value.status
+      ?.split(",")
+      .map((status) => status.trim())
+      .filter(Boolean);
+
+    if (value.status && (!statuses || statuses.length === 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["status"],
+        message: "At least one status is required",
+      });
+    }
+
+    for (const status of statuses ?? []) {
+      if (!draftHistoryStatusSet.has(status)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["status"],
+          message: `Invalid draft status: ${status}`,
+        });
+      }
+    }
+
+    if (value.from && value.to && new Date(value.from) > new Date(value.to)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["from"],
+        message: "`from` must be before or equal to `to`",
+      });
+    }
+
+    if (value.cursor) {
+      try {
+        decodeDraftHistoryCursor(value.cursor);
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["cursor"],
+          message: "Invalid cursor",
+        });
+      }
+    }
+  })
+  .transform(
+    (value): DraftHistoryQuery => ({
+      status: value.status
+        ? value.status
+            .split(",")
+            .map((status) => status.trim())
+            .filter(Boolean) as DraftStatus[]
+        : undefined,
+      from: value.from ? new Date(value.from) : undefined,
+      to: value.to ? new Date(value.to) : undefined,
+      limit: value.limit,
+      cursor: value.cursor ? decodeDraftHistoryCursor(value.cursor) : undefined,
+      sort: value.sort,
+    }),
+  );
+
+function buildDraftHistoryWhere(userId: string, query: DraftHistoryQuery): Prisma.TweetDraftWhereInput {
+  const where: Prisma.TweetDraftWhereInput = {
+    userId,
+  };
+
+  if (query.status?.length) {
+    where.status = { in: query.status };
+  }
+
+  if (query.from || query.to) {
+    where.createdAt = {
+      ...(query.from ? { gte: query.from } : {}),
+      ...(query.to ? { lte: query.to } : {}),
+    };
+  }
+
+  return where;
+}
+
+function buildDraftHistoryCursorWhere(
+  cursor: DraftHistoryCursor,
+  sort: DraftHistorySort,
+): Prisma.TweetDraftWhereInput {
+  if (sort === "oldest") {
+    return {
+      OR: [
+        { createdAt: { gt: cursor.createdAt } },
+        { createdAt: cursor.createdAt, id: { gt: cursor.id } },
+      ],
+    };
+  }
+
+  return {
+    OR: [
+      { createdAt: { lt: cursor.createdAt } },
+      { createdAt: cursor.createdAt, id: { lt: cursor.id } },
+    ],
+  };
+}
 
 // Generate a tweet from source content using AI
 draftsRouter.post("/generate", aiGenerationLimiter, async (req: AuthRequest, res) => {
@@ -339,6 +518,55 @@ draftsRouter.get("/", async (req: AuthRequest, res) => {
     res.json(success({ drafts }));
   } catch (err: any) {
     res.status(500).json(buildErrorResponse(req, "Failed to load drafts"));
+  }
+});
+
+// Paginated draft history
+draftsRouter.get("/history", async (req: AuthRequest, res) => {
+  try {
+    const query = draftHistoryQuerySchema.parse(req.query);
+    const baseWhere = buildDraftHistoryWhere(req.userId!, query);
+    const where: Prisma.TweetDraftWhereInput = query.cursor
+      ? {
+          AND: [baseWhere, buildDraftHistoryCursorWhere(query.cursor, query.sort)],
+        }
+      : baseWhere;
+    const orderBy: Prisma.TweetDraftOrderByWithRelationInput[] =
+      query.sort === "oldest"
+        ? [{ createdAt: "asc" }, { id: "asc" }]
+        : [{ createdAt: "desc" }, { id: "desc" }];
+
+    const [rows, totalCount] = await Promise.all([
+      prisma.tweetDraft.findMany({
+        where,
+        orderBy,
+        take: query.limit + 1,
+      }),
+      prisma.tweetDraft.count({ where: baseWhere }),
+    ]);
+
+    const hasMore = rows.length > query.limit;
+    const drafts = rows.slice(0, query.limit);
+    const nextCursor = hasMore && drafts.length > 0
+      ? encodeDraftHistoryCursor(drafts[drafts.length - 1])
+      : null;
+    const response: DraftHistoryResponse = {
+      drafts,
+      nextCursor,
+      hasMore,
+      total: totalCount > 1000 ? null : totalCount,
+    };
+
+    res.json(success(response));
+  } catch (err: any) {
+    if (err instanceof z.ZodError) {
+      return res
+        .status(400)
+        .json(buildErrorResponse(req, "Invalid request", { details: err.errors }));
+    }
+
+    logger.error({ err: err.message }, "Failed to load draft history");
+    res.status(500).json(buildErrorResponse(req, "Failed to load draft history"));
   }
 });
 


### PR DESCRIPTION
## What changed
- added `GET /drafts/history` for authenticated users
- added CSV status filtering, inclusive date range filters, cursor pagination, and newest/oldest sorting
- returns `drafts`, `nextCursor`, `hasMore`, and `total` (`null` when filtered count exceeds 1000)

## Tests
- added 7 route tests covering defaults, status filtering, date filtering, cursor continuation, limit clamping, invalid status validation, and empty results

Built by Codex (gpt-5.4) via Forge maximizer.