### PR TITLE
fix(oracle): SSE anti-buffering headers for Railway proxy

### DIFF
--- a/services/api/src/__tests__/routes/oracle.test.ts
+++ b/services/api/src/__tests__/routes/oracle.test.ts
@@ -243,7 +243,7 @@ describe("POST /api/oracle/message", () => {
 
     expect(mockAnthropicCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: "claude-sonnet-4-6",
+        model: "claude-sonnet-4-5-20251001",
         system: expect.stringContaining("Oracle system prompt"),
         messages: [
           {

--- a/services/api/src/routes/oracle.ts
+++ b/services/api/src/routes/oracle.ts
@@ -176,7 +176,7 @@ async function handleSessionMessage(req: AuthRequest, res: Response) {
   try {
     const client = getAnthropicClient();
     const response = await client.messages.create({
-      model: "claude-sonnet-4-6",
+      model: "claude-sonnet-4-5-20251001",
       max_tokens: 800,
       system: buildOracleSessionSystemPrompt(nextContext),
       messages: messagesWithUser.slice(-20).map((message) => ({
@@ -664,6 +664,7 @@ oracleRouter.post("/chat/stream", aiGenerationLimiter, async (req: AuthRequest, 
     res.setHeader("Content-Type", "text/event-stream");
     res.setHeader("Cache-Control", "no-cache");
     res.setHeader("Connection", "keep-alive");
+    res.setHeader("X-Accel-Buffering", "no");
 
     let closed = false;
     req.on("close", () => { closed = true; });


### PR DESCRIPTION
- Adds `X-Accel-Buffering: no` to POST /api/oracle/chat/stream to prevent Railway proxy from buffering SSE responses
- Fixes invalid Anthropic model ID `claude-sonnet-4-6` → `claude-sonnet-4-5-20251001` in session message handler