### PR TITLE
Add env hygiene CI guardrails

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,198 @@
+# Canonical schema for Atlas backend production deploys.
+# Real values live in 1Password item "Atlas Backend / Production / .env.production"
+# in the "Delphi Digital" vault. Copy secrets from fields with the same key names.
+
+# Required. Keep production deploys locked to the production config profile.
+NODE_ENV=production
+
+# Required. Listener port exposed by the platform process manager.
+PORT=8000
+
+# Required. Comma-separated production frontend origins allowed by backend CORS.
+# Source: 1Password field FRONTEND_URL.
+FRONTEND_URL=<production-frontend-origin>[,<additional-production-origin>]
+
+# Required by Railway deploys for long-running AI requests.
+RAILWAY_SERVICE_TIMEOUT=90000
+
+# Required. Primary Postgres connection string for Atlas backend.
+# Source: 1Password field DATABASE_URL.
+DATABASE_URL=<paste-DATABASE_URL-from-1Password>
+
+# Recommended in production. Redis connection string for caching and rate-limit storage.
+# Source: 1Password field REDIS_URL.
+REDIS_URL=<paste-REDIS_URL-from-1Password>
+
+# Required. JWT signing secret for Atlas backend auth tokens.
+# Source: 1Password field JWT_SECRET.
+JWT_SECRET=<paste-JWT_SECRET-from-1Password>
+
+# Optional. AES-256-GCM key for encrypted XOAuth token storage.
+# Source: 1Password field TOKEN_ENCRYPTION_KEY.
+TOKEN_ENCRYPTION_KEY=<paste-TOKEN_ENCRYPTION_KEY-from-1Password>
+
+# Required if you override the default auth limiter in production.
+RATE_LIMIT_AUTH_MAX_REQUESTS=10
+
+# Required if you override the default auth limiter window in production.
+RATE_LIMIT_AUTH_WINDOW_MS=60000
+
+# Required if you override the default login limiter in production.
+RATE_LIMIT_LOGIN_MAX_REQUESTS=5
+
+# Required if you override the default login limiter window in production.
+RATE_LIMIT_LOGIN_WINDOW_MS=900000
+
+# Required if you override the default register limiter in production.
+RATE_LIMIT_REGISTER_MAX_REQUESTS=5
+
+# Required if you override the default register limiter window in production.
+RATE_LIMIT_REGISTER_WINDOW_MS=900000
+
+# Required if you override the default docs limiter in production.
+RATE_LIMIT_DOCS_MAX_REQUESTS=30
+
+# Required if you override the default docs limiter window in production.
+RATE_LIMIT_DOCS_WINDOW_MS=60000
+
+# Required if you override the default AI limiter in production.
+RATE_LIMIT_AI_GENERATION_MAX_REQUESTS=20
+
+# Required if you override the default AI limiter window in production.
+RATE_LIMIT_AI_GENERATION_WINDOW_MS=3600000
+
+# Required if you override the default general limiter in production.
+RATE_LIMIT_GENERAL_MAX_REQUESTS=100
+
+# Required if you override the default general limiter window in production.
+RATE_LIMIT_GENERAL_WINDOW_MS=60000
+
+# Optional. OpenAI API key for research, transcription, and generation features.
+# Source: 1Password field OPENAI_API_KEY.
+OPENAI_API_KEY=<paste-OPENAI_API_KEY-from-1Password>
+
+# Optional. Anthropic API key for Claude-backed generation flows.
+# Source: 1Password field ANTHROPIC_API_KEY.
+ANTHROPIC_API_KEY=<paste-ANTHROPIC_API_KEY-from-1Password>
+
+# Optional. Google AI key for Gemini-backed image and text flows.
+# Source: 1Password field GOOGLE_AI_API_KEY.
+GOOGLE_AI_API_KEY=<paste-GOOGLE_AI_API_KEY-from-1Password>
+
+# Optional. Default Gemini text model override.
+GEMINI_MODEL=gemini-2.5-flash
+
+# Optional. Default Gemini image model override.
+GEMINI_IMAGE_MODEL=gemini-2.5-flash-image
+
+# Optional. xAI API key for Grok-backed trending and research flows.
+# Source: 1Password field XAI_API_KEY.
+XAI_API_KEY=<paste-XAI_API_KEY-from-1Password>
+
+# Optional. Supabase project URL used by legacy auth and admin helpers.
+# Source: 1Password field SUPABASE_URL.
+SUPABASE_URL=<paste-SUPABASE_URL-from-1Password>
+
+# Optional. Supabase service role used by backend admin helpers.
+# Source: 1Password field SUPABASE_SERVICE_ROLE_KEY.
+SUPABASE_SERVICE_ROLE_KEY=<paste-SUPABASE_SERVICE_ROLE_KEY-from-1Password>
+
+# Optional. Supabase JWT secret when legacy Supabase auth is enabled.
+# Source: 1Password field SUPABASE_JWT_SECRET.
+SUPABASE_JWT_SECRET=<paste-SUPABASE_JWT_SECRET-from-1Password>
+
+# Optional. Supabase project ref used by backup helpers.
+# Source: 1Password field SUPABASE_PROJECT_REF.
+SUPABASE_PROJECT_REF=<paste-SUPABASE_PROJECT_REF-from-1Password>
+
+# Optional. Supabase management token used for restore-point snapshots.
+# Source: 1Password field SUPABASE_MANAGEMENT_API_TOKEN.
+SUPABASE_MANAGEMENT_API_TOKEN=<paste-SUPABASE_MANAGEMENT_API_TOKEN-from-1Password>
+
+# Optional. Separate QA Supabase project URL used by QA routes.
+# Source: 1Password field QA_SUPABASE_URL.
+QA_SUPABASE_URL=<paste-QA_SUPABASE_URL-from-1Password>
+
+# Optional. Separate QA Supabase anon/service key used by QA routes.
+# Source: 1Password field QA_SUPABASE_KEY.
+QA_SUPABASE_KEY=<paste-QA_SUPABASE_KEY-from-1Password>
+
+# Optional. Read-only X API bearer token.
+# Source: 1Password field TWITTER_BEARER_TOKEN.
+TWITTER_BEARER_TOKEN=<paste-TWITTER_BEARER_TOKEN-from-1Password>
+
+# Optional. X OAuth client ID used for account linking and login.
+# Source: 1Password field TWITTER_CLIENT_ID.
+TWITTER_CLIENT_ID=<paste-TWITTER_CLIENT_ID-from-1Password>
+
+# Optional. X OAuth client secret used for account linking and login.
+# Source: 1Password field TWITTER_CLIENT_SECRET.
+TWITTER_CLIENT_SECRET=<paste-TWITTER_CLIENT_SECRET-from-1Password>
+
+# Optional. Production callback URL for X account linking.
+# Source: 1Password field TWITTER_OAUTH_CALLBACK_URL.
+TWITTER_OAUTH_CALLBACK_URL=<production-api-origin>/api/auth/x/callback
+
+# Optional. Production callback URL for X login. Keep the trailing slash.
+# Source: 1Password field TWITTER_LOGIN_CALLBACK_URL.
+TWITTER_LOGIN_CALLBACK_URL=<production-api-origin>/api/auth/twitter/callback/
+
+# Optional. Telegram bot token used by backend alert delivery.
+# Source: 1Password field TELEGRAM_BOT_TOKEN.
+TELEGRAM_BOT_TOKEN=<paste-TELEGRAM_BOT_TOKEN-from-1Password>
+
+# Optional. Legacy telegram-bot service token if that worker is deployed separately.
+# Source: 1Password field BOT_TOKEN.
+BOT_TOKEN=<paste-BOT_TOKEN-from-1Password>
+
+# Optional. Paperclip API key for task creation and sync.
+# Source: 1Password field PAPERCLIP_API_KEY.
+PAPERCLIP_API_KEY=<paste-PAPERCLIP_API_KEY-from-1Password>
+
+# Optional. Shared webhook secret expected on inbound Paperclip requests.
+# Source: 1Password field PAPERCLIP_WEBHOOK_SECRET.
+PAPERCLIP_WEBHOOK_SECRET=<paste-PAPERCLIP_WEBHOOK_SECRET-from-1Password>
+
+# Optional. Sentry DSN for backend production error reporting.
+# Source: 1Password field SENTRY_DSN.
+SENTRY_DSN=<paste-SENTRY_DSN-from-1Password>
+
+# Optional. GitHub token used by loop-driven PR creation.
+# Source: 1Password field GITHUB_TOKEN.
+GITHUB_TOKEN=<paste-GITHUB_TOKEN-from-1Password>
+
+# Optional. GitHub owner for loop-driven automation.
+# Source: 1Password field GITHUB_OWNER.
+GITHUB_OWNER=<paste-GITHUB_OWNER-from-1Password>
+
+# Optional. GitHub repository for loop-driven automation.
+# Source: 1Password field GITHUB_REPO.
+GITHUB_REPO=<paste-GITHUB_REPO-from-1Password>
+
+# Optional. Path for persisted Ralph loop state on the deployed filesystem.
+RALPH_STATE_PATH=.ralph/state.json
+
+# Optional. Cloudflare R2 endpoint for logical backups.
+# Source: 1Password field R2_ENDPOINT.
+R2_ENDPOINT=<paste-R2_ENDPOINT-from-1Password>
+
+# Optional. Cloudflare R2 bucket for logical backups.
+# Source: 1Password field R2_BUCKET.
+R2_BUCKET=<paste-R2_BUCKET-from-1Password>
+
+# Optional. Cloudflare R2 access key ID for logical backups.
+# Source: 1Password field R2_ACCESS_KEY_ID.
+R2_ACCESS_KEY_ID=<paste-R2_ACCESS_KEY_ID-from-1Password>
+
+# Optional. Cloudflare R2 secret access key for logical backups.
+# Source: 1Password field R2_SECRET_ACCESS_KEY.
+R2_SECRET_ACCESS_KEY=<paste-R2_SECRET_ACCESS_KEY-from-1Password>
+
+# Optional. Local backup output directory for logical dumps.
+BACKUP_LOCAL_DIR=backups
+
+# Optional. Retention window for local and R2 backups, in days.
+BACKUP_RETENTION_DAYS=30
+
+# Optional safety gate for rotate-x-tokens.ts. Keep disabled in normal runtime shells.
+RUN_ROTATE_X_TOKENS=0

--- a/.github/workflows/env-hygiene.yml
+++ b/.github/workflows/env-hygiene.yml
@@ -1,0 +1,103 @@
+name: Env Hygiene
+
+on:
+  pull_request:
+    paths:
+      - "**"
+
+permissions:
+  contents: read
+
+jobs:
+  env-hygiene:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install ripgrep
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+
+      - name: Check for skip marker
+        id: skip
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF}"
+
+          if git log --format=%B "origin/${GITHUB_BASE_REF}..HEAD" | rg -q '\[skip-env-hygiene\]'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Found [skip-env-hygiene] in PR commits; bypassing env hygiene."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Scan pull request diff for dev URLs
+        if: steps.skip.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pattern_parts=(
+            'http://local''host'
+            '127\.0\.0''\.1'
+            '\.ng''rok\.'
+            '-dev\.up\.railway\.''app'
+            'vercel\.app/_pre''view'
+            'staging\.delphi''digital'
+          )
+          env_hygiene_regex="$(IFS='|'; echo "${pattern_parts[*]}")"
+
+          mapfile -t changed_files < <(
+            git diff --name-only --diff-filter=AMRT "origin/${GITHUB_BASE_REF}...HEAD" |
+              rg -v '(^|/)(__tests__/|docs/)|(^|/)[^/]+\.test\.ts$|(^|/)[^/]+\.spec\.ts$|(^|/)README\.md$'
+          )
+
+          if [ "${#changed_files[@]}" -eq 0 ]; then
+            echo "No eligible changed files to scan."
+            exit 0
+          fi
+
+          added_lines_file="$(mktemp)"
+          offending_lines_file="$(mktemp)"
+          trap 'rm -f "$added_lines_file" "$offending_lines_file"' EXIT
+
+          git diff --no-color --unified=0 "origin/${GITHUB_BASE_REF}...HEAD" -- "${changed_files[@]}" | awk '
+            /^\+\+\+ b\// {
+              file = substr($0, 7)
+              next
+            }
+            /^@@/ {
+              if (match($0, /\+([0-9]+)/, match_line)) {
+                line = match_line[1] + 0
+              }
+              next
+            }
+            /^\+/ && !/^\+\+\+/ {
+              print file ":" line ":" substr($0, 2)
+              line++
+              next
+            }
+            /^ / {
+              line++
+            }
+          ' > "$added_lines_file"
+
+          if [ ! -s "$added_lines_file" ]; then
+            echo "No added lines to scan."
+            exit 0
+          fi
+
+          if rg --no-filename --color=never "$env_hygiene_regex" "$added_lines_file" > "$offending_lines_file"; then
+            echo "Dev-only URL fragments detected in this pull request:"
+            cat "$offending_lines_file"
+            exit 1
+          fi
+
+          echo "Env hygiene passed: no blocked dev URLs found in added lines."

--- a/docs/env-hygiene.md
+++ b/docs/env-hygiene.md
@@ -1,0 +1,13 @@
+# Env Hygiene
+
+This repo ships an env hygiene gate to stop obvious dev-only URLs from leaking into production-facing changes. The CI workflow inspects added lines in pull requests and fails when it finds localhost, loopback, ngrok, Railway dev hosts, Vercel preview paths, or Delphi staging hostnames outside the approved exclusions for tests, docs, and README files.
+
+Run the same check locally before deploy with:
+
+```bash
+bash scripts/env-hygiene-local.sh
+```
+
+If you need to bypass the CI gate for a specific pull request, add `[skip-env-hygiene]` to at least one commit message in that PR. Use that sparingly and only when the matched line is intentionally non-production.
+
+The canonical production values do not live in git. Use the root-level [.env.production.example](/private/tmp/worktrees/codex-t4-env-hygiene-ci-033100/.env.production.example) as the schema, and pull the real `.env.production` from the 1Password item `Atlas Backend / Production / .env.production` in the `Delphi Digital` vault.

--- a/scripts/env-hygiene-local.sh
+++ b/scripts/env-hygiene-local.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+red=$'\033[31m'
+green=$'\033[32m'
+yellow=$'\033[33m'
+blue=$'\033[34m'
+reset=$'\033[0m'
+
+pattern_parts=(
+  'http://local''host'
+  '127\.0\.0''\.1'
+  '\.ng''rok\.'
+  '-dev\.up\.railway\.''app'
+  'vercel\.app/_pre''view'
+  'staging\.delphi''digital'
+)
+env_hygiene_regex="$(IFS='|'; echo "${pattern_parts[*]}")"
+
+approved_baseline_pattern='^(\./)?\.env\.example:(3|43|45):|^(\./)?services/api/src/lib/config\.ts:9:'
+
+raw_matches_file="$(mktemp)"
+filtered_matches_file="$(mktemp)"
+trap 'rm -f "$raw_matches_file" "$filtered_matches_file"' EXIT
+
+printf '%sEnv hygiene scan%s\n' "$blue" "$reset"
+printf 'Repo: %s\n' "$repo_root"
+
+rg \
+  --hidden \
+  --line-number \
+  --with-filename \
+  --color=never \
+  --glob '!.git/**' \
+  --glob '!**/__tests__/**' \
+  --glob '!**/*.test.ts' \
+  --glob '!**/*.spec.ts' \
+  --glob '!docs/**' \
+  --glob '!**/README.md' \
+  "$env_hygiene_regex" \
+  . > "$raw_matches_file" || true
+
+grep -Ev "$approved_baseline_pattern" "$raw_matches_file" > "$filtered_matches_file" || true
+
+approved_baseline_hits=0
+if [ -s "$raw_matches_file" ]; then
+  approved_baseline_hits="$(grep -Ec "$approved_baseline_pattern" "$raw_matches_file" || true)"
+fi
+
+if [ -s "$filtered_matches_file" ]; then
+  offending_line_count="$(wc -l < "$filtered_matches_file" | tr -d ' ')"
+  offending_file_count="$(cut -d: -f1 "$filtered_matches_file" | sort -u | wc -l | tr -d ' ')"
+
+  printf '%sBlocked dev URLs found:%s\n' "$red" "$reset"
+  while IFS= read -r line; do
+    printf '%s%s%s\n' "$yellow" "$line" "$reset"
+  done < "$filtered_matches_file"
+
+  printf '%sSummary:%s %s offending line(s) across %s file(s)%s\n' \
+    "$red" "$reset" "$offending_line_count" "$offending_file_count" \
+    "$([ "$approved_baseline_hits" -gt 0 ] && printf '; %s approved baseline match(es) ignored' "$approved_baseline_hits")"
+  exit 1
+fi
+
+printf '%sSummary:%s 0 offending lines%s\n' \
+  "$green" "$reset" \
+  "$([ "$approved_baseline_hits" -gt 0 ] && printf '; %s approved baseline match(es) ignored' "$approved_baseline_hits")"


### PR DESCRIPTION
## Summary
- add a pull request workflow that scans added lines for blocked dev-only URL patterns before merge
- add a local `scripts/env-hygiene-local.sh` mirror so operators can run the same gate before deploy
- document the bypass flow and the canonical `.env.production` source, and add a production env template with 1Password references

## Why
This gates dev-URL leaks before they ship to prod.

## Verification
- `bash scripts/env-hygiene-local.sh`
