### PR TITLE
fix(onboarding): P0 scanner timeout hardening (twitter/calibrate/voice)

### DIFF
--- a/services/api/src/__tests__/routes/ai-rate-limits.test.ts
+++ b/services/api/src/__tests__/routes/ai-rate-limits.test.ts
@@ -60,6 +60,14 @@ jest.mock("../../lib/research", () => ({
   }),
 }));
 
+jest.mock("../../lib/twitter", () => ({
+  fetchTweetsByHandle: jest.fn(),
+}));
+
+jest.mock("../../lib/calibrate", () => ({
+  calibrateFromTweets: jest.fn(),
+}));
+
 jest.mock("../../lib/prisma", () => ({
   prisma: {
     researchResult: {
@@ -70,24 +78,79 @@ jest.mock("../../lib/prisma", () => ({
     analyticsEvent: {
       create: jest.fn().mockResolvedValue({ id: "event-1" }),
     },
+    voiceProfile: {
+      upsert: jest.fn(),
+    },
   },
 }));
 
 import { researchRouter } from "../../routes/research";
+import { voiceRouter } from "../../routes/voice";
+import { prisma } from "../../lib/prisma";
+import { fetchTweetsByHandle } from "../../lib/twitter";
+import { calibrateFromTweets } from "../../lib/calibrate";
 
 const app = express();
 app.set("trust proxy", 1);
 app.use(express.json());
 app.use(requestIdMiddleware);
 app.use("/api/research", researchRouter);
+app.use("/api/voice", voiceRouter);
 
 const RESEARCH_BODY = { query: "what is the price of bitcoin" };
+const CALIBRATE_BODY = { handle: "atlasanalyst" };
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockFetchTweetsByHandle = fetchTweetsByHandle as jest.MockedFunction<typeof fetchTweetsByHandle>;
+const mockCalibrateFromTweets = calibrateFromTweets as jest.MockedFunction<typeof calibrateFromTweets>;
 
 beforeEach(() => {
   jest.clearAllMocks();
   // Memory store is module-level — reset between tests so a previous
   // test's burst doesn't leak into the next one.
   clearRateLimitStore();
+  mockFetchTweetsByHandle.mockResolvedValue({
+    user: { id: "twitter-user-1", username: "atlasanalyst", name: "Atlas Analyst" },
+    tweets: [{ id: "tweet-1", text: "BTC structure still matters." }],
+  });
+  mockCalibrateFromTweets.mockResolvedValue({
+    humor: 55,
+    formality: 50,
+    brevity: 70,
+    contrarianTone: 60,
+    directness: 60,
+    warmth: 45,
+    technicalDepth: 80,
+    confidence: 75,
+    evidenceOrientation: 82,
+    solutionOrientation: 63,
+    socialPosture: 52,
+    selfPromotionalIntensity: 31,
+    calibrationConfidence: 0.91,
+    analysis: "Stubbed calibration",
+    tweetsAnalyzed: 1,
+  });
+  (mockPrisma.voiceProfile.upsert as jest.Mock).mockResolvedValue({
+    id: "vp-1",
+    userId: "user-alpha",
+    humor: 55,
+    formality: 50,
+    brevity: 70,
+    contrarianTone: 60,
+    directness: 60,
+    warmth: 45,
+    technicalDepth: 80,
+    confidence: 75,
+    evidenceOrientation: 82,
+    solutionOrientation: 63,
+    socialPosture: 52,
+    selfPromotionalIntensity: 31,
+    tweetsAnalyzed: 1,
+    analysis: "Stubbed calibration",
+    maturity: "BEGINNER",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  });
 });
 
 describe("POST /api/research — AI generation rate limit (#88075)", () => {
@@ -142,5 +205,20 @@ describe("POST /api/research — AI generation rate limit (#88075)", () => {
     // before the limiter sees the request, so we don't burn the IP bucket.
     const res = await request(app).post("/api/research").send(RESEARCH_BODY);
     expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/voice/calibrate — AI generation rate limit (#203)", () => {
+  it("uses the shared AI limiter on calibration requests", async () => {
+    const headers = { Authorization: "Bearer user-alpha" };
+
+    const first = await request(app).post("/api/voice/calibrate").set(headers).send(CALIBRATE_BODY);
+    const second = await request(app).post("/api/voice/calibrate").set(headers).send(CALIBRATE_BODY);
+    const third = await request(app).post("/api/voice/calibrate").set(headers).send(CALIBRATE_BODY);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(third.status).toBe(429);
+    expect(third.body.error).toBe("Too many requests. Please try again later.");
   });
 });

--- a/services/api/src/__tests__/routes/calibrate.test.ts
+++ b/services/api/src/__tests__/routes/calibrate.test.ts
@@ -205,8 +205,14 @@ describe("POST /api/voice/calibrate", () => {
       .send({ handle: "atlasanalyst" });
 
     expect(res.status).toBe(200);
-    expect(mockFetchTweetsByHandle).toHaveBeenCalledWith("atlasanalyst");
-    expect(mockCalibrateFromTweets).toHaveBeenCalledWith(tweets.map((tweet) => tweet.text));
+    const [handle, maxResults, signal] = mockFetchTweetsByHandle.mock.calls[0];
+    expect(handle).toBe("atlasanalyst");
+    expect(maxResults).toBe(50);
+    expect(signal).toBeInstanceOf(AbortSignal);
+
+    const [tweetTexts, calibrationSignal] = mockCalibrateFromTweets.mock.calls[0];
+    expect(tweetTexts).toEqual(tweets.map((tweet) => tweet.text));
+    expect(calibrationSignal).toBe(signal);
     expect(mockPrisma.voiceProfile.upsert).toHaveBeenCalledWith({
       where: { userId: "user-123" },
       update: dimensionData,
@@ -353,5 +359,39 @@ describe("POST /api/voice/calibrate", () => {
     expectErrorResponse(res.body, "Voice calibration failed: model unavailable");
     expect(mockPrisma.voiceProfile.upsert).not.toHaveBeenCalled();
     expect(mockPrisma.analyticsEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 and aborts the calibration when the 40s route timeout fires", async () => {
+    const tweets = makeTweets(12);
+    let calibrationSignal: AbortSignal | undefined;
+    const realSetTimeout = global.setTimeout;
+    const setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((
+      handler: Parameters<typeof setTimeout>[0],
+      timeout?: number,
+      ...args: any[]
+    ) => realSetTimeout(handler, timeout === 40_000 ? 0 : timeout, ...args));
+
+    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets });
+    mockCalibrateFromTweets.mockImplementationOnce((_tweetTexts, signal) => {
+      calibrationSignal = signal;
+      return new Promise((_, reject) => {
+        signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      }) as ReturnType<typeof calibrateFromTweets>;
+    });
+
+    try {
+      const res = await request(app)
+        .post("/api/voice/calibrate")
+        .set(AUTH)
+        .send({ handle: "atlasanalyst" });
+
+      expect(res.status).toBe(503);
+      expect(res.body).toEqual({ error: "calibration_timeout", retryable: true });
+      expect(calibrationSignal?.aborted).toBe(true);
+      expect(mockPrisma.voiceProfile.upsert).not.toHaveBeenCalled();
+      expect(mockPrisma.analyticsEvent.create).not.toHaveBeenCalled();
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 });

--- a/services/api/src/lib/calibrate.ts
+++ b/services/api/src/lib/calibrate.ts
@@ -83,23 +83,47 @@ export async function calibrateFromTweets(
     .map((t, i) => `[${i + 1}] ${t}`)
     .join("\n\n");
 
-  const response = await client.messages.create({
-    model: "claude-sonnet-4-6",
-    max_tokens: 500,
-    system: CALIBRATION_PROMPT,
-    messages: [
-      {
-        role: "user",
-        content: `Analyze these ${tweets.length} tweets:\n\n${tweetBlock}`,
-      },
-    ],
-  });
+  const response = await client.messages.create(
+    {
+      model: "claude-sonnet-4-6",
+      max_tokens: 500,
+      system: CALIBRATION_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: `Analyze these ${tweets.length} tweets:\n\n${tweetBlock}`,
+        },
+      ],
+    },
+    { signal: AbortSignal.timeout(25000) }
+  );
 
   const textBlock = response.content.find((b) => b.type === "text");
   const content = textBlock?.text?.trim();
   if (!content) throw new Error("Empty response from Claude during calibration");
 
-  const result = JSON.parse(content);
+  let result: any;
+  try {
+    result = JSON.parse(content);
+  } catch {
+    return {
+      humor: 50,
+      formality: 50,
+      brevity: 50,
+      contrarianTone: 50,
+      directness: 50,
+      warmth: 50,
+      technicalDepth: 50,
+      confidence: 50,
+      evidenceOrientation: 50,
+      solutionOrientation: 50,
+      socialPosture: 50,
+      selfPromotionalIntensity: 50,
+      calibrationConfidence: 0,
+      analysis: "Could not parse model output — using defaults.",
+      tweetsAnalyzed: tweets.length,
+    };
+  }
 
   const clamp100 = (v: number) => Math.min(Math.max(Math.round(v ?? 50), 0), 100);
   /** AI returns 0-10 for extended dims; multiply by 10 for 0-100 storage */

--- a/services/api/src/lib/calibrate.ts
+++ b/services/api/src/lib/calibrate.ts
@@ -6,6 +6,7 @@
  */
 
 import { getAnthropicClient } from "./anthropic";
+import { logger } from "./logger";
 
 export interface CalibrationResult {
   // All dimensions stored as 0-100 scale
@@ -71,6 +72,7 @@ Be precise. Base your scores on patterns across ALL tweets, not individual outli
 
 export async function calibrateFromTweets(
   tweets: string[],
+  signal?: AbortSignal,
 ): Promise<CalibrationResult> {
   if (tweets.length === 0) {
     throw new Error("No tweets provided for calibration");
@@ -95,7 +97,11 @@ export async function calibrateFromTweets(
         },
       ],
     },
-    { signal: AbortSignal.timeout(25000) }
+    {
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(25_000)])
+        : AbortSignal.timeout(25_000),
+    }
   );
 
   const textBlock = response.content.find((b) => b.type === "text");
@@ -106,6 +112,10 @@ export async function calibrateFromTweets(
   try {
     result = JSON.parse(content);
   } catch {
+    logger.warn(
+      { contentPreview: content.slice(0, 200) },
+      "Calibration JSON parse failed, using neutral fallback profile",
+    );
     return {
       humor: 50,
       formality: 50,

--- a/services/api/src/lib/twitter.ts
+++ b/services/api/src/lib/twitter.ts
@@ -26,9 +26,17 @@ function getBearerToken(): string {
   return token;
 }
 
+export class TwitterTimeoutError extends Error {
+  constructor(message = "Twitter API request timed out") {
+    super(message);
+    this.name = "TwitterTimeoutError";
+  }
+}
+
 async function twitterGet<T>(path: string): Promise<T> {
   const res = await fetch(`${TWITTER_API_BASE}${path}`, {
     headers: { Authorization: `Bearer ${getBearerToken()}` },
+    signal: AbortSignal.timeout(8000),
   });
 
   if (!res.ok) {

--- a/services/api/src/lib/twitter.ts
+++ b/services/api/src/lib/twitter.ts
@@ -26,6 +26,11 @@ function getBearerToken(): string {
   return token;
 }
 
+function withTimeoutSignal(timeoutMs: number, signal?: AbortSignal): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+}
+
 export class TwitterTimeoutError extends Error {
   constructor(message = "Twitter API request timed out") {
     super(message);
@@ -33,10 +38,10 @@ export class TwitterTimeoutError extends Error {
   }
 }
 
-async function twitterGet<T>(path: string): Promise<T> {
+async function twitterGet<T>(path: string, signal?: AbortSignal): Promise<T> {
   const res = await fetch(`${TWITTER_API_BASE}${path}`, {
     headers: { Authorization: `Bearer ${getBearerToken()}` },
-    signal: AbortSignal.timeout(8000),
+    signal: withTimeoutSignal(8000, signal),
   });
 
   if (!res.ok) {
@@ -50,10 +55,11 @@ async function twitterGet<T>(path: string): Promise<T> {
 /**
  * Look up a Twitter user by username (handle without @).
  */
-export async function lookupUser(username: string): Promise<UserLookupResult> {
+export async function lookupUser(username: string, signal?: AbortSignal): Promise<UserLookupResult> {
   const clean = username.replace(/^@/, "");
   const data = await twitterGet<{ data: UserLookupResult }>(
-    `/users/by/username/${encodeURIComponent(clean)}?user.fields=profile_image_url`
+    `/users/by/username/${encodeURIComponent(clean)}?user.fields=profile_image_url`,
+    signal,
   );
   if (!data.data) throw new Error(`User @${clean} not found on Twitter/X`);
   // Upsize from default 48px (_normal) to 400px
@@ -68,7 +74,8 @@ export async function lookupUser(username: string): Promise<UserLookupResult> {
  */
 export async function fetchUserTweets(
   userId: string,
-  maxResults = 50
+  maxResults = 50,
+  signal?: AbortSignal,
 ): Promise<Tweet[]> {
   const params = new URLSearchParams({
     max_results: String(Math.min(maxResults, 100)),
@@ -77,7 +84,8 @@ export async function fetchUserTweets(
   });
 
   const data = await twitterGet<{ data?: Tweet[]; meta: { result_count: number } }>(
-    `/users/${userId}/tweets?${params}`
+    `/users/${userId}/tweets?${params}`,
+    signal,
   );
 
   return data.data || [];
@@ -88,10 +96,11 @@ export async function fetchUserTweets(
  */
 export async function fetchTweetsByHandle(
   handle: string,
-  maxResults = 50
+  maxResults = 50,
+  signal?: AbortSignal,
 ): Promise<{ user: UserLookupResult; tweets: Tweet[] }> {
-  const user = await lookupUser(handle);
-  const tweets = await fetchUserTweets(user.id, maxResults);
+  const user = await lookupUser(handle, signal);
+  const tweets = await fetchUserTweets(user.id, maxResults, signal);
   return { user, tweets };
 }
 

--- a/services/api/src/routes/voice.ts
+++ b/services/api/src/routes/voice.ts
@@ -546,47 +546,61 @@ voiceRouter.post("/calibrate", async (req: AuthRequest, res) => {
     const body = calibrateSchema.parse(req.body);
     const normalizedHandle = normalizeReferenceHandle(body.handle);
 
-    // Fetch tweets from Twitter/X
-    const { user: twitterUser, tweets } = await fetchTweetsByHandle(normalizedHandle);
+    // 40s server-side race so the client never hangs indefinitely
+    const RACE_MS = 40_000;
+    const racePromise = Promise.race([
+      (async () => {
+        // Fetch tweets from Twitter/X
+        const { user: twitterUser, tweets } = await fetchTweetsByHandle(normalizedHandle);
 
-    if (tweets.length === 0) {
-      return res.status(400).json(error(`No tweets found for @${normalizedHandle}`));
-    }
+        if (tweets.length === 0) {
+          return res.status(400).json(error(`No tweets found for @${normalizedHandle}`));
+        }
 
-    // Claude calibration can take tens of seconds on larger tweet sets, so Railway deploys
-    // need RAILWAY_SERVICE_TIMEOUT=90000 for this endpoint.
-    const calibration = await calibrateFromTweets(tweets.map((t) => t.text));
+        // Claude calibration can take tens of seconds on larger tweet sets, so Railway deploys
+        // need RAILWAY_SERVICE_TIMEOUT=90000 for this endpoint.
+        const calibration = await calibrateFromTweets(tweets.map((t) => t.text));
 
-    // Update voice profile with all 12 calibrated dimensions
-    const dimensionData = buildVoiceProfileUpdate(calibration);
+        // Update voice profile with all 12 calibrated dimensions
+        const dimensionData = buildVoiceProfileUpdate(calibration);
 
-    const profile = await prisma.voiceProfile.upsert({
-      where: { userId: req.userId! },
-      update: dimensionData,
-      create: { userId: req.userId!, ...dimensionData },
-    });
+        const profile = await prisma.voiceProfile.upsert({
+          where: { userId: req.userId! },
+          update: dimensionData,
+          create: { userId: req.userId!, ...dimensionData },
+        });
 
-    // Log analytics
-    await prisma.analyticsEvent.create({
-      data: { userId: req.userId!, type: "VOICE_REFINEMENT" },
-    });
+        // Log analytics
+        await prisma.analyticsEvent.create({
+          data: { userId: req.userId!, type: "VOICE_REFINEMENT" },
+        });
 
-    res.json(success({
-      profile,
-      calibration: {
-        confidence: calibration.calibrationConfidence,
-        analysis: calibration.analysis,
-        tweetsAnalyzed: calibration.tweetsAnalyzed,
-        twitterUser: { username: twitterUser.username, name: twitterUser.name },
-      },
-    }));
+        return res.json(success({
+          profile,
+          calibration: {
+            confidence: calibration.calibrationConfidence,
+            analysis: calibration.analysis,
+            tweetsAnalyzed: calibration.tweetsAnalyzed,
+            twitterUser: { username: twitterUser.username, name: twitterUser.name },
+          },
+        }));
+      })(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("calibration_timeout")), RACE_MS)
+      ),
+    ]);
+
+    await racePromise;
   } catch (err: any) {
     if (err instanceof z.ZodError) {
       return res.status(400).json(error("Invalid request", 400, err.errors));
     }
-    logger.error({ err: err.message }, "Calibration failed");
-    // Surface Twitter API errors to the client so the frontend can show a useful message
     const msg = err.message ?? "";
+    if (msg === "calibration_timeout") {
+      return res.status(503).json({ error: "calibration_timeout", retryable: true });
+    }
+    logger.error({ err: msg }, "Calibration failed");
+    // Surface Twitter API errors to the client so the frontend can show a useful message
     if (msg.includes("429")) return res.status(429).json(error(`Twitter API rate limit: ${msg}`));
     if (msg.includes("404") || msg.includes("not found")) return res.status(404).json(error(msg));
     if (msg.includes("403")) return res.status(403).json(error(msg));

--- a/services/api/src/routes/voice.ts
+++ b/services/api/src/routes/voice.ts
@@ -10,6 +10,8 @@ import { calibrateFromTweets, type CalibrationResult } from "../lib/calibrate";
 import { getVoiceInsights } from "../lib/voice-insights";
 import { blendVoices } from "../lib/voice-blend";
 import { logger } from "../lib/logger";
+import { config } from "../lib/config";
+import { rateLimitByUser } from "../middleware/rateLimit";
 
 // Public router — no auth required
 export const referenceAccountsRouter = Router();
@@ -95,6 +97,10 @@ referenceAccountsRouter.post("/reference-accounts/seed", async (req, res) => {
 
 export const voiceRouter = Router();
 voiceRouter.use(authenticate);
+const aiGenerationLimiter = rateLimitByUser(
+  config.RATE_LIMIT_AI_GENERATION_MAX_REQUESTS,
+  config.RATE_LIMIT_AI_GENERATION_WINDOW_MS,
+);
 
 const profileSchema = z.object({
   humor: z.number().min(0).max(100).optional(),
@@ -541,63 +547,78 @@ const calibrateSchema = z.object({
   handle: z.string().min(1).max(50),
 });
 
-voiceRouter.post("/calibrate", async (req: AuthRequest, res) => {
+voiceRouter.post("/calibrate", aiGenerationLimiter, async (req: AuthRequest, res) => {
+  let timeout: NodeJS.Timeout | undefined;
+  const abort = new AbortController();
   try {
     const body = calibrateSchema.parse(req.body);
     const normalizedHandle = normalizeReferenceHandle(body.handle);
 
-    // 40s server-side race so the client never hangs indefinitely
     const RACE_MS = 40_000;
-    const racePromise = Promise.race([
-      (async () => {
-        // Fetch tweets from Twitter/X
-        const { user: twitterUser, tweets } = await fetchTweetsByHandle(normalizedHandle);
 
-        if (tweets.length === 0) {
-          return res.status(400).json(error(`No tweets found for @${normalizedHandle}`));
-        }
+    const workPromise = (async () => {
+      // Fail fast at 40s so the client gets a retryable timeout before Railway's 90s cap.
+      const { user: twitterUser, tweets } = await fetchTweetsByHandle(normalizedHandle, 50, abort.signal);
+      if (abort.signal.aborted) return;
 
-        // Claude calibration can take tens of seconds on larger tweet sets, so Railway deploys
-        // need RAILWAY_SERVICE_TIMEOUT=90000 for this endpoint.
-        const calibration = await calibrateFromTweets(tweets.map((t) => t.text));
+      if (tweets.length === 0) {
+        return res.status(400).json(error(`No tweets found for @${normalizedHandle}`));
+      }
 
-        // Update voice profile with all 12 calibrated dimensions
-        const dimensionData = buildVoiceProfileUpdate(calibration);
+      const calibration = await calibrateFromTweets(
+        tweets.map((t) => t.text),
+        abort.signal,
+      );
+      if (abort.signal.aborted) return;
 
-        const profile = await prisma.voiceProfile.upsert({
-          where: { userId: req.userId! },
-          update: dimensionData,
-          create: { userId: req.userId!, ...dimensionData },
-        });
+      // Railway deploys still need RAILWAY_SERVICE_TIMEOUT=90000 for long Anthropic calls.
+      const dimensionData = buildVoiceProfileUpdate(calibration);
 
-        // Log analytics
-        await prisma.analyticsEvent.create({
-          data: { userId: req.userId!, type: "VOICE_REFINEMENT" },
-        });
+      const profile = await prisma.voiceProfile.upsert({
+        where: { userId: req.userId! },
+        update: dimensionData,
+        create: { userId: req.userId!, ...dimensionData },
+      });
+      if (abort.signal.aborted) return;
 
-        return res.json(success({
-          profile,
-          calibration: {
-            confidence: calibration.calibrationConfidence,
-            analysis: calibration.analysis,
-            tweetsAnalyzed: calibration.tweetsAnalyzed,
-            twitterUser: { username: twitterUser.username, name: twitterUser.name },
-          },
-        }));
-      })(),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("calibration_timeout")), RACE_MS)
-      ),
+      // Log analytics
+      await prisma.analyticsEvent.create({
+        data: { userId: req.userId!, type: "VOICE_REFINEMENT" },
+      });
+      if (abort.signal.aborted) return;
+
+      return res.json(success({
+        profile,
+        calibration: {
+          confidence: calibration.calibrationConfidence,
+          analysis: calibration.analysis,
+          tweetsAnalyzed: calibration.tweetsAnalyzed,
+          twitterUser: { username: twitterUser.username, name: twitterUser.name },
+        },
+      }));
+    })();
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        abort.abort();
+        reject(new Error("calibration_timeout"));
+      }, RACE_MS);
+    });
+
+    await Promise.race([
+      workPromise,
+      timeoutPromise,
     ]);
-
-    await racePromise;
   } catch (err: any) {
     if (err instanceof z.ZodError) {
       return res.status(400).json(error("Invalid request", 400, err.errors));
     }
     const msg = err.message ?? "";
-    if (msg === "calibration_timeout") {
-      return res.status(503).json({ error: "calibration_timeout", retryable: true });
+    if (msg === "calibration_timeout" || abort.signal.aborted) {
+      if (!res.headersSent) {
+        return res.status(503).json({ error: "calibration_timeout", retryable: true });
+      }
+      return;
     }
     logger.error({ err: msg }, "Calibration failed");
     // Surface Twitter API errors to the client so the frontend can show a useful message
@@ -605,6 +626,8 @@ voiceRouter.post("/calibrate", async (req: AuthRequest, res) => {
     if (msg.includes("404") || msg.includes("not found")) return res.status(404).json(error(msg));
     if (msg.includes("403")) return res.status(403).json(error(msg));
     res.status(502).json(error(`Voice calibration failed: ${msg}`));
+  } finally {
+    clearTimeout(timeout);
   }
 });
 


### PR DESCRIPTION
Implements /tmp/forge-plan-p0-scanner.md backend half. 8s twitter abort, 25s anthropic, 40s route race returning 503 calibration_timeout. REQUIRES Forge-Audit pre-merge (auth-adjacent).