### PR TITLE
fix(calibrate): reject degenerate all-zero AI output

### DIFF
--- a/services/api/src/lib/calibrate.ts
+++ b/services/api/src/lib/calibrate.ts
@@ -139,7 +139,7 @@ export async function calibrateFromTweets(
   /** AI returns 0-10 for extended dims; multiply by 10 for 0-100 storage */
   const tenToHundred = (v: number) => clamp100(Math.round((v ?? 5) * 10));
 
-  return {
+  const dims = {
     // Core voice (already 0-100)
     humor: clamp100(result.humor),
     formality: clamp100(result.formality),
@@ -155,6 +155,19 @@ export async function calibrateFromTweets(
     solutionOrientation: tenToHundred(result.solutionOrientation),
     socialPosture: tenToHundred(result.socialPosture),
     selfPromotionalIntensity: tenToHundred(result.selfPromotionalIntensity),
+  };
+
+  // Reject degenerate all-zero output (model degraded or hit the scale floor).
+  // The caller's catch block will return neutral defaults instead of persisting zeros.
+  const coreValues = [dims.humor, dims.formality, dims.brevity, dims.contrarianTone];
+  if (coreValues.every((v) => v <= 4)) {
+    throw new Error(
+      "Calibration returned degenerate output — all core dimensions <= 4. Using defaults.",
+    );
+  }
+
+  return {
+    ...dims,
     // Meta
     calibrationConfidence: Math.min(Math.max(result.calibrationConfidence ?? 0.5, 0), 1),
     analysis: result.analysis || "Voice profile calibrated from tweet analysis.",


### PR DESCRIPTION
## Problem
When Claude returns all-zero voice dimensions (model degraded / throwaway account with no meaningful tweets), `clamp100` faithfully stores the zeros. Those zeros persist to Postgres and echo back to the frontend, causing sliders to display 0/10 — a broken UX.

## Fix
Build the `dims` object first, then guard:

```ts
const coreValues = [dims.humor, dims.formality, dims.brevity, dims.contrarianTone];
if (coreValues.every((v) => v <= 4)) {
  throw new Error("Calibration returned degenerate output — all core dimensions <= 4. Using defaults.");
}
```

The calling code already has a catch block that returns neutral 50s, but it only catches exceptions — so we explicitly throw when all four core dims are effectively zero. Degenerate outputs now route to safe defaults instead of corrupting the DB.

## Threshold
`<= 4` (not `=== 0`) catches near-zero noise (rounded-down 0.3s etc.) without being too aggressive — a genuine low-humor/low-contrarian profile will still have at least one core dim above 4.

## Test plan
- [ ] Unit: mock calibration response with all core dims = 0, confirm `buildVoiceProfileUpdate` throws
- [ ] Unit: mock response with mixed low dims (e.g. humor=2, formality=50), confirm it returns normally
- [ ] Integration: onboarding with a throwaway account no longer lands on zeroed sliders