### PR TITLE
fix(calibrate): top-engaged + most-recent tweet blend for voice scan

### DIFF
--- a/services/api/src/__tests__/routes/ai-rate-limits.test.ts
+++ b/services/api/src/__tests__/routes/ai-rate-limits.test.ts
@@ -115,6 +115,7 @@ beforeEach(() => {
   mockFetchTweetsByHandle.mockResolvedValue({
     user: { id: "twitter-user-1", username: "atlasanalyst", name: "Atlas Analyst" },
     tweets: [{ id: "tweet-1", text: "BTC structure still matters." }],
+    stats: { pool: 50, topN: 0, recentN: 50 },
   });
   mockCalibrateFromTweets.mockResolvedValue({
     humor: 55,

--- a/services/api/src/__tests__/routes/calibrate.test.ts
+++ b/services/api/src/__tests__/routes/calibrate.test.ts
@@ -183,6 +183,7 @@ describe("POST /api/voice/calibrate", () => {
     mockFetchTweetsByHandle.mockResolvedValueOnce({
       user: twitterUser,
       tweets: [],
+      stats: { pool: 100, topN: 25, recentN: 25 },
     });
 
     const res = await request(app)
@@ -191,7 +192,7 @@ describe("POST /api/voice/calibrate", () => {
       .send({ handle: "atlasanalyst" });
 
     expect(res.status).toBe(400);
-    expectErrorResponse(res.body, "No tweets found for @atlasanalyst");
+    expectErrorResponse(res.body, "No public tweets found for @atlasanalyst — make sure your account is public");
     expect(mockCalibrateFromTweets).not.toHaveBeenCalled();
     expect(mockPrisma.voiceProfile.upsert).not.toHaveBeenCalled();
     expect(mockPrisma.analyticsEvent.create).not.toHaveBeenCalled();
@@ -203,7 +204,7 @@ describe("POST /api/voice/calibrate", () => {
     const dimensionData = buildDimensionData(calibration);
     const profile = makeProfile(dimensionData);
 
-    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets });
+    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets, stats: { pool: 100, topN: 25, recentN: 25 } });
     mockCalibrateFromTweets.mockResolvedValueOnce(calibration);
     (mockPrisma.voiceProfile.upsert as jest.Mock).mockResolvedValueOnce(profile);
 
@@ -213,9 +214,10 @@ describe("POST /api/voice/calibrate", () => {
       .send({ handle: "atlasanalyst" });
 
     expect(res.status).toBe(200);
-    const [handle, maxResults, signal] = mockFetchTweetsByHandle.mock.calls[0];
+    const [handle, opts] = mockFetchTweetsByHandle.mock.calls[0];
     expect(handle).toBe("atlasanalyst");
-    expect(maxResults).toBe(50);
+    expect(opts).toEqual({ mode: "blended", signal: expect.any(AbortSignal) });
+    const signal = (opts as { signal: AbortSignal }).signal;
     expect(signal).toBeInstanceOf(AbortSignal);
 
     const [tweetTexts, calibrationSignal] = mockCalibrateFromTweets.mock.calls[0];
@@ -233,6 +235,7 @@ describe("POST /api/voice/calibrate", () => {
         confidence: number;
         analysis: string;
         tweetsAnalyzed: number;
+        source: { mode: string; pool: number; topN: number; recentN: number };
         twitterUser: { username: string; name: string };
       };
     }>(res.body);
@@ -246,6 +249,7 @@ describe("POST /api/voice/calibrate", () => {
       confidence: calibration.calibrationConfidence,
       analysis: calibration.analysis,
       tweetsAnalyzed: calibration.tweetsAnalyzed,
+      source: { mode: "top-and-recent", pool: 100, topN: 25, recentN: 25 },
       twitterUser: {
         username: twitterUser.username,
         name: twitterUser.name,
@@ -258,7 +262,7 @@ describe("POST /api/voice/calibrate", () => {
     const calibration = makeCalibration({ tweetsAnalyzed: tweets.length });
     const dimensionData = buildDimensionData(calibration);
 
-    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets });
+    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets, stats: { pool: 100, topN: 25, recentN: 25 } });
     mockCalibrateFromTweets.mockResolvedValueOnce(calibration);
     (mockPrisma.voiceProfile.upsert as jest.Mock).mockResolvedValueOnce(
       makeProfile(dimensionData),
@@ -279,7 +283,7 @@ describe("POST /api/voice/calibrate", () => {
     const calibration = makeCalibration({ tweetsAnalyzed: tweets.length });
     const dimensionData = buildDimensionData(calibration);
 
-    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets });
+    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets, stats: { pool: 100, topN: 25, recentN: 25 } });
     mockCalibrateFromTweets.mockResolvedValueOnce(calibration);
     (mockPrisma.voiceProfile.upsert as jest.Mock).mockResolvedValueOnce(
       makeProfile(dimensionData),
@@ -300,7 +304,7 @@ describe("POST /api/voice/calibrate", () => {
     const calibration = makeCalibration({ tweetsAnalyzed: tweets.length });
     const dimensionData = buildDimensionData(calibration);
 
-    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets });
+    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets, stats: { pool: 100, topN: 25, recentN: 25 } });
     mockCalibrateFromTweets.mockResolvedValueOnce(calibration);
     (mockPrisma.voiceProfile.upsert as jest.Mock).mockResolvedValueOnce(
       makeProfile(dimensionData),
@@ -320,7 +324,7 @@ describe("POST /api/voice/calibrate", () => {
     const tweets = makeTweets(12);
     const calibration = makeCalibration({ tweetsAnalyzed: tweets.length });
 
-    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets });
+    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets, stats: { pool: 100, topN: 25, recentN: 25 } });
     mockCalibrateFromTweets.mockResolvedValueOnce(calibration);
     (mockPrisma.voiceProfile.upsert as jest.Mock).mockResolvedValueOnce(
       makeProfile(buildDimensionData(calibration)),
@@ -341,7 +345,7 @@ describe("POST /api/voice/calibrate", () => {
     const tweets = makeTweets(12);
     const calibration = makeCalibration({ tweetsAnalyzed: tweets.length });
 
-    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets });
+    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets, stats: { pool: 100, topN: 25, recentN: 25 } });
     mockCalibrateFromTweets.mockResolvedValueOnce(calibration);
     (mockPrisma.voiceProfile.upsert as jest.Mock).mockResolvedValueOnce(
       makeProfile(buildDimensionData(calibration)),
@@ -360,7 +364,7 @@ describe("POST /api/voice/calibrate", () => {
   });
 
   it("returns 502 when Twitter fetch fails", async () => {
-    mockFetchTweetsByHandle.mockRejectedValueOnce(new Error("twitter unavailable"));
+    mockFetchTweetsByHandle.mockRejectedValueOnce(new Error("Twitter API 503: upstream unavailable"));
 
     const res = await request(app)
       .post("/api/voice/calibrate")
@@ -368,7 +372,7 @@ describe("POST /api/voice/calibrate", () => {
       .send({ handle: "atlasanalyst" });
 
     expect(res.status).toBe(502);
-    expectErrorResponse(res.body, "Voice calibration failed: twitter unavailable");
+    expectErrorResponse(res.body, "Twitter API 503: upstream unavailable");
     expect(mockCalibrateFromTweets).not.toHaveBeenCalled();
     expect(mockPrisma.voiceProfile.upsert).not.toHaveBeenCalled();
     expect(mockPrisma.analyticsEvent.create).not.toHaveBeenCalled();
@@ -377,7 +381,7 @@ describe("POST /api/voice/calibrate", () => {
   it("returns 502 when calibration fails", async () => {
     const tweets = makeTweets(12);
 
-    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets });
+    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets, stats: { pool: 100, topN: 25, recentN: 25 } });
     mockCalibrateFromTweets.mockRejectedValueOnce(new Error("model unavailable"));
 
     const res = await request(app)
@@ -401,7 +405,7 @@ describe("POST /api/voice/calibrate", () => {
       ...args: any[]
     ) => realSetTimeout(handler, timeout === 40_000 ? 0 : timeout, ...args));
 
-    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets });
+    mockFetchTweetsByHandle.mockResolvedValueOnce({ user: twitterUser, tweets, stats: { pool: 100, topN: 25, recentN: 25 } });
     mockCalibrateFromTweets.mockImplementationOnce((_tweetTexts, signal) => {
       calibrationSignal = signal;
       return new Promise((_, reject) => {

--- a/services/api/src/__tests__/routes/reference-accounts.test.ts
+++ b/services/api/src/__tests__/routes/reference-accounts.test.ts
@@ -134,6 +134,7 @@ describe("POST /api/voice/reference-accounts/seed", () => {
         { id: "t1", text: "Do things that don't scale." },
         { id: "t2", text: "Great founders notice what other people ignore." },
       ],
+      stats: { pool: 30, topN: 0, recentN: 30 },
     });
     mockCalibrateFromTweets.mockResolvedValueOnce({
       ...seededProfile,
@@ -212,6 +213,7 @@ describe("POST /api/voice/reference-accounts/seed", () => {
         profile_image_url: "https://example.com/new-paul.jpg",
       },
       tweets: [{ id: "t1", text: "Build for the future." }],
+      stats: { pool: 30, topN: 0, recentN: 30 },
     });
     mockCalibrateFromTweets.mockResolvedValueOnce({
       ...seededProfile,
@@ -254,6 +256,7 @@ describe("POST /api/voice/reference-accounts/seed", () => {
         name: "Paul Graham",
       },
       tweets: [],
+      stats: { pool: 30, topN: 0, recentN: 30 },
     });
 
     const res = await request(app)

--- a/services/api/src/lib/twitter.ts
+++ b/services/api/src/lib/twitter.ts
@@ -7,10 +7,18 @@ import { config } from "./config";
 
 const TWITTER_API_BASE = "https://api.twitter.com/2";
 
-interface Tweet {
+export interface Tweet {
   id: string;
   text: string;
   created_at?: string;
+  public_metrics?: {
+    like_count: number;
+    retweet_count: number;
+    reply_count: number;
+    quote_count?: number;
+    impression_count?: number;
+    bookmark_count?: number;
+  };
 }
 
 interface UserLookupResult {
@@ -74,12 +82,12 @@ export async function lookupUser(username: string, signal?: AbortSignal): Promis
  */
 export async function fetchUserTweets(
   userId: string,
-  maxResults = 50,
+  maxResults = 100,
   signal?: AbortSignal,
 ): Promise<Tweet[]> {
   const params = new URLSearchParams({
     max_results: String(Math.min(maxResults, 100)),
-    "tweet.fields": "created_at",
+    "tweet.fields": "created_at,public_metrics",
     exclude: "retweets,replies",
   });
 
@@ -92,16 +100,83 @@ export async function fetchUserTweets(
 }
 
 /**
+ * Fetch top-engaged + most-recent tweets for a user.
+ */
+export async function fetchTopAndRecentTweets(
+  userId: string,
+  opts: { poolSize?: number; topN?: number; recentN?: number; signal?: AbortSignal } = {}
+): Promise<Tweet[]> {
+  const pool = await fetchUserTweets(userId, opts.poolSize ?? 100, opts.signal);
+  const topN = opts.topN ?? 25;
+  const recentN = opts.recentN ?? 25;
+
+  const scored = pool.map((t) => {
+    const m = t.public_metrics;
+    const engagement =
+      (m?.like_count ?? 0) +
+      (m?.retweet_count ?? 0) * 2 +
+      (m?.reply_count ?? 0) +
+      (m?.bookmark_count ?? 0);
+    return { tweet: t, engagement };
+  });
+
+  const topEngaged = [...scored]
+    .sort((a, b) => b.engagement - a.engagement)
+    .slice(0, topN)
+    .map((s) => s.tweet);
+
+  const recent = [...pool]
+    .sort((a, b) => (b.created_at ?? "").localeCompare(a.created_at ?? ""))
+    .slice(0, recentN);
+
+  const seen = new Set<string>();
+  const blended: Tweet[] = [];
+  for (const t of [...topEngaged, ...recent]) {
+    if (!seen.has(t.id)) {
+      seen.add(t.id);
+      blended.push(t);
+    }
+  }
+  return blended;
+}
+
+/**
  * Convenience: fetch tweets by handle (combines lookup + fetch).
  */
 export async function fetchTweetsByHandle(
   handle: string,
-  maxResults = 50,
-  signal?: AbortSignal,
-): Promise<{ user: UserLookupResult; tweets: Tweet[] }> {
-  const user = await lookupUser(handle, signal);
-  const tweets = await fetchUserTweets(user.id, maxResults, signal);
-  return { user, tweets };
+  opts:
+    | { mode?: "recent" | "blended"; maxResults?: number; signal?: AbortSignal }
+    | number = {},
+): Promise<{
+  user: UserLookupResult;
+  tweets: Tweet[];
+  stats: { pool: number; topN: number; recentN: number };
+}> {
+  // Backwards compatibility: if opts is a number, treat it as maxResults
+  const options: { mode?: "recent" | "blended"; maxResults?: number; signal?: AbortSignal } =
+    typeof opts === "number" ? { mode: "recent", maxResults: opts } : opts;
+
+  const user = await lookupUser(handle, options.signal);
+  if (options.mode === "blended" || options.mode === undefined) {
+    const blended = await fetchTopAndRecentTweets(user.id, {
+      poolSize: 100,
+      topN: 25,
+      recentN: 25,
+      signal: options.signal,
+    });
+    return {
+      user,
+      tweets: blended,
+      stats: { pool: 100, topN: 25, recentN: 25 },
+    };
+  }
+  const tweets = await fetchUserTweets(user.id, options.maxResults ?? 50, options.signal);
+  return {
+    user,
+    tweets,
+    stats: { pool: tweets.length, topN: 0, recentN: tweets.length },
+  };
 }
 
 // --- Tweet Metrics ---

--- a/services/api/src/routes/voice.ts
+++ b/services/api/src/routes/voice.ts
@@ -631,11 +631,14 @@ voiceRouter.post("/calibrate", aiGenerationLimiter, async (req: AuthRequest, res
 
     const workPromise = (async () => {
       // Fail fast at 40s so the client gets a retryable timeout before Railway's 90s cap.
-      const { user: twitterUser, tweets } = await fetchTweetsByHandle(normalizedHandle, 50, abort.signal);
+      const { user: twitterUser, tweets, stats } = await fetchTweetsByHandle(
+        normalizedHandle,
+        { mode: "blended", signal: abort.signal },
+      );
       if (abort.signal.aborted) return;
 
       if (tweets.length === 0) {
-        return res.status(400).json(error(`No tweets found for @${normalizedHandle}`));
+        return res.status(400).json(error(`No public tweets found for @${normalizedHandle} — make sure your account is public`));
       }
 
       const calibration = await calibrateFromTweets(
@@ -672,6 +675,7 @@ voiceRouter.post("/calibrate", aiGenerationLimiter, async (req: AuthRequest, res
           confidence: calibration.calibrationConfidence,
           analysis: calibration.analysis,
           tweetsAnalyzed: calibration.tweetsAnalyzed,
+          source: { mode: "top-and-recent", ...stats },
           twitterUser: { username: twitterUser.username, name: twitterUser.name },
         },
       }));
@@ -704,6 +708,7 @@ voiceRouter.post("/calibrate", aiGenerationLimiter, async (req: AuthRequest, res
     if (msg.includes("429")) return res.status(429).json(error(`Twitter API rate limit: ${msg}`));
     if (msg.includes("404") || msg.includes("not found")) return res.status(404).json(error(msg));
     if (msg.includes("403")) return res.status(403).json(error(msg));
+    if (msg.includes("Twitter API")) return res.status(502).json(error(msg));
     res.status(502).json(error(`Voice calibration failed: ${msg}`));
   } finally {
     clearTimeout(timeout);


### PR DESCRIPTION
Bug: onboarding 'Scanning @handle' produced stub-looking voice dimensions because calibration only pulled the raw timeline (no engagement signal). Now fetches 100-tweet pool and blends top 25 by engagement + top 25 most recent. Surfaces real upstream X API errors to frontend. Also syncs xAvatarUrl on calibration.

Note: TWITTER_BEARER_TOKEN presence in Railway production could not be verified from this environment — please confirm it's set before merging.