### PR TITLE
fix(rate-limit): raise general API limit 100→500 req/min — prevent demo 429s

### DIFF
--- a/services/api/src/lib/config.ts
+++ b/services/api/src/lib/config.ts
@@ -31,7 +31,7 @@ const envSchema = z.object({
   RATE_LIMIT_DOCS_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
   RATE_LIMIT_AI_GENERATION_MAX_REQUESTS: z.coerce.number().int().positive().default(20),
   RATE_LIMIT_AI_GENERATION_WINDOW_MS: z.coerce.number().int().positive().default(60 * 60 * 1000),
-  RATE_LIMIT_GENERAL_MAX_REQUESTS: z.coerce.number().int().positive().default(100),
+  RATE_LIMIT_GENERAL_MAX_REQUESTS: z.coerce.number().int().positive().default(500),
   RATE_LIMIT_GENERAL_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
 
   // AI providers


### PR DESCRIPTION
## Summary
- Bumps `RATE_LIMIT_GENERAL_MAX_REQUESTS` default from 100 → 500 req/60s
- Applies to all `/api/*` routes via the global `generalApiLimiter`
- Auth-specific limiters (login: 5/15min, register: 5/15min) are unchanged — security not affected
- Prevents 429 errors during rapid SPA navigation and dashboard polling in the Anil demo

## Why
100 req/min per user is too tight for a SPA that hits analytics, voice, drafts, and oracle endpoints on every page load.

🤖 Generated with Claude Code