### PR TITLE
fix: railway staging branch + build reliability

### DIFF
--- a/services/api/src/lib/config.ts
+++ b/services/api/src/lib/config.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 const envSchema = z.object({
-  NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+  NODE_ENV: z.enum(["development", "production", "staging", "test"]).default("development"),
   PORT: z.coerce.number().default(8000),
   FRONTEND_URL: z.string().default("http://localhost:3000"),
 


### PR DESCRIPTION
NODE_ENV='staging' was rejected by the Zod env validator (enum allowed
only development|production|test), causing every Railway staging deploy
to crash on boot. Add 'staging' to the allowed NODE_ENV enum so Railway
staging deploys boot successfully.

Cherry-picked from staging branch fix (commit 90022ef).
