### PR TITLE
feat(voice): swipe-onboarding API — top-tweets routes + swipe-signals endpoint

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,52 +8,53 @@ datasource db {
 }
 
 model User {
-  id            String   @id @default(cuid())
-  supabaseId    String?
-  handle        String   @unique
-  email         String?  @unique
-  passwordHash  String?
-  displayName   String?
-  avatarUrl     String?
-  role          Role     @default(ANALYST)
-  onboardingTrack OnboardingTrack?
-  telegramChatId    String?
-  xHandle           String?
-  xAccessToken      String?
-  xRefreshToken     String?
-  xTokenExpiresAt   DateTime?
+  id               String           @id @default(cuid())
+  supabaseId       String?
+  handle           String           @unique
+  email            String?          @unique
+  passwordHash     String?
+  displayName      String?
+  avatarUrl        String?
+  role             Role             @default(ANALYST)
+  onboardingTrack  OnboardingTrack?
+  telegramChatId   String?
+  xHandle          String?
+  xAccessToken     String?
+  xRefreshToken    String?
+  xTokenExpiresAt  DateTime?
   // C-3: AES-256-GCM encrypted (format "v1:iv:tag:ct") token columns.
   // Live alongside plaintext columns during the migration window — the
   // read path prefers `*Enc` and falls back to plaintext, so either set
   // of columns can be populated. See services/api/src/lib/crypto.ts.
-  xAccessTokenEnc   String?
-  xRefreshTokenEnc  String?
-  xBio              String?
-  xAvatarUrl        String?
-  xFollowerCount    Int?
-  tourCompleted     Boolean  @default(false)
-  tourStep          Int      @default(0)
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  xAccessTokenEnc  String?
+  xRefreshTokenEnc String?
+  xBio             String?
+  xAvatarUrl       String?
+  xFollowerCount   Int?
+  tourCompleted    Boolean          @default(false)
+  tourStep         Int              @default(0)
+  createdAt        DateTime         @default(now())
+  updatedAt        DateTime         @updatedAt
 
-  voiceProfile      VoiceProfile?
-  referenceVoices   ReferenceVoice[]
-  savedBlends       SavedBlend[]
-  tweetDrafts       TweetDraft[]
-  draftQueueItems   DraftQueueItem[]
-  analyticsEvents   AnalyticsEvent[]
-  alertSubscriptions AlertSubscription[]
-  sessions          Session[]
-  oracleSessions    OracleSession[]
-  researchResults   ResearchResult[]
-  generatedImages   GeneratedImage[]
-  alerts            Alert[]
-  briefingPreference BriefingPreference?
-  briefings          Briefing[]
-  nlpMonitors       NlpMonitor[]
-  campaigns         Campaign[]
+  voiceProfile          VoiceProfile?
+  referenceVoices       ReferenceVoice[]
+  savedBlends           SavedBlend[]
+  tweetDrafts           TweetDraft[]
+  draftQueueItems       DraftQueueItem[]
+  analyticsEvents       AnalyticsEvent[]
+  alertSubscriptions    AlertSubscription[]
+  sessions              Session[]
+  oracleSessions        OracleSession[]
+  researchResults       ResearchResult[]
+  generatedImages       GeneratedImage[]
+  alerts                Alert[]
+  briefingPreference    BriefingPreference?
+  briefings             Briefing[]
+  nlpMonitors           NlpMonitor[]
+  campaigns             Campaign[]
   voiceDimensionInsight VoiceDimensionInsight?
   blendedVoiceProfile   BlendedVoiceProfile?
+  voiceSwipeSignals     VoiceSwipeSignal[]
 
   @@index([supabaseId])
   @@index([xHandle])
@@ -98,25 +99,25 @@ model OracleSession {
 }
 
 model VoiceProfile {
-  id              String   @id @default(cuid())
-  userId          String   @unique
-  humor           Int      @default(50)
-  formality       Int      @default(50)
-  brevity         Int      @default(50)
-  contrarianTone  Int      @default(50)
-  directness               Int     @default(50)
-  warmth                   Int     @default(50)
-  technicalDepth           Int     @default(50)
-  confidence               Int     @default(50)
-  evidenceOrientation      Int     @default(50)
-  solutionOrientation      Int     @default(50)
-  socialPosture            Int     @default(50)
-  selfPromotionalIntensity Int     @default(50)
-  maturity        VoiceMaturity @default(BEGINNER)
-  tweetsAnalyzed  Int      @default(0)
-  analysis        String?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id                       String        @id @default(cuid())
+  userId                   String        @unique
+  humor                    Int           @default(50)
+  formality                Int           @default(50)
+  brevity                  Int           @default(50)
+  contrarianTone           Int           @default(50)
+  directness               Int           @default(50)
+  warmth                   Int           @default(50)
+  technicalDepth           Int           @default(50)
+  confidence               Int           @default(50)
+  evidenceOrientation      Int           @default(50)
+  solutionOrientation      Int           @default(50)
+  socialPosture            Int           @default(50)
+  selfPromotionalIntensity Int           @default(50)
+  maturity                 VoiceMaturity @default(BEGINNER)
+  tweetsAnalyzed           Int           @default(0)
+  analysis                 String?
+  createdAt                DateTime      @default(now())
+  updatedAt                DateTime      @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -130,15 +131,15 @@ enum VoiceMaturity {
 }
 
 model ReferenceVoice {
-  id          String   @id @default(cuid())
-  userId      String?
-  name        String
-  handle      String?
-  avatarUrl   String?
-  category    String?
-  isActive    Boolean  @default(true)
-  isGlobal    Boolean  @default(false)
-  createdAt   DateTime @default(now())
+  id        String   @id @default(cuid())
+  userId    String?
+  name      String
+  handle    String?
+  avatarUrl String?
+  category  String?
+  isActive  Boolean  @default(true)
+  isGlobal  Boolean  @default(false)
+  createdAt DateTime @default(now())
 
   user         User?                  @relation(fields: [userId], references: [id], onDelete: Cascade)
   blendVoices  BlendVoice[]
@@ -148,30 +149,30 @@ model ReferenceVoice {
 }
 
 model ReferenceVoiceProfile {
-  id                       String   @id @default(cuid())
-  referenceVoiceId         String   @unique
+  id               String @id @default(cuid())
+  referenceVoiceId String @unique
 
   // Voice dimensions (0-100)
-  humor                    Int      @default(50)
-  formality                Int      @default(50)
-  brevity                  Int      @default(50)
-  contrarianTone           Int      @default(50)
-  directness               Int      @default(50)
-  warmth                   Int      @default(50)
-  technicalDepth           Int      @default(50)
-  confidence               Int      @default(50)
-  evidenceOrientation      Int      @default(50)
-  solutionOrientation      Int      @default(50)
-  socialPosture            Int      @default(50)
-  selfPromotionalIntensity Int      @default(50)
+  humor                    Int @default(50)
+  formality                Int @default(50)
+  brevity                  Int @default(50)
+  contrarianTone           Int @default(50)
+  directness               Int @default(50)
+  warmth                   Int @default(50)
+  technicalDepth           Int @default(50)
+  confidence               Int @default(50)
+  evidenceOrientation      Int @default(50)
+  solutionOrientation      Int @default(50)
+  socialPosture            Int @default(50)
+  selfPromotionalIntensity Int @default(50)
 
   // Calibration metadata
-  calibrationConfidence    Float?
-  analysis                 String?
-  tweetsAnalyzed           Int      @default(0)
-  sampleTweets             String[]
-  createdAt                DateTime @default(now())
-  updatedAt                DateTime @updatedAt
+  calibrationConfidence Float?
+  analysis              String?
+  tweetsAnalyzed        Int      @default(0)
+  sampleTweets          String[]
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
 
   referenceVoice ReferenceVoice @relation(fields: [referenceVoiceId], references: [id], onDelete: Cascade)
 
@@ -193,11 +194,11 @@ model SavedBlend {
 }
 
 model BlendVoice {
-  id              String @id @default(cuid())
-  blendId         String
+  id               String  @id @default(cuid())
+  blendId          String
   referenceVoiceId String?
-  label           String
-  percentage      Int
+  label            String
+  percentage       Int
 
   blend          SavedBlend      @relation(fields: [blendId], references: [id], onDelete: Cascade)
   referenceVoice ReferenceVoice? @relation(fields: [referenceVoiceId], references: [id], onDelete: SetNull)
@@ -206,27 +207,27 @@ model BlendVoice {
 }
 
 model TweetDraft {
-  id            String      @id @default(cuid())
-  userId        String
-  content       String
-  version       Int         @default(1)
-  status        DraftStatus @default(DRAFT)
-  confidence    Float?
-  predictedEngagement Int?
-  actualEngagement    Int?
-  engagementMetrics   Json?
-  xTweetId      String?
-  metricsLastFetchedAt DateTime?
-  sourceType    SourceType?
-  sourceContent String?
-  blendId       String?
-  feedback      String?
-  scheduledAt   DateTime?
-  campaignId    String?
-  sortOrder     Int?
+  id                      String      @id @default(cuid())
+  userId                  String
+  content                 String
+  version                 Int         @default(1)
+  status                  DraftStatus @default(DRAFT)
+  confidence              Float?
+  predictedEngagement     Int?
+  actualEngagement        Int?
+  engagementMetrics       Json?
+  xTweetId                String?
+  metricsLastFetchedAt    DateTime?
+  sourceType              SourceType?
+  sourceContent           String?
+  blendId                 String?
+  feedback                String?
+  scheduledAt             DateTime?
+  campaignId              String?
+  sortOrder               Int?
   voiceDimensionsSnapshot Json?
-  createdAt     DateTime    @default(now())
-  updatedAt     DateTime    @updatedAt
+  createdAt               DateTime    @default(now())
+  updatedAt               DateTime    @updatedAt
 
   user     User             @relation(fields: [userId], references: [id], onDelete: Cascade)
   images   GeneratedImage[]
@@ -306,13 +307,13 @@ enum AnalyticsType {
 }
 
 model AlertSubscription {
-  id        String    @id @default(cuid())
+  id        String          @id @default(cuid())
   userId    String
   type      AlertType
   value     String
-  isActive  Boolean   @default(true)
+  isActive  Boolean         @default(true)
   delivery  AlertDelivery[] @default([PORTAL])
-  createdAt DateTime  @default(now())
+  createdAt DateTime        @default(now())
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -337,7 +338,7 @@ enum AlertCategory {
 }
 
 model Alert {
-  id          String      @id @default(cuid())
+  id          String        @id @default(cuid())
   type        String
   title       String
   context     String?
@@ -349,7 +350,7 @@ model Alert {
   userId      String?
   expiresAt   DateTime?
   deliveredAt DateTime?
-  createdAt   DateTime    @default(now())
+  createdAt   DateTime      @default(now())
 
   user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
 
@@ -371,17 +372,17 @@ model LearningLogEntry {
 }
 
 model ResearchResult {
-  id              String   @id @default(cuid())
-  userId          String
-  query           String
-  summary         String
-  keyFacts        Json
-  sentiment       String
-  relatedTopics   Json
-  sources         Json
-  confidence      Float
-  draftId         String?
-  createdAt       DateTime @default(now())
+  id            String   @id @default(cuid())
+  userId        String
+  query         String
+  summary       String
+  keyFacts      Json
+  sentiment     String
+  relatedTopics Json
+  sources       Json
+  confidence    Float
+  draftId       String?
+  createdAt     DateTime @default(now())
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -418,14 +419,14 @@ model Briefing {
 }
 
 model GeneratedImage {
-  id          String   @id @default(cuid())
-  userId      String
-  draftId     String?
-  prompt      String
-  style       String
-  imageUrl    String
-  mimeType    String   @default("image/png")
-  createdAt   DateTime @default(now())
+  id        String   @id @default(cuid())
+  userId    String
+  draftId   String?
+  prompt    String
+  style     String
+  imageUrl  String
+  mimeType  String   @default("image/png")
+  createdAt DateTime @default(now())
 
   user  User        @relation(fields: [userId], references: [id], onDelete: Cascade)
   draft TweetDraft? @relation(fields: [draftId], references: [id], onDelete: SetNull)
@@ -493,40 +494,57 @@ model VoiceDimensionInsight {
 }
 
 model BlendedVoiceProfile {
-  id                       String   @id @default(cuid())
-  userId                   String   @unique
-  primaryTwitterId         String
-  primaryHandle            String?
-  additionalTwitterIds     String[]
-  additionalHandles        String[]
-  weights                  Json     // { "twitter_id": weight_value }
+  id                   String   @id @default(cuid())
+  userId               String   @unique
+  primaryTwitterId     String
+  primaryHandle        String?
+  additionalTwitterIds String[]
+  additionalHandles    String[]
+  weights              Json // { "twitter_id": weight_value }
 
   // Blended style dimensions (0-100)
-  humor                    Int      @default(50)
-  formality                Int      @default(50)
-  brevity                  Int      @default(50)
-  contrarianTone           Int      @default(50)
-  directness               Int      @default(50)
-  warmth                   Int      @default(50)
-  technicalDepth           Int      @default(50)
-  confidence               Int      @default(50)
-  evidenceOrientation      Int      @default(50)
-  solutionOrientation      Int      @default(50)
-  socialPosture            Int      @default(50)
-  selfPromotionalIntensity Int      @default(50)
+  humor                    Int @default(50)
+  formality                Int @default(50)
+  brevity                  Int @default(50)
+  contrarianTone           Int @default(50)
+  directness               Int @default(50)
+  warmth                   Int @default(50)
+  technicalDepth           Int @default(50)
+  confidence               Int @default(50)
+  evidenceOrientation      Int @default(50)
+  solutionOrientation      Int @default(50)
+  socialPosture            Int @default(50)
+  selfPromotionalIntensity Int @default(50)
 
   // Raw style signals per inspiration (for transparency / debugging)
-  styleSignals             Json?    // { "twitter_id": { avgLength, emojiRate, ... } }
+  styleSignals Json? // { "twitter_id": { avgLength, emojiRate, ... } }
 
   // Meta
-  tweetsAnalyzed           Int      @default(0)
-  blendSummary             String?
-  createdAt                DateTime @default(now())
-  updatedAt                DateTime @updatedAt
+  tweetsAnalyzed Int      @default(0)
+  blendSummary   String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("blended_voice_profiles")
+}
+
+model VoiceSwipeSignal {
+  id        String   @id @default(cuid())
+  userId    String
+  tweetId   String
+  text      String
+  direction String // "like" | "dislike"
+  source    String // "OWN" | "REF"
+  handle    String?
+  reasons   String[]
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, source])
+  @@map("voice_swipe_signals")
 }
 
 model FeatureFlag {

--- a/services/api/src/lib/voice-blend.ts
+++ b/services/api/src/lib/voice-blend.ts
@@ -397,6 +397,76 @@ async function lookupUserById(
   return data.data;
 }
 
+// --- Swipe onboarding heuristic mapper ---
+
+export interface SwipeSignal {
+  tweetId: string;
+  text: string;
+  direction: "like" | "dislike";
+  source: "OWN" | "REF";
+  handle?: string | null;
+  reasons: string[];
+}
+
+export interface VoiceDimensions {
+  humor: number;
+  formality: number;
+  brevity: number;
+  contrarianTone: number;
+  directness: number;
+  warmth: number;
+  technicalDepth: number;
+  confidence: number;
+  evidenceOrientation: number;
+  solutionOrientation: number;
+  socialPosture: number;
+  selfPromotionalIntensity: number;
+}
+
+/**
+ * Pure function: SwipeSignal[] → Partial<VoiceDimensions>.
+ * Aggregates reason chips into dimension deltas clamped to [-20, +20].
+ */
+export function applySwipeHeuristics(signals: SwipeSignal[]): Partial<VoiceDimensions> {
+  const deltas: Record<string, number> = {};
+
+  for (const signal of signals) {
+    if (signal.direction !== "like") continue;
+    for (const reason of signal.reasons) {
+      const r = reason.toLowerCase();
+      switch (r) {
+        case "punchy":
+          deltas.brevity = (deltas.brevity || 0) + 10;
+          break;
+        case "contrarian":
+          deltas.contrarianTone = (deltas.contrarianTone || 0) + 15;
+          break;
+        case "funny":
+          deltas.humor = (deltas.humor || 0) + 10;
+          break;
+        case "data-driven":
+          deltas.evidenceOrientation = (deltas.evidenceOrientation || 0) + 15;
+          break;
+        case "plain-spoken":
+          deltas.technicalDepth = (deltas.technicalDepth || 0) - 10;
+          deltas.formality = (deltas.formality || 0) - 5;
+          break;
+        case "snarky":
+          deltas.directness = (deltas.directness || 0) + 10;
+          deltas.humor = (deltas.humor || 0) + 5;
+          break;
+      }
+    }
+  }
+
+  const result: Partial<VoiceDimensions> = {};
+  for (const [key, value] of Object.entries(deltas)) {
+    result[key as keyof VoiceDimensions] = Math.max(-20, Math.min(20, value));
+  }
+
+  return result;
+}
+
 /**
  * Return a default calibration result for users with no tweets.
  */

--- a/services/api/src/routes/twitter.ts
+++ b/services/api/src/routes/twitter.ts
@@ -6,6 +6,8 @@ import { logger } from "../lib/logger";
 import { success, error } from "../lib/response";
 import { buildErrorResponse } from "../middleware/requestId";
 import { getCached, setCache } from "../lib/redis";
+import { config } from "../lib/config";
+import { rateLimitByUser } from "../middleware/rateLimit";
 import {
   buildTokenWrite,
   readAccessToken,
@@ -45,10 +47,10 @@ async function getFromCache<T>(key: string): Promise<T | null> {
   return null;
 }
 
-async function writeToCache<T>(key: string, data: T): Promise<void> {
+async function writeToCache<T>(key: string, data: T, ttlSeconds = CACHE_TTL_SECONDS): Promise<void> {
   const json = JSON.stringify(data);
-  await setCache(key, json, CACHE_TTL_SECONDS);
-  memoryCache.set(key, { data, expiresAt: Date.now() + CACHE_TTL_SECONDS * 1000 });
+  await setCache(key, json, ttlSeconds);
+  memoryCache.set(key, { data, expiresAt: Date.now() + ttlSeconds * 1000 });
 }
 
 // ── Token helpers ────────────────────────────────────────────────────
@@ -333,4 +335,251 @@ function mapLikes(tweets: TwitterLikeTweet[], authors: TwitterLikeAuthor[]) {
       retweet_count: t.public_metrics?.retweet_count ?? 0,
     };
   });
+}
+
+// ── Top tweets (swipe onboarding) ────────────────────────────────────
+
+interface TwitterTopTweetRaw {
+  id: string;
+  text: string;
+  created_at?: string;
+  public_metrics?: {
+    like_count: number;
+    retweet_count: number;
+    reply_count: number;
+  };
+}
+
+interface TwitterTopTweet {
+  id: string;
+  text: string;
+  author_handle: string | null;
+  author_avatar: string | null;
+  created_at: string | null;
+  like_count: number;
+  retweet_count: number;
+  reply_count: number;
+}
+
+const DEMO_TOP_TWEETS: TwitterTopTweet[] = [
+  {
+    id: "demo-1",
+    text: "The best time to build was 10 years ago. The second best time is right now.",
+    author_handle: "demo",
+    author_avatar: null,
+    created_at: new Date().toISOString(),
+    like_count: 1240,
+    retweet_count: 180,
+    reply_count: 45,
+  },
+  {
+    id: "demo-2",
+    text: "Crypto isn't about getting rich quick. It's about not getting poor slowly.",
+    author_handle: "demo",
+    author_avatar: null,
+    created_at: new Date(Date.now() - 86400000).toISOString(),
+    like_count: 890,
+    retweet_count: 120,
+    reply_count: 32,
+  },
+  {
+    id: "demo-3",
+    text: "Bear markets are for builders. Bull markets are for believers. Which one are you?",
+    author_handle: "demo",
+    author_avatar: null,
+    created_at: new Date(Date.now() - 172800000).toISOString(),
+    like_count: 650,
+    retweet_count: 95,
+    reply_count: 28,
+  },
+  {
+    id: "demo-4",
+    text: "Simplicity scales. Complexity fails. This applies to protocols, portfolios, and life.",
+    author_handle: "demo",
+    author_avatar: null,
+    created_at: new Date(Date.now() - 259200000).toISOString(),
+    like_count: 420,
+    retweet_count: 70,
+    reply_count: 15,
+  },
+  {
+    id: "demo-5",
+    text: "Don't trust, verify. Then ship.",
+    author_handle: "demo",
+    author_avatar: null,
+    created_at: new Date(Date.now() - 345600000).toISOString(),
+    like_count: 310,
+    retweet_count: 55,
+    reply_count: 12,
+  },
+];
+
+function sortTopTweets(tweets: TwitterTopTweet[]): TwitterTopTweet[] {
+  return tweets.sort((a, b) => {
+    const scoreA = a.like_count + 2 * a.retweet_count + a.reply_count;
+    const scoreB = b.like_count + 2 * b.retweet_count + b.reply_count;
+    return scoreB - scoreA;
+  });
+}
+
+function mapTopTweets(tweets: TwitterTopTweetRaw[], handle: string | null, avatar: string | null): TwitterTopTweet[] {
+  return tweets.map((t) => ({
+    id: t.id,
+    text: t.text,
+    author_handle: handle,
+    author_avatar: avatar,
+    created_at: t.created_at || null,
+    like_count: t.public_metrics?.like_count ?? 0,
+    retweet_count: t.public_metrics?.retweet_count ?? 0,
+    reply_count: t.public_metrics?.reply_count ?? 0,
+  }));
+}
+
+/**
+ * Make an authenticated GET request to the Twitter API v2 using the app Bearer token.
+ */
+async function twitterBearerGet<T>(path: string): Promise<{ data: T | null; status: number }> {
+  const token = config.TWITTER_BEARER_TOKEN;
+  if (!token) {
+    return { data: null, status: 503 };
+  }
+  const res = await fetch(`${TWITTER_API_BASE}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    logger.warn({ status: res.status, body }, "Twitter API error (bearer)");
+    return { data: null, status: res.status };
+  }
+  const json = (await res.json()) as T;
+  return { data: json, status: res.status };
+}
+
+// GET /api/twitter/me/top-tweets
+twitterRouter.get("/me/top-tweets", authenticate, async (req: AuthRequest, res) => {
+  try {
+    const userId = req.userId!;
+    const limit = Math.min(Math.max(parseInt(req.query.limit as string) || 10, 1), 50);
+    const cacheKey = `twitter:top-self:${userId}`;
+
+    const cached = await getFromCache<TwitterTopTweet[]>(cacheKey);
+    if (cached) {
+      return res.json(success({ tweets: cached.slice(0, limit), cached: true }));
+    }
+
+    const accessToken = await getValidAccessToken(userId);
+    if (!accessToken) {
+      return res.json(success({ tweets: DEMO_TOP_TWEETS.slice(0, limit), cached: false, fallback: "demo" }));
+    }
+
+    const meResult = await twitterUserGet<{ data: { id: string } }>(accessToken, "/users/me");
+    if (meResult.rateLimited) {
+      return res.status(429).json(error("Twitter API rate limit reached. Please try again later."));
+    }
+    if (meResult.status === 401) {
+      return res.json(success({ tweets: DEMO_TOP_TWEETS.slice(0, limit), cached: false, fallback: "demo" }));
+    }
+    if (!meResult.data?.data?.id) {
+      return res.status(502).json(error("Failed to verify X identity"));
+    }
+
+    const xUserId = meResult.data.data.id;
+    const params = new URLSearchParams({
+      max_results: String(limit),
+      "tweet.fields": "created_at,public_metrics",
+      exclude: "retweets,replies",
+    });
+
+    const result = await twitterUserGet<{ data?: TwitterTopTweetRaw[] }>(
+      accessToken,
+      `/users/${xUserId}/tweets?${params}`,
+    );
+
+    if (result.rateLimited) {
+      return res.status(429).json(error("Twitter API rate limit reached. Please try again later."));
+    }
+    if (result.status === 401) {
+      return res.json(success({ tweets: DEMO_TOP_TWEETS.slice(0, limit), cached: false, fallback: "demo" }));
+    }
+    if (!result.data?.data) {
+      return res.status(502).json(error("Failed to fetch tweets from X"));
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { xHandle: true, xAvatarUrl: true },
+    });
+
+    const tweets = sortTopTweets(mapTopTweets(result.data.data, user?.xHandle ?? null, user?.xAvatarUrl ?? null));
+    await writeToCache(cacheKey, tweets, 3600); // 1 hour
+
+    res.json(success({ tweets: tweets.slice(0, limit), cached: false }));
+  } catch (err: any) {
+    logger.error({ err: err.message }, "Twitter me/top-tweets fetch failed");
+    res.status(500).json(buildErrorResponse(req, "Failed to fetch top tweets"));
+  }
+});
+
+const topTweetsByHandleLimiter = rateLimitByUser(30, 60 * 1000);
+
+// GET /api/twitter/handle/:handle/top-tweets
+twitterRouter.get("/handle/:handle/top-tweets", authenticate, topTweetsByHandleLimiter, async (req: AuthRequest, res) => {
+  try {
+    const handle = normalizeReferenceHandle(req.params.handle as string);
+    const limit = Math.min(Math.max(parseInt(req.query.limit as string) || 10, 1), 50);
+    const cacheKey = `twitter:top-public:${handle}`;
+
+    const cached = await getFromCache<TwitterTopTweet[]>(cacheKey);
+    if (cached) {
+      return res.json(success({ tweets: cached.slice(0, limit), cached: true }));
+    }
+
+    const lookup = await twitterBearerGet<{ data: { id: string; username: string; name: string; profile_image_url?: string } }>(
+      `/users/by/username/${encodeURIComponent(handle)}?user.fields=profile_image_url`,
+    );
+
+    if (lookup.status === 404) {
+      return res.json(success({ tweets: DEMO_TOP_TWEETS.slice(0, limit), cached: false, fallback: "demo" }));
+    }
+    if (lookup.status === 429) {
+      return res.status(429).json(error("Twitter API rate limit reached. Please try again later."));
+    }
+    if (!lookup.data?.data) {
+      return res.status(502).json(error("Failed to lookup user on X"));
+    }
+
+    const xUser = lookup.data.data;
+    const params = new URLSearchParams({
+      max_results: String(limit),
+      "tweet.fields": "created_at,public_metrics",
+      exclude: "retweets,replies",
+    });
+
+    const result = await twitterBearerGet<{ data?: TwitterTopTweetRaw[] }>(
+      `/users/${xUser.id}/tweets?${params}`,
+    );
+
+    if (result.status === 429) {
+      return res.status(429).json(error("Twitter API rate limit reached. Please try again later."));
+    }
+    if (!result.data?.data) {
+      return res.status(502).json(error("Failed to fetch tweets from X"));
+    }
+
+    const avatarUrl = xUser.profile_image_url
+      ? xUser.profile_image_url.replace("_normal", "_400x400")
+      : null;
+
+    const tweets = sortTopTweets(mapTopTweets(result.data.data, xUser.username, avatarUrl));
+    await writeToCache(cacheKey, tweets, 86400); // 24 hours
+
+    res.json(success({ tweets: tweets.slice(0, limit), cached: false }));
+  } catch (err: any) {
+    logger.error({ err: err.message }, "Twitter handle/top-tweets fetch failed");
+    res.status(500).json(buildErrorResponse(req, "Failed to fetch top tweets"));
+  }
+});
+
+function normalizeReferenceHandle(handle: string) {
+  return handle.replace(/^@/, "").trim().toLowerCase();
 }

--- a/services/api/src/routes/voice.ts
+++ b/services/api/src/routes/voice.ts
@@ -9,7 +9,7 @@ import { authenticate, AuthRequest } from "../middleware/auth";
 import { fetchTweetsByHandle } from "../lib/twitter";
 import { calibrateFromTweets, type CalibrationResult } from "../lib/calibrate";
 import { getVoiceInsights } from "../lib/voice-insights";
-import { blendVoices } from "../lib/voice-blend";
+import { blendVoices, applySwipeHeuristics, type SwipeSignal } from "../lib/voice-blend";
 import { logger } from "../lib/logger";
 import { config } from "../lib/config";
 import { rateLimitByUser } from "../middleware/rateLimit";
@@ -707,6 +707,132 @@ voiceRouter.post("/calibrate", aiGenerationLimiter, async (req: AuthRequest, res
     res.status(502).json(error(`Voice calibration failed: ${msg}`));
   } finally {
     clearTimeout(timeout);
+  }
+});
+
+// Get voice dimension insights (engagement feedback loop)
+// Persist swipe signals and calibrate voice profile from likes + reasons
+const swipeSignalItemSchema = z.object({
+  tweetId: z.string().min(1),
+  text: z.string().min(1),
+  reasons: z.array(z.string()).default([]),
+  handle: z.string().optional(),
+});
+
+const swipeSignalsSchema = z.object({
+  ownLikes: z.array(swipeSignalItemSchema).default([]),
+  ownDislikes: z.array(swipeSignalItemSchema).default([]),
+  refLikes: z.array(swipeSignalItemSchema).default([]),
+  refDislikes: z.array(swipeSignalItemSchema).default([]),
+});
+
+voiceRouter.post("/swipe-signals", aiGenerationLimiter, async (req: AuthRequest, res) => {
+  try {
+    const body = swipeSignalsSchema.parse(req.body);
+    const userId = req.userId!;
+
+    // Flatten and persist all signals
+    const rawSignals = [
+      ...body.ownLikes.map((s) => ({ ...s, direction: "like" as const, source: "OWN" as const })),
+      ...body.ownDislikes.map((s) => ({ ...s, direction: "dislike" as const, source: "OWN" as const })),
+      ...body.refLikes.map((s) => ({ ...s, direction: "like" as const, source: "REF" as const })),
+      ...body.refDislikes.map((s) => ({ ...s, direction: "dislike" as const, source: "REF" as const })),
+    ];
+
+    if (rawSignals.length > 0) {
+      await prisma.voiceSwipeSignal.createMany({
+        data: rawSignals.map((s) => ({
+          userId,
+          tweetId: s.tweetId,
+          text: s.text,
+          direction: s.direction,
+          source: s.source,
+          handle: s.handle ?? null,
+          reasons: s.reasons,
+        })),
+      });
+    }
+
+    const likedTexts = [
+      ...body.ownLikes.map((s) => s.text),
+      ...body.refLikes.map((s) => s.text),
+    ];
+
+    let calibration: CalibrationResult;
+    if (likedTexts.length > 0) {
+      calibration = await calibrateFromTweets(likedTexts);
+    } else {
+      calibration = {
+        humor: 50,
+        formality: 50,
+        brevity: 50,
+        contrarianTone: 50,
+        directness: 50,
+        warmth: 50,
+        technicalDepth: 50,
+        confidence: 50,
+        evidenceOrientation: 50,
+        solutionOrientation: 50,
+        socialPosture: 50,
+        selfPromotionalIntensity: 50,
+        calibrationConfidence: 0,
+        analysis: "No liked tweets to analyze.",
+        tweetsAnalyzed: 0,
+      };
+    }
+
+    // Apply heuristic deltas from liked signals with reason chips
+    const likedSignals: SwipeSignal[] = rawSignals
+      .filter((s) => s.direction === "like")
+      .map((s) => ({
+        tweetId: s.tweetId,
+        text: s.text,
+        direction: s.direction,
+        source: s.source,
+        handle: s.handle ?? null,
+        reasons: s.reasons,
+      }));
+
+    const heuristicDeltas = applySwipeHeuristics(likedSignals);
+    const baseDimensions = buildCalibrationDimensions(calibration);
+
+    const adjustedDimensions = { ...baseDimensions };
+    for (const [key, delta] of Object.entries(heuristicDeltas)) {
+      const dimKey = key as keyof typeof adjustedDimensions;
+      adjustedDimensions[dimKey] = Math.min(100, Math.max(0, adjustedDimensions[dimKey] + delta));
+    }
+
+    const profileUpdate = {
+      ...adjustedDimensions,
+      tweetsAnalyzed: calibration.tweetsAnalyzed,
+      maturity: resolveVoiceMaturity(calibration.tweetsAnalyzed),
+      analysis: calibration.analysis,
+    };
+
+    const profile = await prisma.voiceProfile.upsert({
+      where: { userId },
+      update: profileUpdate,
+      create: { userId, ...profileUpdate },
+    });
+
+    await prisma.analyticsEvent.create({
+      data: { userId, type: "VOICE_REFINEMENT" },
+    });
+
+    res.json(success({
+      profile,
+      calibration: {
+        confidence: calibration.calibrationConfidence,
+        analysis: calibration.analysis,
+        tweetsAnalyzed: calibration.tweetsAnalyzed,
+      },
+    }));
+  } catch (err: any) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json(error("Invalid request", 400, err.errors));
+    }
+    logger.error({ err: err.message }, "Swipe signals failed");
+    res.status(502).json(error(`Swipe signals failed: ${err.message}`));
   }
 });
 


### PR DESCRIPTION
Adds GET /api/twitter/me/top-tweets, GET /api/twitter/handle/:handle/top-tweets,
POST /api/voice/swipe-signals, VoiceSwipeSignal model, and reasons→dimension
heuristic mapper. Powers the new Tinder-swipe onboarding flow in atlas-portal.
