### PR TITLE
fix(auth): server-side JWT revocation on logout

### DIFF
--- a/prisma/migrations/20260414180000_add_tokens_invalidated_before/migration.sql
+++ b/prisma/migrations/20260414180000_add_tokens_invalidated_before/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "tokensInvalidatedBefore" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model User {
   xFollowerCount    Int?
   tourCompleted     Boolean  @default(false)
   tourStep          Int      @default(0)
+  tokensInvalidatedBefore DateTime?
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 

--- a/services/api/src/__tests__/auth-revocation.test.ts
+++ b/services/api/src/__tests__/auth-revocation.test.ts
@@ -1,0 +1,204 @@
+/**
+ * JWT revocation on logout integration tests
+ * Tests that /logout sets tokensInvalidatedBefore and middleware rejects old tokens
+ */
+
+import request from "supertest";
+import express from "express";
+import { requestIdMiddleware } from "../middleware/requestId";
+import { expectSuccessResponse } from "./helpers/response";
+
+process.env.NODE_ENV = "test";
+process.env.JWT_SECRET = "test-secret";
+process.env.DATABASE_URL = "postgresql://localhost:5432/atlas_test";
+delete process.env.REDIS_URL;
+
+const mockSupabaseAuth = {
+  admin: {
+    createUser: jest.fn(),
+    signOut: jest.fn(),
+  },
+  signInWithPassword: jest.fn(),
+  getUser: jest.fn(),
+  refreshSession: jest.fn(),
+};
+
+jest.mock("../lib/supabase", () => ({
+  supabaseAdmin: {
+    auth: mockSupabaseAuth,
+  },
+}));
+
+jest.mock("../lib/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("jsonwebtoken", () => ({
+  sign: jest.fn().mockReturnValue("mock_token"),
+  verify: jest.fn().mockReturnValue({ userId: "user-123", iat: 1000 }),
+  decode: jest.fn().mockReturnValue({ iat: 1000 }),
+}));
+
+jest.mock("bcryptjs", () => ({
+  __esModule: true,
+  default: {
+    hash: jest.fn().mockResolvedValue("hashed-password"),
+    compare: jest.fn().mockResolvedValue(true),
+  },
+}));
+
+jest.mock("../lib/logger", () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock("../middleware/rateLimit", () => ({
+  rateLimit: () => (_req: any, _res: any, next: any) => next(),
+  rateLimitByUser: () => (_req: any, _res: any, next: any) => next(),
+  clearRateLimitStore: jest.fn(),
+}));
+
+import { authRouter } from "../routes/auth";
+import { prisma } from "../lib/prisma";
+import jwt from "jsonwebtoken";
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockJwt = jwt as jest.Mocked<typeof jwt>;
+
+const app = express();
+app.use(express.json());
+app.use(requestIdMiddleware);
+app.use("/api/auth", authRouter);
+
+const mockUser = {
+  id: "user-123",
+  handle: "testuser",
+  email: "test@example.com",
+  role: "ANALYST",
+  supabaseId: "sb-uuid-123",
+  voiceProfile: null,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (mockPrisma.user.findUnique as jest.Mock).mockReset();
+  (mockPrisma.user.findFirst as jest.Mock).mockReset();
+  (mockPrisma.user.update as jest.Mock).mockReset();
+  (mockPrisma.user.create as jest.Mock).mockReset();
+
+  // Default: getUser fails so authenticate falls through to JWT path
+  mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: null }, error: { message: "invalid" } });
+  // Default: Supabase sign-in fails so login falls through to legacy path
+  mockSupabaseAuth.signInWithPassword.mockResolvedValue({ data: { session: null }, error: { message: "invalid" } });
+
+  // Default jwt mocks
+  (mockJwt.sign as jest.Mock).mockReturnValue("mock_token");
+  (mockJwt.verify as jest.Mock).mockReturnValue({ userId: "user-123", iat: 1000 });
+  (mockJwt.decode as jest.Mock).mockReturnValue({ iat: 1000 });
+});
+
+describe("JWT revocation on logout", () => {
+  it("valid legacy token works before logout", async () => {
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+      ...mockUser,
+      tokensInvalidatedBefore: null,
+    });
+
+    const res = await request(app)
+      .get("/api/auth/me")
+      .set("Authorization", "Bearer mock_token");
+
+    expect(res.status).toBe(200);
+  });
+
+  it("same token returns 401 after /logout", async () => {
+    (mockPrisma.user.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ ...mockUser, tokensInvalidatedBefore: null })
+      .mockResolvedValueOnce({ ...mockUser, supabaseId: "sb-uuid-123" })
+      .mockResolvedValueOnce({ ...mockUser, tokensInvalidatedBefore: new Date(2000 * 1000) });
+
+    (mockPrisma.user.update as jest.Mock).mockResolvedValue({
+      ...mockUser,
+      tokensInvalidatedBefore: new Date(2000 * 1000),
+    });
+
+    const logoutRes = await request(app)
+      .post("/api/auth/logout")
+      .set("Authorization", "Bearer mock_token");
+    expect(logoutRes.status).toBe(200);
+
+    const meRes = await request(app)
+      .get("/api/auth/me")
+      .set("Authorization", "Bearer mock_token");
+
+    expect(meRes.status).toBe(401);
+    expect(meRes.body.error).toMatch(/revoked/i);
+  });
+
+  it("new token issued after logout works", async () => {
+    (mockPrisma.user.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ ...mockUser, passwordHash: "hashed-password", tokensInvalidatedBefore: null })
+      .mockResolvedValueOnce({ ...mockUser, tokensInvalidatedBefore: null })
+      .mockResolvedValueOnce({ ...mockUser, supabaseId: "sb-uuid-123" })
+      .mockResolvedValueOnce({ ...mockUser, tokensInvalidatedBefore: new Date(1000 * 1000) })
+      .mockResolvedValueOnce({ ...mockUser, voiceProfile: null });
+
+    (mockPrisma.user.update as jest.Mock).mockResolvedValue({
+      ...mockUser,
+      tokensInvalidatedBefore: new Date(1000 * 1000),
+    });
+
+    // login with old credentials to get token t1
+    const loginRes = await request(app)
+      .post("/api/auth/login")
+      .send({ email: "test@example.com", password: "secret123" });
+    expect(loginRes.status).toBe(200);
+    const t1 = expectSuccessResponse<any>(loginRes.body).token;
+
+    // logout with t1
+    const logoutRes = await request(app)
+      .post("/api/auth/logout")
+      .set("Authorization", `Bearer ${t1}`);
+    expect(logoutRes.status).toBe(200);
+
+    // simulate new token t2 with later iat
+    (mockJwt.verify as jest.Mock).mockReturnValue({ userId: "user-123", iat: 2000 });
+    (mockJwt.decode as jest.Mock).mockReturnValue({ iat: 2000 });
+
+    const meRes = await request(app)
+      .get("/api/auth/me")
+      .set("Authorization", "Bearer mock_token_new");
+    expect(meRes.status).toBe(200);
+  });
+
+  it("logout invalidates tokens on all devices (same user, different tokens)", async () => {
+    (mockPrisma.user.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ ...mockUser, tokensInvalidatedBefore: null })
+      .mockResolvedValueOnce({ ...mockUser, supabaseId: "sb-uuid-123" })
+      .mockResolvedValueOnce({ ...mockUser, tokensInvalidatedBefore: new Date(2000 * 1000) });
+
+    (mockPrisma.user.update as jest.Mock).mockResolvedValue({
+      ...mockUser,
+      tokensInvalidatedBefore: new Date(2000 * 1000),
+    });
+
+    // token A calls logout
+    const logoutRes = await request(app)
+      .post("/api/auth/logout")
+      .set("Authorization", "Bearer token_a");
+    expect(logoutRes.status).toBe(200);
+
+    // token B (same user, earlier iat) is now rejected
+    const meRes = await request(app)
+      .get("/api/auth/me")
+      .set("Authorization", "Bearer token_b");
+    expect(meRes.status).toBe(401);
+    expect(meRes.body.error).toMatch(/revoked/i);
+  });
+});

--- a/services/api/src/__tests__/auth.test.ts
+++ b/services/api/src/__tests__/auth.test.ts
@@ -2,11 +2,12 @@
  * Auth routes test suite (legacy — tests /me endpoint behavior)
  * The comprehensive Supabase auth tests are in routes/auth.test.ts
  * This file tests: GET /me, auth middleware behavior
- * Mocks: Prisma, Supabase (null — JWT fallback), jsonwebtoken
+ * Mocks: Prisma, Supabase (null — JWT fallback)
  */
 
 import request from "supertest";
 import express from "express";
+import jwt from "jsonwebtoken";
 import { requestIdMiddleware } from "../middleware/requestId";
 import { expectSuccessResponse } from "./helpers/response";
 
@@ -28,11 +29,6 @@ jest.mock("../lib/prisma", () => ({
   },
 }));
 
-jest.mock("jsonwebtoken", () => ({
-  sign: jest.fn().mockReturnValue("mock_token"),
-  verify: jest.fn().mockReturnValue({ userId: "user-123" }),
-}));
-
 jest.mock("bcryptjs", () => ({
   hash: jest.fn().mockResolvedValue("hashed_password"),
   compare: jest.fn().mockResolvedValue(true),
@@ -51,6 +47,10 @@ const app = express();
 app.use(express.json());
 app.use(requestIdMiddleware);
 app.use("/api/auth", authRouter);
+
+function signTestToken(userId = "user-123"): string {
+  return jwt.sign({ userId }, process.env.JWT_SECRET || "test-secret", { expiresIn: "7d" });
+}
 
 const mockUser = {
   id: "user-123",
@@ -117,7 +117,7 @@ describe("POST /api/auth/login", () => {
 });
 
 describe("GET /api/auth/me", () => {
-  const validToken = "Bearer mock_token";
+  const validToken = () => `Bearer ${signTestToken()}`;
 
   it("returns 401 when no token provided", async () => {
     const res = await request(app).get("/api/auth/me");
@@ -125,24 +125,28 @@ describe("GET /api/auth/me", () => {
   });
 
   it("returns 404 when user not found", async () => {
-    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce(null);
+    (mockPrisma.user.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ id: "user-123", tokensInvalidatedBefore: null })
+      .mockResolvedValueOnce(null);
 
     const res = await request(app)
       .get("/api/auth/me")
-      .set("Authorization", validToken);
+      .set("Authorization", validToken());
 
     expect(res.status).toBe(404);
   });
 
   it("returns user with voiceProfile when authenticated", async () => {
-    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
-      ...mockUser,
-      voiceProfile: { humor: 5, formality: 5 },
-    });
+    (mockPrisma.user.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ id: "user-123", tokensInvalidatedBefore: null })
+      .mockResolvedValueOnce({
+        ...mockUser,
+        voiceProfile: { humor: 5, formality: 5 },
+      });
 
     const res = await request(app)
       .get("/api/auth/me")
-      .set("Authorization", validToken);
+      .set("Authorization", validToken());
 
     expect(res.status).toBe(200);
     const data = expectSuccessResponse<any>(res.body);

--- a/services/api/src/__tests__/e2e/smoke.test.ts
+++ b/services/api/src/__tests__/e2e/smoke.test.ts
@@ -14,6 +14,7 @@ type UserRecord = {
   passwordHash: string | null;
   role: "ANALYST" | "MANAGER" | "ADMIN";
   supabaseId: string | null;
+  tokensInvalidatedBefore: Date | null;
   displayName: string | null;
   avatarUrl: string | null;
   createdAt: Date;
@@ -182,6 +183,7 @@ const mockPrisma = {
         passwordHash: args.data.passwordHash ?? null,
         role: "ANALYST",
         supabaseId: args.data.supabaseId ?? null,
+        tokensInvalidatedBefore: args.data.tokensInvalidatedBefore ?? null,
         displayName: args.data.displayName ?? null,
         avatarUrl: args.data.avatarUrl ?? null,
         createdAt: now,

--- a/services/api/src/__tests__/integration/x-oauth-cookie-auth.test.ts
+++ b/services/api/src/__tests__/integration/x-oauth-cookie-auth.test.ts
@@ -128,6 +128,7 @@ const DB_USER = {
   handle: TEST_X_HANDLE,
   email: null,
   role: "ANALYST",
+  tokensInvalidatedBefore: null,
   onboardingTrack: "TRACK_B",
   xHandle: TEST_X_HANDLE,
   xBio: TWITTER_PROFILE.description,

--- a/services/api/src/__tests__/middleware.test.ts
+++ b/services/api/src/__tests__/middleware.test.ts
@@ -20,6 +20,7 @@ jest.mock("../lib/config", () => ({
 
 jest.mock("jsonwebtoken", () => ({
   verify: jest.fn(),
+  decode: jest.fn(),
 }));
 
 const isJtiRevokedMock = jest.fn();
@@ -30,11 +31,13 @@ jest.mock("../lib/jwt-revocation", () => ({
 }));
 
 // Import after mocks
-import { authenticate, AuthRequest } from "../middleware/auth";
+import { authenticate, AuthRequest, isTokenRevoked } from "../middleware/auth";
 import { config } from "../lib/config";
+import { prisma } from "../lib/prisma";
 
 const mockJwt = jwt as jest.Mocked<typeof jwt>;
 const mockConfig = config as { JWT_SECRET: string };
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 
 function makeReq(authHeader?: string): AuthRequest {
   return {
@@ -58,6 +61,11 @@ describe("authenticate middleware", () => {
     mockConfig.JWT_SECRET = "test-secret";
     isJtiRevokedMock.mockReset();
     isJtiRevokedMock.mockResolvedValue(false);
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: "user-abc",
+      tokensInvalidatedBefore: null,
+    });
+    (mockJwt.decode as jest.Mock).mockReturnValue({ iat: 1000 });
   });
 
   it("returns 401 when Authorization header is missing", async () => {
@@ -156,5 +164,34 @@ describe("authenticate middleware", () => {
     await authenticate(req, res, next as NextFunction);
     expect(isJtiRevokedMock).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
+  });
+});
+
+describe("isTokenRevoked helper", () => {
+  it("returns true when token has no iat", () => {
+    (mockJwt.decode as jest.Mock).mockReturnValueOnce({});
+    expect(isTokenRevoked("token", null)).toBe(true);
+  });
+
+  it("returns true when token has no decode result", () => {
+    (mockJwt.decode as jest.Mock).mockReturnValueOnce(null);
+    expect(isTokenRevoked("token", null)).toBe(true);
+  });
+
+  it("returns true when iat is before the cutoff", () => {
+    (mockJwt.decode as jest.Mock).mockReturnValueOnce({ iat: 1000 });
+    const cutoff = new Date(1000 * 1000 + 2000); // iatMs (1000000) < cutoff - 1000
+    expect(isTokenRevoked("token", cutoff)).toBe(true);
+  });
+
+  it("returns false when iat is after the cutoff (outside skew window)", () => {
+    (mockJwt.decode as jest.Mock).mockReturnValueOnce({ iat: 2000 });
+    const cutoff = new Date(1000 * 1000); // iatMs (2000000) >= cutoff - 1000
+    expect(isTokenRevoked("token", cutoff)).toBe(false);
+  });
+
+  it("returns false when cutoff is null", () => {
+    (mockJwt.decode as jest.Mock).mockReturnValueOnce({ iat: 1000 });
+    expect(isTokenRevoked("token", null)).toBe(false);
   });
 });

--- a/services/api/src/__tests__/routes/auth.test.ts
+++ b/services/api/src/__tests__/routes/auth.test.ts
@@ -1,11 +1,12 @@
 /**
  * Auth routes test suite
  * Tests POST /register, POST /login, GET /me, GET /sessions, DELETE /sessions/:id
- * Mocks: Prisma, Supabase admin client, jsonwebtoken
+ * Mocks: Prisma, Supabase admin client
  */
 
 import request from "supertest";
 import express from "express";
+import jwt from "jsonwebtoken";
 import { requestIdMiddleware } from "../../middleware/requestId";
 import { expectErrorResponse, expectSuccessResponse } from "../helpers/response";
 
@@ -49,11 +50,6 @@ jest.mock("../../lib/prisma", () => ({
   },
 }));
 
-jest.mock("jsonwebtoken", () => ({
-  sign: jest.fn().mockReturnValue("mock_token"),
-  verify: jest.fn().mockReturnValue({ userId: "user-123" }),
-}));
-
 jest.mock("bcryptjs", () => ({
   __esModule: true,
   default: {
@@ -74,7 +70,11 @@ app.use(express.json());
 app.use(requestIdMiddleware);
 app.use("/api/auth", authRouter);
 
-const AUTH = "Bearer mock_token";
+function signTestToken(userId = "user-123"): string {
+  return jwt.sign({ userId }, process.env.JWT_SECRET || "test-secret", { expiresIn: "7d" });
+}
+
+const AUTH = () => `Bearer ${signTestToken()}`;
 
 const mockVoiceProfile = {
   id: "voice-1",
@@ -92,6 +92,7 @@ const mockUser = {
   email: "atlas@example.com",
   role: "ANALYST",
   supabaseId: "sb-uuid-123",
+  tokensInvalidatedBefore: null,
   voiceProfile: mockVoiceProfile,
 };
 
@@ -285,11 +286,13 @@ describe("POST /api/auth/refresh", () => {
 
 describe("GET /api/auth/me", () => {
   it("returns user with voice profile when authenticated", async () => {
-    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce(mockUser);
+    (mockPrisma.user.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ id: "user-123", tokensInvalidatedBefore: null })
+      .mockResolvedValueOnce(mockUser);
 
     const res = await request(app)
       .get("/api/auth/me")
-      .set("Authorization", AUTH);
+      .set("Authorization", AUTH());
 
     expect(res.status).toBe(200);
     const data = expectSuccessResponse<any>(res.body);
@@ -305,11 +308,15 @@ describe("GET /api/auth/me", () => {
 
 describe("GET /api/auth/sessions", () => {
   it("lists active sessions for authenticated user", async () => {
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "user-123",
+      tokensInvalidatedBefore: null,
+    });
     (mockPrisma.session.findMany as jest.Mock).mockResolvedValueOnce([mockSession]);
 
     const res = await request(app)
       .get("/api/auth/sessions")
-      .set("Authorization", AUTH);
+      .set("Authorization", AUTH());
 
     expect(res.status).toBe(200);
     const data = expectSuccessResponse<any>(res.body);
@@ -320,23 +327,31 @@ describe("GET /api/auth/sessions", () => {
 
 describe("DELETE /api/auth/sessions/:id", () => {
   it("revokes a session for the authenticated user", async () => {
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "user-123",
+      tokensInvalidatedBefore: null,
+    });
     (mockPrisma.session.findFirst as jest.Mock).mockResolvedValueOnce(mockSession);
     (mockPrisma.session.delete as jest.Mock).mockResolvedValueOnce(mockSession);
 
     const res = await request(app)
       .delete("/api/auth/sessions/session-1")
-      .set("Authorization", AUTH);
+      .set("Authorization", AUTH());
 
     expect(res.status).toBe(200);
     expect(expectSuccessResponse<any>(res.body)).toEqual({ success: true });
   });
 
   it("returns 404 when session is not found", async () => {
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "user-123",
+      tokensInvalidatedBefore: null,
+    });
     (mockPrisma.session.findFirst as jest.Mock).mockResolvedValueOnce(null);
 
     const res = await request(app)
       .delete("/api/auth/sessions/missing-session")
-      .set("Authorization", AUTH);
+      .set("Authorization", AUTH());
 
     expect(res.status).toBe(404);
   });

--- a/services/api/src/middleware/auth.ts
+++ b/services/api/src/middleware/auth.ts
@@ -10,6 +10,18 @@ export interface AuthRequest extends Request {
   userId?: string;
 }
 
+export function isTokenRevoked(token: string, invalidatedBefore: Date | null): boolean {
+  const decoded = jwt.decode(token) as { iat?: number } | null;
+  if (!decoded || typeof decoded.iat !== "number") {
+    return true; // missing iat → treat as revoked (safe default)
+  }
+  const iatMs = decoded.iat * 1000;
+  if (invalidatedBefore !== null && iatMs < invalidatedBefore.getTime() - 1000) {
+    return true;
+  }
+  return false;
+}
+
 /**
  * Dual-mode auth middleware.
  * Token sources (priority): HttpOnly cookie > Authorization header
@@ -45,6 +57,9 @@ export async function authenticate(req: AuthRequest, res: Response, next: NextFu
         }
 
         if (user) {
+          if (isTokenRevoked(token, user.tokensInvalidatedBefore)) {
+            return res.status(401).json({ error: "Token revoked" });
+          }
           req.userId = user.id;
           return next();
         }
@@ -72,7 +87,18 @@ export async function authenticate(req: AuthRequest, res: Response, next: NextFu
       return res.status(401).json({ error: "Invalid or expired token" });
     }
 
-    req.userId = payload.userId;
+    const user = await prisma.user.findUnique({
+      where: { id: payload.userId },
+      select: { id: true, tokensInvalidatedBefore: true },
+    });
+    if (!user) {
+      return res.status(401).json({ error: "Invalid or expired token" });
+    }
+    if (isTokenRevoked(token, user.tokensInvalidatedBefore)) {
+      return res.status(401).json({ error: "Token revoked" });
+    }
+
+    req.userId = user.id;
     return next();
   } catch {
     return res.status(401).json({ error: "Invalid or expired token" });

--- a/services/api/src/routes/auth.ts
+++ b/services/api/src/routes/auth.ts
@@ -350,12 +350,35 @@ authRouter.post("/logout", authenticate, async (req: AuthRequest, res) => {
       }
     }
 
+    // 1. Mark all tokens issued before now as invalid
+    await prisma.user.update({
+      where: { id: req.userId! },
+      data: { tokensInvalidatedBefore: new Date(Date.now() + 1000) },
+    });
+
+    // 2. Kill Supabase refresh token server-side (best-effort)
+    if (supabaseAdmin) {
+      const user = await prisma.user.findUnique({
+        where: { id: req.userId! },
+        select: { supabaseId: true },
+      });
+      if (user?.supabaseId) {
+        try {
+          await supabaseAdmin.auth.admin.signOut(user.supabaseId, "global");
+        } catch (err: any) {
+          logger.warn({ err: err.message }, "Supabase signOut failed (non-fatal)");
+        }
+      }
+    }
+
+    // 3. Clear cookies
     clearAuthCookies(res);
     res.json(success({ success: true }));
   } catch (err: any) {
     if (err instanceof z.ZodError) {
       return res.status(400).json(error("Invalid request", 400, err.errors));
     }
+    logger.error({ err: err.message }, "Logout error");
     res.status(500).json(error("Logout failed"));
   }
 });


### PR DESCRIPTION
Implements /tmp/forge-plan-p2-jwt-revocation.md. Adds User.tokensInvalidatedBefore + middleware iat check + supabase global signOut on /logout. MANDATORY Forge-Audit — auth-adjacent Sandwich bottom-bread.