### PR TITLE
security: harden /promote endpoint

### DIFF
--- a/services/api/src/__tests__/routes/admin.test.ts
+++ b/services/api/src/__tests__/routes/admin.test.ts
@@ -42,6 +42,7 @@ jest.mock("../../lib/prisma", () => ({
       count: jest.fn(),
       findUnique: jest.fn(),
       findMany: jest.fn(),
+      update: jest.fn(),
     },
     analyticsEvent: {
       count: jest.fn(),
@@ -849,5 +850,103 @@ describe("GET /api/admin/feed", () => {
     const res = await request(app).get("/api/admin/feed").set(AUTH);
     expect(res.status).toBe(500);
     expectErrorResponse(res.body, "Failed to load admin feed");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// POST /api/admin/promote
+// ═══════════════════════════════════════════════════════════════
+
+describe("POST /api/admin/promote", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 without token", async () => {
+    const res = await request(app)
+      .post("/api/admin/promote")
+      .send({ handle: "alice", role: "MANAGER" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin user", async () => {
+    mockNonAdmin();
+    const res = await request(app)
+      .post("/api/admin/promote")
+      .set(AUTH)
+      .send({ handle: "alice", role: "MANAGER" });
+    expect(res.status).toBe(403);
+    expectErrorResponse(res.body, "Admin access required");
+  });
+
+  it("returns 404 when target user not found", async () => {
+    mockAdmin();
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce(null);
+
+    const res = await request(app)
+      .post("/api/admin/promote")
+      .set(AUTH)
+      .send({ handle: "unknown", role: "MANAGER" });
+
+    expect(res.status).toBe(404);
+    expectErrorResponse(res.body, "User not found");
+  });
+
+  it("promotes user and returns updated user", async () => {
+    mockAdmin();
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "user-alice",
+      handle: "alice",
+    });
+    (mockPrisma.user.update as jest.Mock).mockResolvedValueOnce({
+      id: "user-alice",
+      handle: "alice",
+      role: "MANAGER",
+    });
+
+    const res = await request(app)
+      .post("/api/admin/promote")
+      .set(AUTH)
+      .send({ handle: "alice", role: "MANAGER" });
+
+    expect(res.status).toBe(200);
+    const data = expectSuccessResponse<any>(res.body);
+    expect(data.handle).toBe("alice");
+    expect(data.role).toBe("MANAGER");
+    expect(data.id).toBe("user-alice");
+    expect(mockPrisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-alice" },
+        data: { role: "MANAGER" },
+      }),
+    );
+  });
+
+  it("returns 400 for invalid request body", async () => {
+    mockAdmin();
+    const res = await request(app)
+      .post("/api/admin/promote")
+      .set(AUTH)
+      .send({ handle: "", role: "MANAGER" });
+
+    expect(res.status).toBe(400);
+    expectErrorResponse(res.body, "Invalid request");
+  });
+
+  it("returns 500 on prisma error", async () => {
+    mockAdmin();
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "user-alice",
+      handle: "alice",
+    });
+    (mockPrisma.user.update as jest.Mock).mockRejectedValueOnce(new Error("DB down"));
+
+    const res = await request(app)
+      .post("/api/admin/promote")
+      .set(AUTH)
+      .send({ handle: "alice", role: "MANAGER" });
+
+    expect(res.status).toBe(500);
+    expectErrorResponse(res.body, "Failed to promote user");
   });
 });

--- a/services/api/src/routes/admin.ts
+++ b/services/api/src/routes/admin.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { prisma } from "../lib/prisma";
 import { error, success } from "../lib/response";
 import { authenticate, AuthRequest } from "../middleware/auth";
-import { rateLimit } from "../middleware/rateLimit";
+import { rateLimit, rateLimitByUser } from "../middleware/rateLimit";
 import { getAnthropicClient } from "../lib/anthropic";
 import {
   getPromptCatalog,
@@ -13,47 +13,6 @@ import {
 import { logger } from "../lib/logger";
 
 export const adminRouter: Router = Router();
-
-const promoteSchema = z.object({
-  handle: z.string().min(1),
-  secret: z.string().min(1),
-  role: z.enum(["ANALYST", "MANAGER"]).default("MANAGER"),
-});
-
-// POST /api/admin/promote — secret-gated role promotion (demo utility, no JWT required)
-adminRouter.post("/promote", rateLimit(10, 60 * 1000, "promote"), async (req, res) => {
-  try {
-    const demoSecret = process.env.DEMO_ADMIN_SECRET;
-    if (!demoSecret) {
-      return res.status(404).json(error("Not found", 404));
-    }
-
-    const body = promoteSchema.parse(req.body);
-    if (body.secret !== demoSecret) {
-      return res.status(401).json(error("Unauthorized", 401));
-    }
-
-    const user = await prisma.user.findUnique({ where: { handle: body.handle } });
-    if (!user) {
-      return res.status(404).json(error("User not found", 404));
-    }
-
-    const updated = await prisma.user.update({
-      where: { id: user.id },
-      data: { role: body.role },
-    });
-
-    logger.info({ handle: updated.handle, role: updated.role, id: updated.id }, "User promoted via demo endpoint");
-    return res.json(success({ handle: updated.handle, role: updated.role, id: updated.id }));
-  } catch (err: any) {
-    if (err instanceof z.ZodError) {
-      return res.status(400).json(error("Invalid request", 400, err.errors));
-    }
-    logger.error({ err: err.message }, "Promote user failed");
-    return res.status(500).json(error("Failed to promote user", 500));
-  }
-});
-
 const resetOnboardingSchema = z.object({
   handle: z.string().min(1),
   secret: z.string().min(1),
@@ -100,6 +59,7 @@ adminRouter.post("/reset-onboarding", rateLimit(20, 60 * 1000, "reset-onboarding
   }
 });
 
+
 adminRouter.use(authenticate);
 
 /** Require ADMIN role — returns the user or sends 403 */
@@ -111,6 +71,46 @@ async function requireAdmin(req: AuthRequest, res: Response): Promise<boolean> {
   }
   return true;
 }
+
+const promoteSchema = z.object({
+  handle: z.string().min(1),
+  role: z.enum(["ANALYST", "MANAGER"]).default("MANAGER"),
+});
+
+// POST /api/admin/promote — admin-only role promotion
+adminRouter.post(
+  "/promote",
+  rateLimitByUser(10, 60 * 60 * 1000),
+  async (req: AuthRequest, res) => {
+    try {
+      if (!(await requireAdmin(req, res))) return;
+
+      const body = promoteSchema.parse(req.body);
+
+      const user = await prisma.user.findUnique({ where: { handle: body.handle } });
+      if (!user) {
+        return res.status(404).json(error("User not found", 404));
+      }
+
+      const updated = await prisma.user.update({
+        where: { id: user.id },
+        data: { role: body.role },
+      });
+
+      logger.info(
+        { handle: updated.handle, role: updated.role, id: updated.id, promotedBy: req.userId },
+        "[AUDIT] User promoted by admin",
+      );
+      return res.json(success({ handle: updated.handle, role: updated.role, id: updated.id }));
+    } catch (err: any) {
+      if (err instanceof z.ZodError) {
+        return res.status(400).json(error("Invalid request", 400, err.errors));
+      }
+      logger.error({ err: err.message }, "Promote user failed");
+      return res.status(500).json(error("Failed to promote user", 500));
+    }
+  },
+);
 
 // GET /api/admin/overview — platform-wide KPIs
 adminRouter.get("/overview", async (req: AuthRequest, res) => {


### PR DESCRIPTION
The /promote endpoint shipped without auth gates in PR #235. This PR adds: admin-only role check (403 for non-ADMIN), audit log on every promotion, rate limiting. Closes the privilege escalation surface.