### PR TITLE
fix(voice): persist xAvatarUrl on calibrate

### DIFF
--- a/services/api/src/__tests__/routes/ai-rate-limits.test.ts
+++ b/services/api/src/__tests__/routes/ai-rate-limits.test.ts
@@ -81,6 +81,9 @@ jest.mock("../../lib/prisma", () => ({
     voiceProfile: {
       upsert: jest.fn(),
     },
+    user: {
+      update: jest.fn(),
+    },
   },
 }));
 
@@ -150,6 +153,10 @@ beforeEach(() => {
     maturity: "BEGINNER",
     createdAt: new Date("2026-01-01T00:00:00.000Z"),
     updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  });
+  (mockPrisma.user.update as jest.Mock).mockResolvedValue({
+    id: "user-alpha",
+    xAvatarUrl: null,
   });
 });
 

--- a/services/api/src/__tests__/routes/calibrate.test.ts
+++ b/services/api/src/__tests__/routes/calibrate.test.ts
@@ -18,6 +18,9 @@ jest.mock("../../middleware/auth", () => ({
 
 jest.mock("../../lib/prisma", () => ({
   prisma: {
+    user: {
+      update: jest.fn(),
+    },
     voiceProfile: {
       upsert: jest.fn(),
     },
@@ -54,6 +57,7 @@ const twitterUser = {
   id: "twitter-user-1",
   username: "atlasanalyst",
   name: "Atlas Analyst",
+  profile_image_url: "https://pbs.twimg.com/profile_images/atlas_400x400.jpg",
 };
 
 function makeTweets(count: number) {
@@ -135,6 +139,10 @@ function buildDimensionData(calibration: ReturnType<typeof makeCalibration>) {
 beforeEach(() => {
   jest.clearAllMocks();
   (mockPrisma.analyticsEvent.create as jest.Mock).mockResolvedValue({ id: "event-1" });
+  (mockPrisma.user.update as jest.Mock).mockResolvedValue({
+    id: "user-123",
+    xAvatarUrl: twitterUser.profile_image_url,
+  });
 });
 
 describe("POST /api/voice/calibrate", () => {
@@ -326,6 +334,28 @@ describe("POST /api/voice/calibrate", () => {
     expect(res.status).toBe(200);
     expect(mockPrisma.analyticsEvent.create).toHaveBeenCalledWith({
       data: { userId: "user-123", type: "VOICE_REFINEMENT" },
+    });
+  });
+
+  it("persists xAvatarUrl from the X lookup result on success", async () => {
+    const tweets = makeTweets(12);
+    const calibration = makeCalibration({ tweetsAnalyzed: tweets.length });
+
+    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets });
+    mockCalibrateFromTweets.mockResolvedValueOnce(calibration);
+    (mockPrisma.voiceProfile.upsert as jest.Mock).mockResolvedValueOnce(
+      makeProfile(buildDimensionData(calibration)),
+    );
+
+    const res = await request(app)
+      .post("/api/voice/calibrate")
+      .set(AUTH)
+      .send({ handle: "atlasanalyst" });
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      where: { id: "user-123" },
+      data: { xAvatarUrl: twitterUser.profile_image_url },
     });
   });
 

--- a/services/api/src/routes/voice.ts
+++ b/services/api/src/routes/voice.ts
@@ -624,6 +624,7 @@ voiceRouter.post("/calibrate", aiGenerationLimiter, async (req: AuthRequest, res
   const abort = new AbortController();
   try {
     const body = calibrateSchema.parse(req.body);
+    const userId = req.userId!;
     const normalizedHandle = normalizeReferenceHandle(body.handle);
 
     const RACE_MS = 40_000;
@@ -647,15 +648,21 @@ voiceRouter.post("/calibrate", aiGenerationLimiter, async (req: AuthRequest, res
       const dimensionData = buildVoiceProfileUpdate(calibration);
 
       const profile = await prisma.voiceProfile.upsert({
-        where: { userId: req.userId! },
+        where: { userId },
         update: dimensionData,
-        create: { userId: req.userId!, ...dimensionData },
+        create: { userId, ...dimensionData },
       });
       if (abort.signal.aborted) return;
 
       // Log analytics
       await prisma.analyticsEvent.create({
-        data: { userId: req.userId!, type: "VOICE_REFINEMENT" },
+        data: { userId, type: "VOICE_REFINEMENT" },
+      });
+      if (abort.signal.aborted) return;
+
+      await prisma.user.update({
+        where: { id: userId },
+        data: { xAvatarUrl: twitterUser.profile_image_url ?? null },
       });
       if (abort.signal.aborted) return;
 


### PR DESCRIPTION
BUG-6. services/api/src/routes/voice.ts writes user.xAvatarUrl during calibrate success branch; integration test asserts persistence.