### PR TITLE
fix: reset-user clears onboardingTrack + supports self-reset

### DIFF
--- a/services/api/src/routes/admin.ts
+++ b/services/api/src/routes/admin.ts
@@ -410,15 +410,17 @@ adminRouter.get("/feed", async (req: AuthRequest, res) => {
 });
 
 const resetUserSchema = z.object({
-  userId: z.string().min(1),
+  userId: z.string().min(1).optional(),
 });
 
 // POST /api/admin/reset-user — reset a user back to "new user" state
+// If userId is omitted, resets the calling admin's own account (self-reset for QA).
 adminRouter.post("/reset-user", async (req: AuthRequest, res) => {
   try {
     if (!(await requireAdmin(req, res))) return;
 
-    const { userId } = resetUserSchema.parse(req.body);
+    const body = resetUserSchema.parse(req.body);
+    const userId = body.userId ?? req.userId!;
 
     await prisma.$transaction(async (tx) => {
       // 1. Reset VoiceProfile to defaults
@@ -462,11 +464,12 @@ adminRouter.post("/reset-user", async (req: AuthRequest, res) => {
       // 6. Delete all Session records (force re-login)
       await tx.session.deleteMany({ where: { userId } });
 
-      // 7. Reset User onboarding fields if they exist, and clear xHandle link
+      // 7. Reset User onboarding fields and clear xHandle link
       await tx.user.update({
         where: { id: userId },
         data: {
           xHandle: null,
+          onboardingTrack: null,
         },
       });
     });


### PR DESCRIPTION
## Summary
- `POST /api/admin/reset-user` now clears `onboardingTrack: null` on the User record
- `userId` is now optional — omitting it resets the calling admin's own account (self-reset for QA)
- Full transaction: VoiceProfile reset, ReferenceVoice/SavedBlend/TweetDraft/AnalyticsEvent/Session deleted, xHandle + onboardingTrack cleared

## Cherry-pick
Commit `675ac507` from `fix/admin-reset-clean` (PR #235), conflict-resolved against main.
Does NOT include the `/promote` endpoint from that branch.

## Test plan
- [ ] `POST /api/admin/reset-user` with `{ userId: "..." }` resets target user
- [ ] `POST /api/admin/reset-user` with no body resets calling admin's own account
- [ ] Verify `onboardingTrack` is null after reset (user re-enters onboarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)