### PR TITLE
fix(admin): secret-gated promote endpoint for demo day

### DIFF
--- a/services/api/src/routes/admin.ts
+++ b/services/api/src/routes/admin.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { prisma } from "../lib/prisma";
 import { error, success } from "../lib/response";
 import { authenticate, AuthRequest } from "../middleware/auth";
+import { rateLimit } from "../middleware/rateLimit";
 import { getAnthropicClient } from "../lib/anthropic";
 import {
   getPromptCatalog,
@@ -16,11 +17,11 @@ export const adminRouter: Router = Router();
 const promoteSchema = z.object({
   handle: z.string().min(1),
   secret: z.string().min(1),
-  role: z.enum(["ANALYST", "MANAGER", "ADMIN"]).default("MANAGER"),
+  role: z.enum(["ANALYST", "MANAGER"]).default("MANAGER"),
 });
 
 // POST /api/admin/promote — secret-gated role promotion (demo utility, no JWT required)
-adminRouter.post("/promote", async (req, res) => {
+adminRouter.post("/promote", rateLimit(10, 60 * 1000, "promote"), async (req, res) => {
   try {
     const demoSecret = process.env.DEMO_ADMIN_SECRET;
     if (!demoSecret) {
@@ -42,6 +43,7 @@ adminRouter.post("/promote", async (req, res) => {
       data: { role: body.role },
     });
 
+    logger.info({ handle: updated.handle, role: updated.role, id: updated.id }, "User promoted via demo endpoint");
     return res.json(success({ handle: updated.handle, role: updated.role, id: updated.id }));
   } catch (err: any) {
     if (err instanceof z.ZodError) {

--- a/services/api/src/routes/admin.ts
+++ b/services/api/src/routes/admin.ts
@@ -12,6 +12,46 @@ import {
 import { logger } from "../lib/logger";
 
 export const adminRouter: Router = Router();
+
+const promoteSchema = z.object({
+  handle: z.string().min(1),
+  secret: z.string().min(1),
+  role: z.enum(["ANALYST", "MANAGER", "ADMIN"]).default("MANAGER"),
+});
+
+// POST /api/admin/promote — secret-gated role promotion (demo utility, no JWT required)
+adminRouter.post("/promote", async (req, res) => {
+  try {
+    const demoSecret = process.env.DEMO_ADMIN_SECRET;
+    if (!demoSecret) {
+      return res.status(404).json(error("Not found", 404));
+    }
+
+    const body = promoteSchema.parse(req.body);
+    if (body.secret !== demoSecret) {
+      return res.status(401).json(error("Unauthorized", 401));
+    }
+
+    const user = await prisma.user.findUnique({ where: { handle: body.handle } });
+    if (!user) {
+      return res.status(404).json(error("User not found", 404));
+    }
+
+    const updated = await prisma.user.update({
+      where: { id: user.id },
+      data: { role: body.role },
+    });
+
+    return res.json(success({ handle: updated.handle, role: updated.role, id: updated.id }));
+  } catch (err: any) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json(error("Invalid request", 400, err.errors));
+    }
+    logger.error({ err: err.message }, "Promote user failed");
+    return res.status(500).json(error("Failed to promote user", 500));
+  }
+});
+
 adminRouter.use(authenticate);
 
 /** Require ADMIN role — returns the user or sends 403 */


### PR DESCRIPTION
Cherry-pick of promote endpoint only. Ships `POST /api/admin/promote` — unauthenticated, gated by `DEMO_ADMIN_SECRET` env var. Unblocks anildelphi /management 403.

**After merge + Railway deploy:**
```bash
curl -X POST https://api-production-9bef.up.railway.app/api/admin/promote \
  -H "Content-Type: application/json" \
  -d '{"handle":"anildelphi","secret":"<DEMO_ADMIN_SECRET>","role":"MANAGER"}'
```

**Required:** Set `DEMO_ADMIN_SECRET` in Railway prod env vars first.

Single file changed — `services/api/src/routes/admin.ts` +40 lines. No schema changes, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)