### PR TITLE
fix(auth): prevent Twitter OAuth refresh token from reaching supabase.refreshSession

### DIFF
--- a/services/api/src/__tests__/auth-refresh-mixed-origin.test.ts
+++ b/services/api/src/__tests__/auth-refresh-mixed-origin.test.ts
@@ -1,0 +1,190 @@
+import request from "supertest";
+import express from "express";
+import cookieParser from "cookie-parser";
+import jwt from "jsonwebtoken";
+
+import { requestIdMiddleware } from "../middleware/requestId";
+
+process.env.NODE_ENV = "test";
+process.env.JWT_SECRET = "test-secret";
+process.env.DATABASE_URL = "postgresql://localhost:5432/atlas_test";
+delete process.env.REDIS_URL;
+
+const mockSupabaseAuth = {
+  admin: {
+    createUser: jest.fn(),
+    signOut: jest.fn(),
+  },
+  signInWithPassword: jest.fn(),
+  getUser: jest.fn(),
+  refreshSession: jest.fn(),
+};
+
+jest.mock("../lib/supabase", () => ({
+  supabaseAdmin: {
+    auth: mockSupabaseAuth,
+  },
+}));
+
+jest.mock("../lib/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    session: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../lib/logger", () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock("../middleware/rateLimit", () => ({
+  rateLimit: () => (_req: any, _res: any, next: any) => next(),
+  rateLimitByUser: () => (_req: any, _res: any, next: any) => next(),
+  clearRateLimitStore: jest.fn(),
+}));
+
+jest.mock("../lib/jwt-revocation", () => ({
+  revokeJti: jest.fn().mockResolvedValue(true),
+  remainingTtlSeconds: jest.fn().mockReturnValue(3600),
+  isJtiRevoked: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock("../lib/cookies", () => {
+  const actual = jest.requireActual("../lib/cookies");
+  return {
+    ...actual,
+    setAuthCookies: jest.fn(actual.setAuthCookies),
+    clearAuthCookies: jest.fn(actual.clearAuthCookies),
+  };
+});
+
+import { authRouter } from "../routes/auth";
+import { prisma } from "../lib/prisma";
+import { isJtiRevoked } from "../lib/jwt-revocation";
+import { clearAuthCookies, setAuthCookies } from "../lib/cookies";
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockIsJtiRevoked = isJtiRevoked as jest.MockedFunction<typeof isJtiRevoked>;
+const mockSetAuthCookies = setAuthCookies as jest.MockedFunction<typeof setAuthCookies>;
+const mockClearAuthCookies = clearAuthCookies as jest.MockedFunction<typeof clearAuthCookies>;
+
+const app = express();
+app.use(express.json());
+app.use(cookieParser());
+app.use(requestIdMiddleware);
+app.use("/api/auth", authRouter);
+
+function signLegacyAccessToken(userId = "user-123", jti = "legacy-jti"): string {
+  return jwt.sign({ userId, jti }, process.env.JWT_SECRET!, { expiresIn: "7d" });
+}
+
+function authCookies(accessToken?: string, refreshToken?: string): string[] {
+  return [
+    ...(accessToken ? [`atlas_access_token=${accessToken}`] : []),
+    ...(refreshToken ? [`atlas_refresh_token=${refreshToken}`] : []),
+  ];
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  mockSupabaseAuth.getUser.mockResolvedValue({
+    data: { user: null },
+    error: { message: "invalid" },
+  });
+  mockSupabaseAuth.refreshSession.mockResolvedValue({
+    data: { session: null },
+    error: null,
+  });
+  mockIsJtiRevoked.mockResolvedValue(false);
+});
+
+describe("mixed-origin auth refresh", () => {
+  it("refreshSession is NOT called when atlas_access_token is a legacy JWT", async () => {
+    const accessToken = signLegacyAccessToken("user-123", "legacy-jti-1");
+
+    const res = await request(app)
+      .post("/api/auth/refresh")
+      .set("Cookie", authCookies(accessToken, "twitter-refresh-token"))
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockSupabaseAuth.refreshSession).not.toHaveBeenCalled();
+    expect(mockSetAuthCookies).toHaveBeenCalledTimes(1);
+    expect(res.body.data.refresh_token).toBe("twitter-refresh-token");
+
+    const decoded = jwt.verify(res.body.data.token, process.env.JWT_SECRET!) as { userId: string };
+    expect(decoded.userId).toBe("user-123");
+  });
+
+  it("revoked jti on refresh returns 401 and does NOT clear cookies", async () => {
+    mockIsJtiRevoked.mockResolvedValueOnce(true);
+    const accessToken = signLegacyAccessToken("user-123", "revoked-jti");
+
+    const res = await request(app)
+      .post("/api/auth/refresh")
+      .set("Cookie", authCookies(accessToken, "twitter-refresh-token"))
+      .send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid or expired token");
+    expect(mockSupabaseAuth.refreshSession).not.toHaveBeenCalled();
+    expect(mockSetAuthCookies).not.toHaveBeenCalled();
+    expect(mockClearAuthCookies).not.toHaveBeenCalled();
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("Supabase refresh error does NOT clearAuthCookies", async () => {
+    mockSupabaseAuth.refreshSession.mockResolvedValueOnce({
+      data: { session: null },
+      error: { message: "invalid refresh token" },
+    });
+
+    const res = await request(app)
+      .post("/api/auth/refresh")
+      .set("Cookie", authCookies("twitter-access-token", "twitter-refresh-token"))
+      .send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid refresh token");
+    expect(mockSupabaseAuth.refreshSession).toHaveBeenCalledWith({
+      refresh_token: "twitter-refresh-token",
+    });
+    expect(mockSetAuthCookies).not.toHaveBeenCalled();
+    expect(mockClearAuthCookies).not.toHaveBeenCalled();
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("logout does not call supabaseAdmin.auth.admin.signOut", async () => {
+    const token = signLegacyAccessToken("user-123", "logout-jti-1");
+
+    const res = await request(app)
+      .post("/api/auth/logout")
+      .set("Authorization", `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockSupabaseAuth.admin.signOut).not.toHaveBeenCalled();
+  });
+
+  it("logout does not set tokensInvalidatedBefore on user model", async () => {
+    const token = signLegacyAccessToken("user-123", "logout-jti-2");
+
+    const res = await request(app)
+      .post("/api/auth/logout")
+      .set("Authorization", `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+});

--- a/services/api/src/__tests__/lib/jwt-revocation-fail-open.test.ts
+++ b/services/api/src/__tests__/lib/jwt-revocation-fail-open.test.ts
@@ -1,0 +1,46 @@
+const setMock = jest.fn();
+const getMock = jest.fn();
+
+jest.mock("../../lib/redis", () => ({
+  getRedis: jest.fn(() => ({
+    set: setMock,
+    get: getMock,
+  })),
+}));
+
+jest.mock("../../lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { logger } from "../../lib/logger";
+import { isJtiRevoked, revokeJti } from "../../lib/jwt-revocation";
+
+const mockLogger = logger as jest.Mocked<typeof logger>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setMock.mockReset();
+  getMock.mockReset();
+});
+
+describe("jwt revocation fail-open behavior", () => {
+  it("isJtiRevoked returns false when redis.get throws", async () => {
+    getMock.mockRejectedValueOnce(new Error("connection lost"));
+
+    await expect(isJtiRevoked("abc123")).resolves.toBe(false);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: "connection lost", jti: "abc123" }),
+      "jti lookup failed — treating as not-revoked (fail-open)",
+    );
+  });
+
+  it("revokeJti returns false on redis error but does not throw", async () => {
+    setMock.mockRejectedValueOnce(new Error("write failed"));
+
+    await expect(revokeJti("abc123", 3600)).resolves.toBe(false);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ err: "write failed", jti: "abc123" }),
+      "Failed to revoke jti",
+    );
+  });
+});

--- a/services/api/src/lib/jwt-revocation.ts
+++ b/services/api/src/lib/jwt-revocation.ts
@@ -73,7 +73,10 @@ export async function isJtiRevoked(jti: string | undefined): Promise<boolean> {
     const value = await r.get(key(jti));
     return value !== null;
   } catch (err: any) {
-    logger.error({ err: err?.message, jti: jti.slice(0, 8) }, "jti lookup failed");
+    logger.warn(
+      { err: err?.message, jti: jti.slice(0, 8) },
+      "jti lookup failed — treating as not-revoked (fail-open)",
+    );
     return false;
   }
 }

--- a/services/api/src/routes/auth.ts
+++ b/services/api/src/routes/auth.ts
@@ -238,8 +238,30 @@ authRouter.post("/refresh", async (req, res) => {
     const bodyRefresh = body.refresh_token;
     const refreshToken = cookieRefresh || bodyRefresh;
 
+    // Step 1: if the access token is a legacy JWT we issued, re-sign it.
+    // Twitter-OAuth sessions store a Twitter OAuth refresh token in
+    // atlas_refresh_token which is NOT a Supabase refresh token. Never pass
+    // it to supabaseAdmin.auth.refreshSession.
+    const accessToken = getAccessToken(req);
+    if (accessToken) {
+      try {
+        const decoded = jwt.verify(accessToken, config.JWT_SECRET) as {
+          userId: string;
+          jti?: string;
+        };
+        if (decoded.jti && (await isJtiRevoked(decoded.jti))) {
+          return res.status(401).json(error("Invalid or expired token"));
+        }
+        const newToken = signLegacyToken(decoded.userId);
+        setAuthCookies(res, newToken, refreshToken ?? "");
+        return res.json(success({ token: newToken, refresh_token: refreshToken ?? null }));
+      } catch {
+        // Not a legacy JWT — fall through to Supabase refresh.
+      }
+    }
+
+    // Step 2: no refresh token — try legacy header re-sign.
     if (!refreshToken) {
-      // For legacy JWT users: check Authorization header and re-sign
       const authHeader = req.headers.authorization;
       if (authHeader?.startsWith("Bearer ")) {
         try {
@@ -247,17 +269,8 @@ authRouter.post("/refresh", async (req, res) => {
             userId: string;
             jti?: string;
           };
-          // C-6: refresh must respect the revocation list. Without this check,
-          // a logged-out token could call /refresh and mint a fresh jti,
-          // defeating the blacklist.
-          if (decoded.jti) {
-            try {
-              if (await isJtiRevoked(decoded.jti)) {
-                return res.status(401).json(error("Invalid or expired token"));
-              }
-            } catch {
-              // Best-effort: allow on Redis error in non-prod
-            }
+          if (decoded.jti && (await isJtiRevoked(decoded.jti))) {
+            return res.status(401).json(error("Invalid or expired token"));
           }
           const newToken = signLegacyToken(decoded.userId);
           return res.json(success({ token: newToken, refresh_token: null }));
@@ -268,6 +281,7 @@ authRouter.post("/refresh", async (req, res) => {
       return res.status(400).json(error("Missing refresh token"));
     }
 
+    // Step 3: Supabase refresh — only if access token is NOT a legacy JWT.
     if (!supabaseAdmin) {
       return res.status(503).json(error("Auth service unavailable"));
     }
@@ -277,7 +291,7 @@ authRouter.post("/refresh", async (req, res) => {
     });
 
     if (refreshError || !data.session) {
-      clearAuthCookies(res);
+      // Do NOT clearAuthCookies — the cookie may still be a valid Twitter OAuth token.
       return res.status(401).json(error("Invalid refresh token"));
     }
 
@@ -340,6 +354,11 @@ authRouter.post("/logout", authenticate, async (req: AuthRequest, res) => {
   try {
     emptyBodySchema.parse(req.body ?? {});
 
+    // C-6 NOTE: Do NOT call supabaseAdmin.auth.admin.signOut(supabaseId, "global") here.
+    // PR #204 tried this and broke login in prod (reverted in #214): admin.signOut invalidates
+    // the Supabase session; on Twitter-OAuth re-login the freshly issued token's iat can land
+    // within the same second as tokensInvalidatedBefore, rejecting valid logins.
+    // Per-jti revocation via Redis is sufficient and race-free.
     // C-6: insert this token's jti into the Redis blacklist with a TTL
     // equal to the token's remaining lifetime, so any concurrent
     // session/tab using the same JWT is rejected on its next request.


### PR DESCRIPTION
## Root cause

PR #204 (JWT revocation) was reverted in PR #214 because after logout, users couldn't re-login.

This PR fixes **root cause 2** of that revert (the mixed-origin cookie bug):
- \`atlas_refresh_token\` cookie holds a **Twitter OAuth refresh token**, not a Supabase refresh token
- Old code passed it unconditionally to \`supabaseAdmin.auth.refreshSession()\` → 400
- That 400 triggered \`clearAuthCookies\` → users kicked out permanently after logout+re-login

## Changes

### auth.ts — /refresh handler
**Step 1 (new):** If \`atlas_access_token\` is a legacy JWT we issued (all Twitter-OAuth sessions), re-sign it directly — Supabase never touched. Keeps Twitter OAuth refresh token unchanged in cookie.

**Step 3 (fixed):** Only reaches \`supabaseAdmin.auth.refreshSession\` if Step 1 didn't match (non-legacy session). Removed \`clearAuthCookies\` on Supabase error — 401 instead, lets client decide.

**Logout guard comment:** Documents why \`admin.signOut\` must never be re-added (root cause 1 from #214).

### jwt-revocation.ts
Changed Redis error log from \`logger.error\` → \`logger.warn\` (fail-open is expected behavior, not an error).

## Tests
- \`auth-refresh-mixed-origin.test.ts\`: verifies \`refreshSession\` is NOT called for legacy JWTs, revoked jti returns 401 without clearing cookies, Supabase error doesn't clear cookies
- \`jwt-revocation-fail-open.test.ts\`: Redis errors return \`false\` and never throw

## Relationship to other PRs
- Complements a13xperi/atlas-backend#221 (jti blacklist on logout — the C-6 per-token revocation)
- Merge #221 first, then this on top

## Opus design
This fix was designed by Opus subagent and implemented by Codex. See forge mission 2026-04-15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)