### PR TITLE
Add briefing heartbeat cron stub

### DIFF
--- a/services/api/src/__tests__/cron/briefing.test.ts
+++ b/services/api/src/__tests__/cron/briefing.test.ts
@@ -1,0 +1,29 @@
+jest.mock("../../lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import { logger } from "../../lib/logger";
+import { startBriefingCron, stopBriefingCron } from "../../../../cron/briefing";
+
+describe("startBriefingCron", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    stopBriefingCron();
+  });
+
+  afterEach(() => {
+    stopBriefingCron();
+    jest.useRealTimers();
+  });
+
+  it("registers without throwing", () => {
+    expect(() => startBriefingCron()).not.toThrow();
+    expect(logger.info).toHaveBeenCalledWith("[briefing-cron] registered");
+  });
+});

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -46,6 +46,7 @@ import { getRedis } from "./lib/redis";
 import { initBot } from "./lib/telegram";
 import { initSocket } from "./lib/socket";
 import { startScheduler } from "./lib/scheduler";
+import { startCronServices } from "../../cron";
 
 dotenv.config();
 
@@ -191,7 +192,6 @@ initBot();
 server.listen(PORT, () => {
   logger.info({ port: PORT }, `Atlas API running on port ${PORT}`);
   startScheduler();
-
   // 2026-04-11: Enable queue + campaigns feature flags
   void (async () => {
     try {
@@ -207,6 +207,7 @@ server.listen(PORT, () => {
       logger.error({ err: err.message }, "Failed to enable feature flags on startup");
     }
   })();
+  startCronServices();
 });
 
 export default app;

--- a/services/cron/briefing.ts
+++ b/services/cron/briefing.ts
@@ -1,0 +1,29 @@
+import { logger } from "../api/src/lib/logger";
+
+export const BRIEFING_CRON_EXPRESSION = "*/5 * * * *";
+const BRIEFING_INTERVAL_MS = 5 * 60_000;
+
+let briefingCronInterval: ReturnType<typeof setInterval> | null = null;
+const logBriefingHeartbeat = logger.info.bind(logger) as (...args: unknown[]) => void;
+
+export function startBriefingCron(): void {
+  if (briefingCronInterval) {
+    return;
+  }
+
+  logger.info("[briefing-cron] registered");
+
+  briefingCronInterval = setInterval(() => {
+    logBriefingHeartbeat("[briefing-cron] Job Heartbeat", { ts: new Date().toISOString() });
+    // TODO: Replace heartbeat stub with real briefing generation.
+  }, BRIEFING_INTERVAL_MS);
+}
+
+export function stopBriefingCron(): void {
+  if (!briefingCronInterval) {
+    return;
+  }
+
+  clearInterval(briefingCronInterval);
+  briefingCronInterval = null;
+}

--- a/services/cron/index.ts
+++ b/services/cron/index.ts
@@ -1,0 +1,12 @@
+import { startBriefingCron } from "./briefing";
+
+let cronServicesStarted = false;
+
+export function startCronServices(): void {
+  if (cronServicesStarted) {
+    return;
+  }
+
+  cronServicesStarted = true;
+  startBriefingCron();
+}


### PR DESCRIPTION
## What changed
- adds a `services/cron/briefing.ts` heartbeat stub on a 5-minute cadence
- adds a small `services/cron/index.ts` bootstrap that starts the briefing cron
- wires the cron bootstrap into API startup
- adds a minimal Jest test covering cron registration

## Why
This is a stub to prevent the "Daily briefing" UI from lying during the Anil demo. It registers and emits a heartbeat log, but does not attempt actual briefing generation yet.

## Tests
- `npx jest services/api/src/__tests__/cron/briefing.test.ts --runInBand`
- `npm run build`