### PR TITLE
feat(api): full health diagnostics endpoint

### DIFF
--- a/services/api/src/__tests__/routes/health.test.ts
+++ b/services/api/src/__tests__/routes/health.test.ts
@@ -1,69 +1,148 @@
 import request from "supertest";
 import express from "express";
+import { statfs } from "fs/promises";
+import { healthRouter } from "../../routes/health";
+import { requestIdMiddleware } from "../../middleware/requestId";
 
 jest.mock("../../lib/prisma", () => ({
   prisma: { $queryRaw: jest.fn().mockResolvedValue([{ "?column?": 1 }]) },
 }));
 
 jest.mock("../../lib/redis", () => ({
-  redis: { ping: jest.fn().mockResolvedValue("PONG") },
+  getRedis: jest.fn(() => null),
 }));
 
+jest.mock("fs/promises", () => ({
+  statfs: jest.fn(),
+}));
+
+import { prisma } from "../../lib/prisma";
+import { getRedis } from "../../lib/redis";
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockGetRedis = getRedis as jest.MockedFunction<typeof getRedis>;
+const mockStatfs = statfs as jest.MockedFunction<typeof statfs>;
+const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+
 const app = express();
+app.use(express.json());
+app.use(requestIdMiddleware);
+app.use(healthRouter);
 
-// Inline a minimal health route matching the real one's response shape
-app.get("/health", async (_req, res) => {
-  const { prisma } = require("../../lib/prisma");
-  const { redis } = require("../../lib/redis");
+const originalFetch = global.fetch;
 
-  let dbStatus = "ok";
-  let dbLatency = 0;
-  try {
-    const start = Date.now();
-    await prisma.$queryRaw`SELECT 1`;
-    dbLatency = Date.now() - start;
-  } catch {
-    dbStatus = "error";
-  }
-
-  let redisStatus = "ok";
-  let redisLatency = 0;
-  try {
-    const start = Date.now();
-    await redis.ping();
-    redisLatency = Date.now() - start;
-  } catch {
-    redisStatus = "unavailable";
-  }
-
-  const mem = process.memoryUsage();
-  res.json({
-    status: "ok",
-    timestamp: new Date().toISOString(),
-    uptime: process.uptime(),
-    version: "0.1.0",
-    checks: {
-      database: { status: dbStatus, latencyMs: dbLatency },
-      redis: { status: redisStatus, latencyMs: redisLatency },
-      memory: { heapUsedMB: +(mem.heapUsed / 1048576).toFixed(2), heapTotalMB: +(mem.heapTotal / 1048576).toFixed(2), rss: mem.rss },
-    },
-  });
+beforeAll(() => {
+  global.fetch = mockFetch;
 });
 
-describe("GET /health", () => {
-  it("returns 200 with status ok and all checks", async () => {
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.REDIS_URL;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.XAI_API_KEY;
+
+  mockPrisma.$queryRaw.mockResolvedValue([{ "?column?": 1 }]);
+  mockGetRedis.mockReturnValue(null);
+  mockStatfs.mockResolvedValue({
+    type: 0,
+    bsize: 4_096,
+    blocks: 1_000,
+    bfree: 500,
+    bavail: 400,
+    files: 1_000,
+    ffree: 500,
+  } as Awaited<ReturnType<typeof statfs>>);
+  mockFetch.mockReset();
+});
+
+describe("health routes", () => {
+  it("returns the existing basic /health payload", async () => {
     const res = await request(app).get("/health");
+
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("ok");
-    expect(res.body.checks.database.status).toBe("ok");
-    expect(res.body.checks.redis.status).toBe("ok");
+    expect(res.body.database).toBe("ok");
+    expect(res.body.cache).toBe("unavailable");
+    expect(res.body.version).toBe("0.1.0");
     expect(typeof res.body.uptime).toBe("number");
     expect(res.body.uptime).toBeGreaterThan(0);
-    expect(res.body.checks.memory.heapUsedMB).toBeGreaterThan(0);
   });
 
-  it("returns valid ISO timestamp", async () => {
-    const res = await request(app).get("/health");
+  it("reports healthy when required checks pass and optional checks are skipped", async () => {
+    const res = await request(app).get("/health/full");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("healthy");
+    expect(res.body.checks.db.status).toBe("ok");
+    expect(res.body.checks.redis.status).toBe("skipped");
+    expect(res.body.checks.openai.status).toBe("skipped");
+    expect(res.body.checks.anthropic.status).toBe("skipped");
+    expect(res.body.checks.xai.status).toBe("skipped");
+    expect(res.body.checks.memory.status).toBe("ok");
+    expect(res.body.checks.disk.status).toBe("ok");
+    expect(res.body.checks.disk.freeBytes).toBe(1_638_400);
+  });
+
+  it("returns 503 unhealthy when the database check fails", async () => {
+    mockPrisma.$queryRaw.mockRejectedValueOnce(new Error("db unavailable"));
+
+    const res = await request(app).get("/health/full");
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("unhealthy");
+    expect(res.body.checks.db.status).toBe("error");
+    expect(res.body.checks.db.error).toBe("db unavailable");
+  });
+
+  it("marks redis as skipped when REDIS_URL is absent", async () => {
+    const res = await request(app).get("/health/full");
+
+    expect(res.status).toBe(200);
+    expect(res.body.checks.redis.status).toBe("skipped");
+    expect(mockGetRedis).not.toHaveBeenCalled();
+  });
+
+  it("returns degraded when an optional provider fails", async () => {
+    process.env.OPENAI_API_KEY = "openai-key";
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    } as Response);
+
+    const res = await request(app).get("/health/full");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("degraded");
+    expect(res.body.checks.openai.status).toBe("error");
+    expect(res.body.checks.openai.error).toBe("OpenAI responded with 500");
+  });
+
+  it("times out slow optional checks after two seconds", async () => {
+    process.env.OPENAI_API_KEY = "openai-key";
+    mockFetch.mockImplementationOnce(
+      () => new Promise<Response>(() => undefined),
+    );
+
+    const startedAt = Date.now();
+    const res = await request(app).get("/health/full");
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("degraded");
+    expect(res.body.checks.openai.status).toBe("error");
+    expect(res.body.checks.openai.error).toBe("openai timed out after 2000ms");
+    expect(elapsedMs).toBeGreaterThanOrEqual(1_900);
+    expect(elapsedMs).toBeLessThan(3_500);
+  });
+
+  it("returns valid ISO timestamps on the full diagnostics route", async () => {
+    const res = await request(app).get("/health/full");
+
     expect(new Date(res.body.timestamp).toISOString()).toBe(res.body.timestamp);
   });
 });

--- a/services/api/src/__tests__/routes/health.test.ts
+++ b/services/api/src/__tests__/routes/health.test.ts
@@ -3,6 +3,7 @@ import express from "express";
 import { statfs } from "fs/promises";
 import { healthRouter } from "../../routes/health";
 import { requestIdMiddleware } from "../../middleware/requestId";
+import { clearRateLimitStore } from "../../middleware/rateLimit";
 
 jest.mock("../../lib/prisma", () => ({
   prisma: { $queryRaw: jest.fn().mockResolvedValue([{ "?column?": 1 }]) },
@@ -41,6 +42,8 @@ afterAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  clearRateLimitStore();
+  process.env.ADMIN_HEALTH_TOKEN = "test-admin-token";
   delete process.env.REDIS_URL;
   delete process.env.OPENAI_API_KEY;
   delete process.env.ANTHROPIC_API_KEY;
@@ -73,8 +76,17 @@ describe("health routes", () => {
     expect(res.body.uptime).toBeGreaterThan(0);
   });
 
+  it("sets security headers on health responses", async () => {
+    const res = await request(app).get("/health");
+
+    expect(res.headers["x-robots-tag"]).toBe("noindex");
+    expect(res.headers["cache-control"]).toBe("no-store");
+  });
+
   it("reports healthy when required checks pass and optional checks are skipped", async () => {
-    const res = await request(app).get("/health/full");
+    const res = await request(app)
+      .get("/health/full")
+      .set("X-Admin-Token", "test-admin-token");
 
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("healthy");
@@ -91,20 +103,23 @@ describe("health routes", () => {
   it("returns 503 unhealthy when the database check fails", async () => {
     mockPrisma.$queryRaw.mockRejectedValueOnce(new Error("db unavailable"));
 
-    const res = await request(app).get("/health/full");
+    const res = await request(app)
+      .get("/health/full")
+      .set("X-Admin-Token", "test-admin-token");
 
     expect(res.status).toBe(503);
     expect(res.body.status).toBe("unhealthy");
     expect(res.body.checks.db.status).toBe("error");
-    expect(res.body.checks.db.error).toBe("db unavailable");
+    expect(res.body.checks.db.error).toBe("db_unreachable");
   });
 
   it("marks redis as skipped when REDIS_URL is absent", async () => {
-    const res = await request(app).get("/health/full");
+    const res = await request(app)
+      .get("/health/full")
+      .set("X-Admin-Token", "test-admin-token");
 
     expect(res.status).toBe(200);
     expect(res.body.checks.redis.status).toBe("skipped");
-    expect(mockGetRedis).not.toHaveBeenCalled();
   });
 
   it("returns degraded when an optional provider fails", async () => {
@@ -114,7 +129,9 @@ describe("health routes", () => {
       status: 500,
     } as Response);
 
-    const res = await request(app).get("/health/full");
+    const res = await request(app)
+      .get("/health/full")
+      .set("X-Admin-Token", "test-admin-token");
 
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("degraded");
@@ -129,7 +146,9 @@ describe("health routes", () => {
     );
 
     const startedAt = Date.now();
-    const res = await request(app).get("/health/full");
+    const res = await request(app)
+      .get("/health/full")
+      .set("X-Admin-Token", "test-admin-token");
     const elapsedMs = Date.now() - startedAt;
 
     expect(res.status).toBe(200);
@@ -141,8 +160,49 @@ describe("health routes", () => {
   });
 
   it("returns valid ISO timestamps on the full diagnostics route", async () => {
-    const res = await request(app).get("/health/full");
+    const res = await request(app)
+      .get("/health/full")
+      .set("X-Admin-Token", "test-admin-token");
 
     expect(new Date(res.body.timestamp).toISOString()).toBe(res.body.timestamp);
+  });
+
+  it("returns 401 when X-Admin-Token is missing or invalid", async () => {
+    const resMissing = await request(app).get("/health/full");
+    expect(resMissing.status).toBe(401);
+    expect(resMissing.body.error).toBe("Unauthorized");
+
+    const resInvalid = await request(app)
+      .get("/health/full")
+      .set("X-Admin-Token", "bad-token");
+    expect(resInvalid.status).toBe(401);
+    expect(resInvalid.body.error).toBe("Unauthorized");
+  });
+
+  it("returns 503 when ADMIN_HEALTH_TOKEN is not configured", async () => {
+    delete process.env.ADMIN_HEALTH_TOKEN;
+
+    const res = await request(app)
+      .get("/health/full")
+      .set("X-Admin-Token", "test-admin-token");
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("Health diagnostics unavailable");
+  });
+
+  it("rate limits /health/full to 6 requests per minute", async () => {
+    // Exhaust the 6-request allowance
+    for (let i = 0; i < 6; i++) {
+      const res = await request(app)
+        .get("/health/full")
+        .set("X-Admin-Token", "test-admin-token");
+      expect(res.status).toBe(200);
+    }
+
+    const res = await request(app)
+      .get("/health/full")
+      .set("X-Admin-Token", "test-admin-token");
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe("Too many requests. Please try again later.");
   });
 });

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -35,6 +35,7 @@ import { adminFlagsRouter } from "./routes/admin-flags";
 import { adminBackupRouter } from "./routes/admin-backup";
 import { twitterRouter } from "./routes/twitter";
 import { queueRouter } from "./routes/queue";
+import { healthRouter } from "./routes/health";
 import { buildErrorResponse, requestIdMiddleware } from "./middleware/requestId";
 import { rateLimit, rateLimitByUser } from "./middleware/rateLimit";
 import { requestLogger } from "./middleware/requestLogger";
@@ -42,7 +43,6 @@ import { logger } from "./lib/logger";
 import { formatErrorResponse } from "./lib/errors";
 import { assertCorsConfig, buildCorsOptions } from "./lib/cors";
 import { prisma } from "./lib/prisma";
-import { getRedis } from "./lib/redis";
 import { initBot } from "./lib/telegram";
 import { initSocket } from "./lib/socket";
 import { startScheduler } from "./lib/scheduler";
@@ -92,39 +92,7 @@ const docsRateLimiter = rateLimit(
   "docs",
 );
 
-// Health check
-app.get("/health", async (_req, res) => {
-  let database: "ok" | "error" = "ok";
-  let cache: "ok" | "unavailable" = "unavailable";
-
-  try {
-    await prisma.$queryRaw`SELECT 1`;
-    database = "ok";
-  } catch {
-    database = "error";
-  }
-
-  try {
-    const redis = getRedis();
-    if (!redis) {
-      throw new Error("Redis unavailable");
-    }
-
-    await redis.ping();
-    cache = "ok";
-  } catch {
-    cache = "unavailable";
-  }
-
-  res.status(database === "error" ? 503 : 200).json({
-    status: "ok",
-    version: process.env.npm_package_version || "unknown",
-    uptime: process.uptime(),
-    database,
-    cache,
-    timestamp: new Date().toISOString(),
-  });
-});
+app.use(healthRouter);
 
 // Routes
 app.use("/api/docs", docsRateLimiter, docsRouter);

--- a/services/api/src/lib/health-checks.ts
+++ b/services/api/src/lib/health-checks.ts
@@ -3,6 +3,7 @@ import * as fsPromises from "fs/promises";
 import path from "path";
 import { prisma } from "./prisma";
 import { getRedis } from "./redis";
+import { logger } from "./logger";
 
 export type HealthCheckStatus = "ok" | "error" | "skipped";
 
@@ -84,17 +85,36 @@ export async function runCheck<T extends Record<string, unknown>>(
   }
 }
 
-export function checkDb(timeoutMs = 2_000): Promise<HealthCheckResult> {
-  return runCheck("db", async () => {
-    await prisma.$queryRaw`SELECT 1`;
-    return {};
-  }, timeoutMs);
+export async function checkDb(timeoutMs = 2_000): Promise<HealthCheckResult> {
+  const startedAt = Date.now();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    await Promise.race([
+      prisma.$queryRaw`SELECT 1`,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error("timeout")), timeoutMs);
+      }),
+    ]);
+
+    return { status: "ok", latencyMs: Date.now() - startedAt };
+  } catch (error) {
+    logger.error({ err: error instanceof Error ? error.message : String(error) }, "Database health check failed");
+    return { status: "error", latencyMs: Date.now() - startedAt, error: "db_unreachable" };
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
 }
 
-export function checkRedis(timeoutMs = 2_000): Promise<HealthCheckResult> {
-  return runCheck("redis", async () => {
+export async function checkRedis(timeoutMs = 2_000): Promise<HealthCheckResult> {
+  const startedAt = Date.now();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
     if (!process.env.REDIS_URL) {
-      return { status: "skipped" };
+      return { status: "skipped", latencyMs: Date.now() - startedAt };
     }
 
     const redis = getRedis();
@@ -102,9 +122,22 @@ export function checkRedis(timeoutMs = 2_000): Promise<HealthCheckResult> {
       throw new Error("Redis client unavailable");
     }
 
-    await redis.ping();
-    return {};
-  }, timeoutMs);
+    await Promise.race([
+      redis.ping(),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error("timeout")), timeoutMs);
+      }),
+    ]);
+
+    return { status: "ok", latencyMs: Date.now() - startedAt };
+  } catch (error) {
+    logger.error({ err: error instanceof Error ? error.message : String(error) }, "Redis health check failed");
+    return { status: "error", latencyMs: Date.now() - startedAt, error: "redis_unreachable" };
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
 }
 
 export function checkOpenAI(timeoutMs = 2_000): Promise<HealthCheckResult> {

--- a/services/api/src/lib/health-checks.ts
+++ b/services/api/src/lib/health-checks.ts
@@ -1,0 +1,207 @@
+import { readFileSync } from "fs";
+import * as fsPromises from "fs/promises";
+import path from "path";
+import { prisma } from "./prisma";
+import { getRedis } from "./redis";
+
+export type HealthCheckStatus = "ok" | "error" | "skipped";
+
+export interface HealthCheckResult {
+  status: HealthCheckStatus;
+  latencyMs: number;
+  error?: string;
+  [key: string]: unknown;
+}
+
+type CheckPayload<T extends Record<string, unknown>> = T & {
+  status?: Extract<HealthCheckStatus, "ok" | "skipped">;
+  error?: string;
+};
+
+let cachedVersion: string | null = null;
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function getPackageJsonPath(): string {
+  return path.resolve(process.cwd(), "package.json");
+}
+
+export function getAppVersion(): string {
+  if (cachedVersion) {
+    return cachedVersion;
+  }
+
+  try {
+    const contents = readFileSync(getPackageJsonPath(), "utf8");
+    const parsed = JSON.parse(contents) as { version?: string };
+    cachedVersion = parsed.version || "unknown";
+  } catch {
+    cachedVersion = process.env.npm_package_version || "unknown";
+  }
+
+  return cachedVersion;
+}
+
+export async function runCheck<T extends Record<string, unknown>>(
+  name: string,
+  fn: () => Promise<CheckPayload<T>>,
+  timeoutMs: number,
+): Promise<HealthCheckResult & T> {
+  const startedAt = Date.now();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    const result = await Promise.race([
+      fn(),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`${name} timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+
+    return {
+      latencyMs: Date.now() - startedAt,
+      ...result,
+      status: result.status ?? "ok",
+    };
+  } catch (error) {
+    return {
+      status: "error",
+      latencyMs: Date.now() - startedAt,
+      error: formatError(error),
+    } as HealthCheckResult & T;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+export function checkDb(timeoutMs = 2_000): Promise<HealthCheckResult> {
+  return runCheck("db", async () => {
+    await prisma.$queryRaw`SELECT 1`;
+    return {};
+  }, timeoutMs);
+}
+
+export function checkRedis(timeoutMs = 2_000): Promise<HealthCheckResult> {
+  return runCheck("redis", async () => {
+    if (!process.env.REDIS_URL) {
+      return { status: "skipped" };
+    }
+
+    const redis = getRedis();
+    if (!redis) {
+      throw new Error("Redis client unavailable");
+    }
+
+    await redis.ping();
+    return {};
+  }, timeoutMs);
+}
+
+export function checkOpenAI(timeoutMs = 2_000): Promise<HealthCheckResult> {
+  return runCheck("openai", async () => {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return { status: "skipped" };
+    }
+
+    const response = await fetch("https://api.openai.com/v1/models", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`OpenAI responded with ${response.status}`);
+    }
+
+    return {};
+  }, timeoutMs);
+}
+
+export function checkAnthropic(timeoutMs = 2_000): Promise<HealthCheckResult> {
+  return runCheck("anthropic", async () => {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      return { status: "skipped" };
+    }
+
+    const response = await fetch("https://api.anthropic.com/v1/models", {
+      method: "GET",
+      headers: {
+        "anthropic-version": "2023-06-01",
+        "x-api-key": apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Anthropic responded with ${response.status}`);
+    }
+
+    return {};
+  }, timeoutMs);
+}
+
+export function checkXai(timeoutMs = 2_000): Promise<HealthCheckResult> {
+  return runCheck("xai", async () => {
+    const apiKey = process.env.XAI_API_KEY;
+    if (!apiKey) {
+      return { status: "skipped" };
+    }
+
+    const response = await fetch("https://api.x.ai/v1/models", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`xAI responded with ${response.status}`);
+    }
+
+    return {};
+  }, timeoutMs);
+}
+
+export function checkMemory(timeoutMs = 2_000): Promise<HealthCheckResult> {
+  return runCheck("memory", async () => {
+    const usage = process.memoryUsage();
+
+    return {
+      rssBytes: usage.rss,
+      heapTotalBytes: usage.heapTotal,
+      heapUsedBytes: usage.heapUsed,
+      externalBytes: usage.external,
+      arrayBuffersBytes: usage.arrayBuffers,
+    };
+  }, timeoutMs);
+}
+
+export function checkDisk(timeoutMs = 2_000): Promise<HealthCheckResult> {
+  return runCheck("disk", async () => {
+    if (typeof fsPromises.statfs !== "function") {
+      return { status: "skipped" };
+    }
+
+    const stats = await fsPromises.statfs(process.cwd());
+    const blockSize = Number(stats.bsize);
+    const freeBlocks = Number(stats.bavail ?? stats.bfree);
+    const totalBlocks = Number(stats.blocks);
+
+    return {
+      freeBytes: blockSize * freeBlocks,
+      totalBytes: blockSize * totalBlocks,
+    };
+  }, timeoutMs);
+}

--- a/services/api/src/routes/health.ts
+++ b/services/api/src/routes/health.ts
@@ -1,0 +1,108 @@
+import { Router } from "express";
+import {
+  checkAnthropic,
+  checkDb,
+  checkDisk,
+  checkMemory,
+  checkOpenAI,
+  checkRedis,
+  checkXai,
+  getAppVersion,
+  type HealthCheckResult,
+} from "../lib/health-checks";
+import { prisma } from "../lib/prisma";
+import { getRedis } from "../lib/redis";
+
+const FULL_CHECK_TIMEOUT_MS = 2_000;
+
+function settledResultToCheck(result: PromiseSettledResult<HealthCheckResult>): HealthCheckResult {
+  if (result.status === "fulfilled") {
+    return result.value;
+  }
+
+  return {
+    status: "error",
+    latencyMs: FULL_CHECK_TIMEOUT_MS,
+    error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+  };
+}
+
+export const healthRouter = Router();
+
+healthRouter.get("/health", async (_req, res) => {
+  try {
+    let database: "ok" | "error" = "ok";
+    let cache: "ok" | "unavailable" = "unavailable";
+
+    try {
+      await prisma.$queryRaw`SELECT 1`;
+      database = "ok";
+    } catch {
+      database = "error";
+    }
+
+    try {
+      const redis = getRedis();
+      if (!redis) {
+        throw new Error("Redis unavailable");
+      }
+
+      await redis.ping();
+      cache = "ok";
+    } catch {
+      cache = "unavailable";
+    }
+
+    res.status(database === "error" ? 503 : 200).json({
+      status: "ok",
+      version: getAppVersion(),
+      uptime: process.uptime(),
+      database,
+      cache,
+      timestamp: new Date().toISOString(),
+    });
+  } catch {
+    res.status(500).json({ error: "Failed to run health check" });
+  }
+});
+
+healthRouter.get("/health/full", async (_req, res) => {
+  try {
+    const settledChecks = await Promise.allSettled([
+      checkDb(FULL_CHECK_TIMEOUT_MS),
+      checkRedis(FULL_CHECK_TIMEOUT_MS),
+      checkOpenAI(FULL_CHECK_TIMEOUT_MS),
+      checkAnthropic(FULL_CHECK_TIMEOUT_MS),
+      checkXai(FULL_CHECK_TIMEOUT_MS),
+      checkMemory(FULL_CHECK_TIMEOUT_MS),
+      checkDisk(FULL_CHECK_TIMEOUT_MS),
+    ]);
+
+    const checks = {
+      db: settledResultToCheck(settledChecks[0]),
+      redis: settledResultToCheck(settledChecks[1]),
+      openai: settledResultToCheck(settledChecks[2]),
+      anthropic: settledResultToCheck(settledChecks[3]),
+      xai: settledResultToCheck(settledChecks[4]),
+      memory: settledResultToCheck(settledChecks[5]),
+      disk: settledResultToCheck(settledChecks[6]),
+    };
+
+    const status =
+      checks.db.status === "error"
+        ? "unhealthy"
+        : Object.entries(checks).some(([name, check]) => name !== "db" && check.status === "error")
+          ? "degraded"
+          : "healthy";
+
+    res.status(status === "unhealthy" ? 503 : 200).json({
+      status,
+      uptime: process.uptime(),
+      version: getAppVersion(),
+      checks,
+      timestamp: new Date().toISOString(),
+    });
+  } catch {
+    res.status(500).json({ error: "Failed to run full health diagnostics" });
+  }
+});

--- a/services/api/src/routes/health.ts
+++ b/services/api/src/routes/health.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import { Router, type Request, type Response, type NextFunction } from "express";
 import {
   checkAnthropic,
   checkDb,
@@ -12,8 +12,25 @@ import {
 } from "../lib/health-checks";
 import { prisma } from "../lib/prisma";
 import { getRedis } from "../lib/redis";
+import { rateLimit } from "../middleware/rateLimit";
+import { logger } from "../lib/logger";
 
 const FULL_CHECK_TIMEOUT_MS = 2_000;
+
+const fullHealthRateLimiter = rateLimit(6, 60 * 1000, "health-full");
+
+function requireAdminToken(req: Request, res: Response, next: NextFunction) {
+  const token = process.env.ADMIN_HEALTH_TOKEN;
+  if (!token) {
+    logger.warn("ADMIN_HEALTH_TOKEN is not set; /health/full is inaccessible");
+    return res.status(503).json({ error: "Health diagnostics unavailable" });
+  }
+  const header = req.headers["x-admin-token"];
+  if (header !== token) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+  next();
+}
 
 function settledResultToCheck(result: PromiseSettledResult<HealthCheckResult>): HealthCheckResult {
   if (result.status === "fulfilled") {
@@ -28,6 +45,12 @@ function settledResultToCheck(result: PromiseSettledResult<HealthCheckResult>): 
 }
 
 export const healthRouter = Router();
+
+healthRouter.use((_req, res, next) => {
+  res.setHeader("X-Robots-Tag", "noindex");
+  res.setHeader("Cache-Control", "no-store");
+  next();
+});
 
 healthRouter.get("/health", async (_req, res) => {
   try {
@@ -66,7 +89,7 @@ healthRouter.get("/health", async (_req, res) => {
   }
 });
 
-healthRouter.get("/health/full", async (_req, res) => {
+healthRouter.get("/health/full", fullHealthRateLimiter, requireAdminToken, async (_req, res) => {
   try {
     const settledChecks = await Promise.allSettled([
       checkDb(FULL_CHECK_TIMEOUT_MS),


### PR DESCRIPTION
## Summary
- add a root-mounted `healthRouter` with the existing `/health` response preserved
- add `/health/full` diagnostics for db, redis, OpenAI, Anthropic, xAI, memory, and disk
- aggregate the result into `healthy`, `degraded`, or `unhealthy` and return `503` only when the db check fails

## Timeout Handling
- run every dependency check with a hard 2 second timeout via `Promise.race`
- execute full diagnostics concurrently with `Promise.allSettled` so one slow dependency does not block the rest

## Tests
- cover healthy, unhealthy, skipped optional checks, degraded optional failures, timeout handling, and timestamp formatting in `services/api/src/__tests__/routes/health.test.ts`
- validated with `npx tsc --noEmit` and `npm test -- health`

Built by Codex (gpt-5.4) via Forge maximizer.